### PR TITLE
go: store/nbs: table_reader: getManyAtOffsetsWithReadFunc: Stop unbounded I/O parallelism in GetMany implementation.

### DIFF
--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -519,59 +519,68 @@ func (tr tableReader) getManyAtOffsetsWithReadFunc(
 		offsets offsetRecSlice,
 		stats *Stats) error,
 ) {
-	// Now |offsetRecords| contains all locations within the table which must be search (note
-	// that there may be duplicates of a particular location). Sort by offset and scan forward,
-	// grouping sequences of reads into large physical reads.
-
-	var batch offsetRecSlice
-	var readStart, readEnd uint64
-
-	for i := 0; i < len(offsetRecords); {
-		if ae.IsSet() {
-			return
-		}
-
-		rec := offsetRecords[i]
-		length := tr.lengths[rec.ordinal]
-
-		if batch == nil {
-			batch = make(offsetRecSlice, 1)
-			batch[0] = offsetRecords[i]
-			readStart = rec.offset
-			readEnd = readStart + uint64(length)
-			i++
-			continue
-		}
-
-		if newReadEnd, canRead := canReadAhead(rec, tr.lengths[rec.ordinal], readStart, readEnd, tr.blockSize); canRead {
-			batch = append(batch, rec)
-			readEnd = newReadEnd
-			i++
-			continue
-		}
-
-		wg.Add(1)
-		goReadStart := readStart
-		goReadEnd := readEnd
-		goBatch := batch
-		go func(batch offsetRecSlice) {
-			defer wg.Done()
-			err := readAtOffsets(ctx, goReadStart, goReadEnd, reqs, goBatch, stats)
-			ae.SetIfError(err)
-		}(batch)
-		batch = nil
+	type readBatch struct {
+		batch     offsetRecSlice
+		readStart uint64
+		readEnd   uint64
 	}
+	batchCh := make(chan readBatch, 128)
+	buildBatches := func() {
+		defer close(batchCh)
 
-	if !ae.IsSet() {
-		if batch != nil {
-			wg.Add(1)
-			go func(batch offsetRecSlice) {
-				defer wg.Done()
-				err := readAtOffsets(ctx, readStart, readEnd, reqs, batch, stats)
-				ae.SetIfError(err)
-			}(batch)
+		// |offsetRecords| contains all locations within the table
+		// which must be search in sorted order and without
+		// duplicates. Now scan forward, grouping sequences of reads
+		// into larger physical reads.
+
+		var batch offsetRecSlice
+		var readStart, readEnd uint64
+
+		for i, rec := range offsetRecords {
+			if ae.IsSet() {
+				break
+			}
+			length := tr.lengths[rec.ordinal]
+
+			if batch == nil {
+				batch = make(offsetRecSlice, 1)
+				batch[0] = offsetRecords[i]
+				readStart = rec.offset
+				readEnd = readStart + uint64(length)
+				continue
+			}
+
+			if newReadEnd, canRead := canReadAhead(rec, tr.lengths[rec.ordinal], readStart, readEnd, tr.blockSize); canRead {
+				batch = append(batch, rec)
+				readEnd = newReadEnd
+				continue
+			}
+
+			batchCh <- readBatch{batch, readStart, readEnd}
 			batch = nil
 		}
+
+		if !ae.IsSet() && batch != nil {
+			batchCh <- readBatch{batch, readStart, readEnd}
+		}
+	}
+	readBatches := func() {
+		defer wg.Done()
+		for rb := range batchCh {
+			if !ae.IsSet() {
+				err := readAtOffsets(ctx, rb.readStart, rb.readEnd, reqs, rb.batch, stats)
+				ae.SetIfError(err)
+			}
+		}
+	}
+
+	go buildBatches()
+
+	ioParallelism := 4
+
+	wg.Add(ioParallelism)
+	for i := 0; i < ioParallelism; i++ {
+		go readBatches()
 	}
 }
 

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -141,11 +141,7 @@ func (ts tableSet) getMany(ctx context.Context, reqs []getRecord, foundChunks ch
 			if rp, ok := haver.(chunkReadPlanner); ok {
 				offsets, remaining := rp.findOffsets(reqs)
 
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					rp.getManyAtOffsets(ctx, reqs, offsets, foundChunks, wg, ae, stats)
-				}()
+				rp.getManyAtOffsets(ctx, reqs, offsets, foundChunks, wg, ae, stats)
 
 				if !remaining {
 					return false
@@ -177,11 +173,7 @@ func (ts tableSet) getManyCompressed(ctx context.Context, reqs []getRecord, foun
 			if rp, ok := haver.(chunkReadPlanner); ok {
 				offsets, remaining := rp.findOffsets(reqs)
 
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					rp.getManyCompressedAtOffsets(ctx, reqs, offsets, foundCmpChunks, wg, ae, stats)
-				}()
+				rp.getManyCompressedAtOffsets(ctx, reqs, offsets, foundCmpChunks, wg, ae, stats)
 
 				if !remaining {
 					return false


### PR DESCRIPTION
When we do things like push, pull or (soon-to-be) garbage collection, we have large sets of Chunk addresses that we pass into `ChunkStore#GetMany` and then go off and process. Clients largely try to control the memory overhead and pipeline depth by passing in a buffered channel of an appropriate size. The expectation is that the implementation of `GetMany` will have an amount of data in flight at any give in time that is in some reasonable way proportional to the channel size.

In the current implementation, there is unbounded concurrency on the read destination allocations and the reads themselves, with one go routine spawned for each byte range we want to read. This results in absolutely massive (virtual) heap utilization and unreasonable I/O parallelism and context switch thrashing in large repo push/pull situations.

This is a small PR to change the concurrency paradigm inside `getManyAtOffsetsWithReadFunc` so that we only have 4 concurrent dispatched reads per `table_reader` instance at a time.

This is still not the behavior we actually want.
* I/O concurrency should be configurable at the ChunkStore layer (or eventually per-device backing a set of `tableReader`s), and not depend on the number of `tableReader`s which happen to back the chunk store.
* Memory overhead is still not correctly bounded here, since read ahead batches are allowed to grow to arbitrary sizes. Reasonable bounds on memory overhead should be configurable at the ChunkStore layer.

I'm landing this as a big incremental improvement over status quo. Here are some non-reproducible one-shot test results from a test program. The test program walks the entire chunk graph, assembles every chunk address, and then does a `GetManyCompressed` on every chunk address and copies their contents to `/dev/null`. It was run on a ~10GB (compressed) data set:

Before:
```
$ /usr/bin/time -l -- go run test.go
...
MemStats: Sys: 16628128568
      161.29 real        67.29 user       456.38 sys
5106425856  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
  10805008  page reclaims
     23881  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
         8  signals received
    652686  voluntary context switches
  21071339  involuntary context switches

```

After:
```
$ /usr/bin/time -l -- go run test.go
...
MemStats: Sys: 4590759160
       32.17 real        30.53 user        29.62 sys
4561879040  maximum resident set size
         0  average shared memory size
         0  average unshared data size
         0  average unshared stack size
   1228770  page reclaims
     67100  page faults
         0  swaps
         0  block input operations
         0  block output operations
         0  messages sent
         0  messages received
        14  signals received
    456898  voluntary context switches
   2954503  involuntary context switches
```

On these runs, sys time, wallclock time, vm page reclaims and virtual memory used are all improved pretty substantially.

Very open to feedback and discussion of potential performance regressions here, but I think this is an incremental win for now.