### PR TITLE
go/go.mod: Do not depend on //proto/third_party/golang-protobuf.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,8 +14,6 @@ pipeline {
                     }
                     steps {
                         dir ("go") {
-                            sh "git submodule update --init --recursive"
-
                             // Keep this in sync with //go/utils/prepr/prepr.sh.
                             sh "go get -mod=readonly ./..."
                             sh "./utils/repofmt/check_fmt.sh"
@@ -41,8 +39,6 @@ pipeline {
                             sh "npm i bats"
                         }
                         dir ("go") {
-                            sh "git submodule update --init --recursive"
-
                             sh "go get -mod=readonly ./..."
                             sh "go build -mod=readonly -o ../.ci_bin/dolt ./cmd/dolt/."
                             sh "go build -mod=readonly -o ../.ci_bin/git-dolt ./cmd/git-dolt/."
@@ -66,8 +62,6 @@ pipeline {
                     }
                     steps {
                         dir ("go/") {
-                            bat "git submodule update --init --recursive"
-
                             bat "go test ./..."
                             bat "go build -mod=readonly -o ..\\.ci_bin\\dolt.exe ./cmd/dolt/."
                             bat "copy /Y ..\\.ci_bin\\dolt.exe ..\\.ci_bin\\dolt"

--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -242,41 +242,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 
 ================================================================================
-= ../proto/third_party/golang-protobuf licensed under: =
-
-Copyright 2010 The Go Authors.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-= LICENSE 967db5a416c0314ad6ce2de8edbfc939da0be94348d829ec78b6e9d0 =
-================================================================================
-
-================================================================================
 = cloud.google.com/go licensed under: =
 
 
@@ -1289,6 +1254,41 @@ third-party archives.
    limitations under the License.
 
 = LICENSE 402f6aca074a87cb9a2cd5b95d9af0d840cdd50ec73029e22195c7b8 =
+================================================================================
+
+================================================================================
+= github.com/golang/protobuf licensed under: =
+
+Copyright 2010 The Go Authors.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+= LICENSE 967db5a416c0314ad6ce2de8edbfc939da0be94348d829ec78b6e9d0 =
 ================================================================================
 
 ================================================================================

--- a/go/go.mod
+++ b/go/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/gocraft/dbr v0.0.0-20190708200302-a54124dfc613
-	github.com/golang/protobuf v1.3.2
+	github.com/golang/protobuf v1.3.3-0.20190805180045-4c88cc3f1a34
 	github.com/golang/snappy v0.0.1
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
@@ -58,7 +58,5 @@ require (
 )
 
 replace github.com/src-d/go-mysql-server => github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190710171053-b2883167103a
-
-replace github.com/golang/protobuf => ../proto/third_party/golang-protobuf
 
 replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20190625235908-66745781a796

--- a/go/go.sum
+++ b/go/go.sum
@@ -101,6 +101,8 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3-0.20190805180045-4c88cc3f1a34 h1:lOqqfn77CiAxttSZEEe2qqzjdnzwCrdzZqEEOiro+18=
+github.com/golang/protobuf v1.3.3-0.20190805180045-4c88cc3f1a34/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=


### PR DESCRIPTION
Development ergonomics are much worse and the runtime library will maintain
compability with the generator major version anyway, or it will explicitly
break compilation.