### PR TITLE
Fixes a panic that occurs if multiple bad rows are found during import

### DIFF
--- a/go/libraries/doltcore/table/pipeline/errors.go
+++ b/go/libraries/doltcore/table/pipeline/errors.go
@@ -18,6 +18,8 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
 )
 
+var NoTransformRowFailure = TransformRowFailure{}
+
 // TransformRowFailure is an error implementation that stores the row that failed to transform, the transform that
 // failed and some details of the error
 type TransformRowFailure struct {

--- a/go/libraries/doltcore/table/pipeline/pipeline.go
+++ b/go/libraries/doltcore/table/pipeline/pipeline.go
@@ -329,7 +329,6 @@ func (p *Pipeline) processBadRows() {
 					return
 				}
 
-
 			case <-p.stopChan:
 				return
 			}

--- a/go/libraries/doltcore/table/pipeline/pipeline.go
+++ b/go/libraries/doltcore/table/pipeline/pipeline.go
@@ -317,17 +317,18 @@ func (p *Pipeline) processBadRows() {
 	if p.badRowCB != nil {
 		for {
 			select {
-			case bRow, ok := <-p.badRowChan:
-				if ok {
-					quit := p.badRowCB(bRow)
-
-					if quit {
-						p.Abort()
-						return
-					}
-				} else {
+			case bRow := <-p.badRowChan:
+				if bRow == &NoTransformRowFailure {
 					return
 				}
+
+				quit := p.badRowCB(bRow)
+
+				if quit {
+					p.Abort()
+					return
+				}
+
 
 			case <-p.stopChan:
 				return

--- a/go/libraries/doltcore/table/pipeline/procfunc_help.go
+++ b/go/libraries/doltcore/table/pipeline/procfunc_help.go
@@ -87,7 +87,9 @@ type SinkFunc func(row.Row, ReadableMap) error
 // processing, stop conditions, and error handling.
 func ProcFuncForSinkFunc(sinkFunc SinkFunc) OutFunc {
 	return func(p *Pipeline, ch <-chan RowWithProps, badRowChan chan<- *TransformRowFailure) {
-		defer close(badRowChan)
+		defer func() {
+			badRowChan <- &NoTransformRowFailure
+		}()
 
 		for {
 			if p.IsStopping() {


### PR DESCRIPTION
When a pipeline is being run, any stage can write to the bad row channel when an error is encountered.  There is a go routine reading from this channel that will not exit until the channel is closed, or an error is encountered. In typical operation the pipeline's sink would close the bad row channel once the pipeline finishes (either via an error triggered stoppage, or successful completion).  However, in the case where multiple errors are getting written to the bad row channel from multiple go routines, it is possible for the bad row channel to be written to, which triggers the pipeline to be stopped, and the channel to be closed, and then have a go routine write to that closed channel.

The fix here is to not close the channel in the sink, but instead to write a marker to the channel which will cause the go routine watching for errors to exit.