### PR TITLE
Changed default remote host to use the env constant

### DIFF
--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -78,8 +78,6 @@ var remoteSynopsis = []string{
 const (
 	addRemoteId    = "add"
 	removeRemoteId = "remove"
-
-	DolthubHostName = "dolthub.com"
 )
 
 var awsParams = []string{dbfactory.AWSRegionParam, dbfactory.AWSCredsTypeParam, dbfactory.AWSCredsFileParam, dbfactory.AWSCredsProfile}
@@ -191,7 +189,7 @@ func getAbsRemoteUrl(fs filesys.Filesys, cfg config.ReadableConfig, urlArg strin
 			return "", "", err
 		}
 
-		hostName = DolthubHostName
+		hostName = env.DefaultRemotesApiHost
 	}
 
 	hostName = strings.TrimSpace(hostName)

--- a/go/cmd/dolt/commands/remote_test.go
+++ b/go/cmd/dolt/commands/remote_test.go
@@ -45,14 +45,14 @@ func TestGetAbsRemoteUrl(t *testing.T) {
 		{
 			"",
 			config.NewMapConfig(map[string]string{}),
-			"https://dolthub.com",
+			"https://doltremoteapi.beta.dolthub.com",
 			"https",
 			false,
 		},
 		{
 			"ts/emp",
 			config.NewMapConfig(map[string]string{}),
-			"https://dolthub.com/ts/emp",
+			"https://doltremoteapi.beta.dolthub.com/ts/emp",
 			"https",
 			false,
 		},

--- a/go/cmd/dolt/commands/remote_test.go
+++ b/go/cmd/dolt/commands/remote_test.go
@@ -45,14 +45,14 @@ func TestGetAbsRemoteUrl(t *testing.T) {
 		{
 			"",
 			config.NewMapConfig(map[string]string{}),
-			"https://doltremoteapi.beta.dolthub.com",
+			"https://" + env.DefaultRemotesApiHost,
 			"https",
 			false,
 		},
 		{
 			"ts/emp",
 			config.NewMapConfig(map[string]string{}),
-			"https://doltremoteapi.beta.dolthub.com/ts/emp",
+			"https://" + env.DefaultRemotesApiHost + "/ts/emp",
 			"https",
 			false,
 		},


### PR DESCRIPTION
Before we were using `dolthub.com` as the default, which is incorrect. I've changed it to the appropriate environment constant so that it also properly updates when we change from our beta domain.