### PR TITLE
go/store/spec: Move to aws://[table:bucket] for NBS on AWS specs because of Go URL parsing changes.

### DIFF
--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -49,7 +49,7 @@ var remoteLongDesc = "With no arguments, shows a list of existing remotes. Sever
 	"url then https is assumed.  If the <url> paramenter is in the format <organization>/<repository> then dolt will use " +
 	"the remotes.default_host from your configuration file (Which will be dolthub.com unless changed).\n" +
 	"\n" +
-	"AWS cloud remote urls should be of the form aws://dynamo-table:s3-bucket/database.  You may configure your aws " +
+	"AWS cloud remote urls should be of the form aws://[dynamo-table:s3-bucket]/database.  You may configure your aws " +
 	"cloud remote using the optional parameters aws-region, aws-creds-type, aws-creds-file.\n" +
 	"\n" +
 	"aws-creds-type specifies the means by which credentials should be retrieved in order to access the specified " +

--- a/go/libraries/doltcore/dbfactory/aws.go
+++ b/go/libraries/doltcore/dbfactory/aws.go
@@ -121,7 +121,7 @@ func (fact AWSFactory) CreateDB(ctx context.Context, nbf *types.NomsBinFormat, u
 }
 
 func (fact AWSFactory) newChunkStore(ctx context.Context, nbf *types.NomsBinFormat, urlObj *url.URL, params map[string]string) (chunks.ChunkStore, error) {
-	parts := strings.SplitN(urlObj.Host, ":", 2) // [table]:[bucket]
+	parts := strings.SplitN(urlObj.Hostname(), ":", 2) // [table]:[bucket]
 	if len(parts) != 2 {
 		return nil, errors.New("aws url has an invalid format")
 	}

--- a/go/store/config/config_test.go
+++ b/go/store/config/config_test.go
@@ -39,7 +39,7 @@ const (
 	memSpec    = "mem"
 	nbsAbsSpec = "nbs:/tmp/noms"
 	awsAlias   = "awsdb"
-	awsSpec    = "aws://dynamo_table:bucket/db"
+	awsSpec    = "aws://[dynamo_table:bucket]/db"
 )
 
 var (

--- a/go/store/nbs/NBS-on-AWS.md
+++ b/go/store/nbs/NBS-on-AWS.md
@@ -67,7 +67,7 @@ This is where the ARN for your bucket and table come in.
 ### On the command line
 
 ```shell
-noms ds aws://dynamo-table:s3-bucket/store-name
+noms ds aws://[dynamo-table:s3-bucket]/store-name
 ```
 
 ### NewAWSStore

--- a/go/store/nbs/README.md
+++ b/go/store/nbs/README.md
@@ -45,5 +45,5 @@ NBS is more-or-less "beta". There's still [work we want to do](https://github.co
 The AWS backend is available via the `aws:` scheme:
 
 ```shell
-./csv-import foo.csv aws://table:bucket::data
+./csv-import foo.csv aws://[table:bucket]::data
 ```

--- a/go/store/spec/spec.go
+++ b/go/store/spec/spec.go
@@ -310,7 +310,7 @@ func parseAWSSpec(ctx context.Context, awsURL string, options SpecOptions) chunk
 	fmt.Println(awsURL, options)
 
 	u, _ := url.Parse(awsURL)
-	parts := strings.SplitN(u.Host, ":", 2) // [table] [, bucket]?
+	parts := strings.SplitN(u.Hostname(), ":", 2) // [table] [, bucket]?
 	d.PanicIfFalse(len(parts) == 2)
 
 	awsConfig := aws.NewConfig().WithRegion(options.AwsRegionOrDefault())

--- a/go/store/spec/spec_test.go
+++ b/go/store/spec/spec_test.go
@@ -230,10 +230,10 @@ func TestHref(t *testing.T) {
 
 	sp, _ := ForDatabase("aws://table/foo/bar/baz")
 	assert.Equal("aws://table/foo/bar/baz", sp.Href())
-	sp, _ = ForDataset("aws://table:bucket/foo/bar/baz::myds")
-	assert.Equal("aws://table:bucket/foo/bar/baz", sp.Href())
-	sp, _ = ForPath("aws://table:bucket/foo/bar/baz::myds.my.path")
-	assert.Equal("aws://table:bucket/foo/bar/baz", sp.Href())
+	sp, _ = ForDataset("aws://[table:bucket]/foo/bar/baz::myds")
+	assert.Equal("aws://[table:bucket]/foo/bar/baz", sp.Href())
+	sp, _ = ForPath("aws://[table:bucket]/foo/bar/baz::myds.my.path")
+	assert.Equal("aws://[table:bucket]/foo/bar/baz", sp.Href())
 
 	sp, err := ForPath("mem::myds.my.path")
 	assert.NoError(err)
@@ -251,7 +251,7 @@ func TestForDatabase(t *testing.T) {
 		"random:",
 		"random:random",
 		"/file/ba:d",
-		"aws://t:b",
+		"aws://[t:b]",
 		"aws://t",
 		"aws://t:",
 	}
@@ -271,7 +271,7 @@ func TestForDatabase(t *testing.T) {
 		{"mem", "mem", "", ""},
 		{tmpDir, "nbs", tmpDir, "nbs:" + tmpDir},
 		{"nbs:" + tmpDir, "nbs", tmpDir, ""},
-		{"aws://table:bucket/db", "aws", "//table:bucket/db", ""},
+		{"aws://[table:bucket]/db", "aws", "//[table:bucket]/db", ""},
 		{"aws://table/db", "aws", "//table/db", ""},
 	}
 
@@ -304,7 +304,7 @@ func TestForDataset(t *testing.T) {
 		"mem:/a/bogus/path:dsname",
 		"nbs:",
 		"nbs:hello",
-		"aws://t:b/db",
+		"aws://[t:b]/db",
 		"mem::foo.value",
 	}
 
@@ -334,7 +334,7 @@ func TestForDataset(t *testing.T) {
 	}{
 		{"nbs:" + tmpDir + "::ds/one", "nbs", tmpDir, "ds/one", ""},
 		{tmpDir + "::ds/one", "nbs", tmpDir, "ds/one", "nbs:" + tmpDir + "::ds/one"},
-		{"aws://table:bucket/db::ds", "aws", "//table:bucket/db", "ds", ""},
+		{"aws://[table:bucket]/db::ds", "aws", "//[table:bucket]/db", "ds", ""},
 		{"aws://table/db::ds", "aws", "//table/db", "ds", ""},
 	}
 
@@ -380,7 +380,7 @@ func TestForPath(t *testing.T) {
 		{tmpDir + "::#0123456789abcdefghijklmnopqrstuv", "nbs", tmpDir, "#0123456789abcdefghijklmnopqrstuv", "nbs:" + tmpDir + "::#0123456789abcdefghijklmnopqrstuv"},
 		{"nbs:" + tmpDir + "::#0123456789abcdefghijklmnopqrstuv", "nbs", tmpDir, "#0123456789abcdefghijklmnopqrstuv", ""},
 		{"mem::#0123456789abcdefghijklmnopqrstuv", "mem", "", "#0123456789abcdefghijklmnopqrstuv", ""},
-		{"aws://table:bucket/db::foo.foo", "aws", "//table:bucket/db", "foo.foo", ""},
+		{"aws://[table:bucket]/db::foo.foo", "aws", "//[table:bucket]/db", "foo.foo", ""},
 		{"aws://table/db::foo.foo", "aws", "//table/db", "foo.foo", ""},
 	}
 


### PR DESCRIPTION
See https://go.googlesource.com/go/+/61bb56ad63992a3199acc55b2537c8355ef887b6
for context on the changes.