### PR TITLE
csv import delim param

### DIFF
--- a/go/libraries/doltcore/mvdata/data_loc.go
+++ b/go/libraries/doltcore/mvdata/data_loc.go
@@ -92,7 +92,7 @@ func (dl *DataLocation) String() string {
 }
 
 func NewDataLocation(path, fileFmtStr string) *DataLocation {
-	var dataFmt DataFormat
+	dataFmt := InvalidDataFormat
 
 	if fileFmtStr == "" {
 		if doltdb.IsValidTableName(path) {
@@ -129,7 +129,7 @@ func (dl *DataLocation) IsFileType() bool {
 	return true
 }
 
-func (dl *DataLocation) CreateReader(ctx context.Context, root *doltdb.RootValue, fs filesys.ReadableFS, schPath string, tblName string) (rdCl table.TableReadCloser, sorted bool, err error) {
+func (dl *DataLocation) CreateReader(ctx context.Context, root *doltdb.RootValue, fs filesys.ReadableFS, schPath string, tblName string, opts interface{}) (rdCl table.TableReadCloser, sorted bool, err error) {
 	if dl.Format == DoltDB {
 		tbl, ok, err := root.GetTable(ctx, dl.Path)
 
@@ -171,7 +171,18 @@ func (dl *DataLocation) CreateReader(ctx context.Context, root *doltdb.RootValue
 
 		switch dl.Format {
 		case CsvFile:
-			rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csv.NewCSVInfo())
+			delim := ","
+
+			if opts != nil {
+				csvOpts, _ := opts.(CsvOptions)
+
+				if len(csvOpts.Delim) != 0 {
+					delim = csvOpts.Delim
+				}
+			}
+
+			rd, err := csv.OpenCSVReader(root.VRW().Format(), dl.Path, fs, csv.NewCSVInfo().SetDelim(delim))
+
 			return rd, false, err
 
 		case PsvFile:

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -250,7 +250,7 @@ func TestCreateRdWr(t *testing.T) {
 		}
 
 		// TODO (oo): fix this for json path test
-		rd, _, err := loc.CreateReader(context.Background(), root, fs, "schema.json", "")
+		rd, _, err := loc.CreateReader(context.Background(), root, fs, "schema.json", "", nil)
 
 		if err != nil {
 			t.Fatal("Unexpected error creating writer", err)

--- a/go/libraries/doltcore/mvdata/data_mover.go
+++ b/go/libraries/doltcore/mvdata/data_mover.go
@@ -40,6 +40,10 @@ const (
 	InvalidOp   MoveOperation = "invalid"
 )
 
+type CsvOptions struct {
+	Delim string
+}
+
 type MoveOptions struct {
 	Operation   MoveOperation
 	ContOnErr   bool
@@ -49,6 +53,7 @@ type MoveOptions struct {
 	PrimaryKey  string
 	Src         *DataLocation
 	Dest        *DataLocation
+	SrcOptions  interface{}
 }
 
 type DataMover struct {
@@ -84,7 +89,7 @@ func NewDataMover(ctx context.Context, root *doltdb.RootValue, fs filesys.Filesy
 	var err error
 	transforms := pipeline.NewTransformCollection()
 
-	rd, srcIsSorted, err := mvOpts.Src.CreateReader(ctx, root, fs, mvOpts.SchFile, mvOpts.Dest.Path)
+	rd, srcIsSorted, err := mvOpts.Src.CreateReader(ctx, root, fs, mvOpts.SchFile, mvOpts.Dest.Path, mvOpts.SrcOptions)
 
 	if err != nil {
 		return nil, &DataMoverCreationError{CreateReaderErr, err}
@@ -206,7 +211,7 @@ func getOutSchema(ctx context.Context, inSch schema.Schema, root *doltdb.RootVal
 	if mvOpts.Operation == UpdateOp {
 		// Get schema from target
 
-		rd, _, err := mvOpts.Dest.CreateReader(ctx, root, fs, mvOpts.SchFile, mvOpts.Dest.Path)
+		rd, _, err := mvOpts.Dest.CreateReader(ctx, root, fs, mvOpts.SchFile, mvOpts.Dest.Path, mvOpts.SrcOptions)
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Previous versions of import required csv files to use commas.  This change allows the delimiter to be a string passed on the command line.