### PR TITLE
fix race condition which caused reproducible crash

### DIFF
--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -428,9 +428,12 @@ func (tr tableReader) getManyAtOffsets(
 		}
 
 		wg.Add(1)
+		goReadStart := readStart
+		goReadEnd := readEnd
+		goBatch := batch
 		go func(batch offsetRecSlice) {
 			defer wg.Done()
-			err := tr.readAtOffsets(ctx, readStart, readEnd, reqs, batch, foundChunks, stats)
+			err := tr.readAtOffsets(ctx, goReadStart, goReadEnd, reqs, goBatch, foundChunks, stats)
 			ae.SetIfError(err)
 		}(batch)
 		batch = nil


### PR DESCRIPTION
The declaration of the variables readStart, readEnd, and batch are declared outside of the for loop, and it is possible that their value can change before the go routine calls readAtOffsets causing some or all of these values to be incorrect.  The fix is to save them to variables scoped to the loop before calling the go routine.