### PR TITLE
Implemented UPDATE

### DIFF
--- a/bats/1pk5col-ints.bats
+++ b/bats/1pk5col-ints.bats
@@ -255,7 +255,7 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     dolt sql -q "insert into test (pk,c1,c2,c3,c4,c5) values (0,1,2,3,4,5),(1,11,12,13,14,15),(2,21,22,23,24,25)"
     run dolt sql -q "update test set c1=6,c2=7,c3=8,c4=9,c5=10 where pk=0"
     [ "$status" -eq 0 ]
-    [ "$output" = "Rows updated: 1" ]
+    [[ "$output" =~ "| 1       |" ]] || false
     run dolt sql -q "select * from test where pk=0"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "10" ]] || false
@@ -263,7 +263,7 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     dolt sql -q "insert into test (pk,c1,c2,c3,c4,c5) values (4,11,12,13,14,15)"
     run dolt sql -q "update test set c2=11,c3=11,c4=11,c5=11 where c1=11"
     [ "$status" -eq 0 ]
-    [ "$output" = "Rows updated: 2" ]
+    [[ "$output" =~ "| 2       |" ]] || false
     run dolt sql -q "select * from test"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "11" ]] || false

--- a/bats/1pk5col-ints.bats
+++ b/bats/1pk5col-ints.bats
@@ -255,7 +255,7 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     dolt sql -q "insert into test (pk,c1,c2,c3,c4,c5) values (0,1,2,3,4,5),(1,11,12,13,14,15),(2,21,22,23,24,25)"
     run dolt sql -q "update test set c1=6,c2=7,c3=8,c4=9,c5=10 where pk=0"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "| 1       |" ]] || false
+    [[ "$output" =~ "| 1       | 1       |" ]] || false
     run dolt sql -q "select * from test where pk=0"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "10" ]] || false
@@ -263,27 +263,26 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     dolt sql -q "insert into test (pk,c1,c2,c3,c4,c5) values (4,11,12,13,14,15)"
     run dolt sql -q "update test set c2=11,c3=11,c4=11,c5=11 where c1=11"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "| 2       |" ]] || false
+    [[ "$output" =~ "| 2       | 2       |" ]] || false
     run dolt sql -q "select * from test"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "11" ]] || false
     [[ ! "$output" =~ "12" ]] || false
     run dolt sql -q "update test set c2=50,c3=50,c4=50,c5=50 where c1=50"
-
-[ "$status" -eq 0 ]
-    [ "$output" = "Rows updated: 0" ]
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| 0       | 0       |" ]] || false
     run dolt sql -q "select * from test"
     [ "$status" -eq 0 ]
     [[ ! "$output" =~ "50" ]] || false
     run dolt sql -q "update test set c12=11 where pk=0"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Unknown column: 'c12'" ]] || false
+    [ "$output" = "column \"c12\" could not be found in any table in scope" ]
     run dolt sql -q "update test set c1='foo' where pk=0"
     [ "$status" -eq 1 ]
-    [[ "$output" =~ "Type mismatch" ]] || false
+    [ "$output" = "unable to cast \"foo\" of type string to int64" ]
     run dolt sql -q "update test set c1=100,c2=100,c3=100,c4=100,c5=100 where pk>0"
     [ "$status" -eq 0 ]
-    [ "$output" = "Rows updated: 3" ]
+    [[ "$output" =~ "| 3       | 3       |" ]] || false
     run dolt sql -q "select * from test"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "100" ]] || false

--- a/bats/advanced-sql.bats
+++ b/bats/advanced-sql.bats
@@ -223,12 +223,6 @@ teardown() {
     [[ "$output" =~ "column \"c3\" could not be found in any table in scope" ]] || false
 }
 
-@test "sql update query on a primary key should error" {
-    run dolt sql -q "update one_pk set pk=11 where pk=0"
-    [ $status -eq 1 ]
-    [[ "$output" =~ "Cannot update primary key column 'pk'" ]] || false
-}
-
 @test "sql show tables" {
     run dolt sql -q "show tables"
     [ $status -eq 0 ]

--- a/go/go.mod
+++ b/go/go.mod
@@ -57,7 +57,7 @@ require (
 	vitess.io/vitess v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible
 )
 
-replace github.com/src-d/go-mysql-server => github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190924190605-0dd0d7f80f1c
+replace github.com/src-d/go-mysql-server => github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190930213140-66f118b01f72
 
 replace vitess.io/vitess => github.com/liquidata-inc/vitess v0.0.0-20190625235908-66745781a796
 

--- a/go/go.sum
+++ b/go/go.sum
@@ -205,6 +205,8 @@ github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190916182737-521be194cc83 h1
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190916182737-521be194cc83/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190924190605-0dd0d7f80f1c h1:KXwwcHeuppGkEBUmMW5R6jumaSzu1hnt+oqFf4+lsc4=
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190924190605-0dd0d7f80f1c/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
+github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190930213140-66f118b01f72 h1:+xQDC01Db1Dvs/BwRnn7yxxocIje4Prds73FlvaULbU=
+github.com/liquidata-inc/go-mysql-server v0.4.1-0.20190930213140-66f118b01f72/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
 github.com/liquidata-inc/ishell v0.0.0-20190514193646-693241f1f2a0 h1:phMgajKClMUiIr+hF2LGt8KRuUa2Vd2GI1sNgHgSXoU=
 github.com/liquidata-inc/ishell v0.0.0-20190514193646-693241f1f2a0/go.mod h1:YC1rI9k5gx8D02ljlbxDfZe80s/iq8bGvaaQsvR+qxs=
 github.com/liquidata-inc/mmap-go v1.0.3 h1:2LndAeAtup9rpvUmu4wZSYCsjCQ0Zpc+NqE+6+PnT7g=

--- a/go/libraries/doltcore/sql/sqltestutil/updatequeries.go
+++ b/go/libraries/doltcore/sql/sqltestutil/updatequeries.go
@@ -1,0 +1,319 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqltestutil
+
+import (
+	"github.com/google/uuid"
+
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
+)
+
+// Structure for a test of an update query
+type UpdateTest struct {
+	// The name of this test. Names should be unique and descriptive.
+	Name string
+	// The update query to run
+	UpdateQuery string
+	// The select query to run to verify the results
+	SelectQuery string
+	// The schema of the result of the query, nil if an error is expected
+	ExpectedSchema schema.Schema
+	// The rows this query should return, nil if an error is expected
+	ExpectedRows []row.Row
+	// An expected error string
+	ExpectedErr string
+	// Setup logic to run before executing this test, after initial tables have been created and populated
+	AdditionalSetup SetupFn
+	// Whether to skip this test on SqlEngine (go-mysql-server) execution.
+	// Over time, this should become false for every query.
+	SkipOnSqlEngine bool
+}
+
+// BasicUpdateTests cover basic update statement features and error handling
+var BasicUpdateTests = []UpdateTest{
+	{
+		Name:           "update one row, one col, primary key where clause",
+		UpdateQuery:    `update people set first = "Domer" where id = 0`,
+		SelectQuery:    `select * from people where id = 0`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, MutateRow(Homer, FirstTag, "Domer")),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:           "update one row, one col, non-primary key where clause",
+		UpdateQuery:    `update people set first = "Domer" where first = "Homer"`,
+		SelectQuery:    `select * from people where first = "Domer"`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, MutateRow(Homer, FirstTag, "Domer")),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:           "update one row, two cols, primary key where clause",
+		UpdateQuery:    `update people set first = "Ned", last = "Flanders" where id = 0`,
+		SelectQuery:    `select * from people where id = 0`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, MutateRow(Homer, FirstTag, "Ned", LastTag, "Flanders")),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name: "update one row, all cols, non-primary key where clause",
+		UpdateQuery: `update people set first = "Ned", last = "Flanders", is_married = false, rating = 10,
+				age = 45, num_episodes = 150, uuid = '00000000-0000-0000-0000-000000000050'
+				where age = 38`,
+		SelectQuery: `select * from people where uuid = '00000000-0000-0000-0000-000000000050'`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Marge, FirstTag, "Ned", LastTag, "Flanders", IsMarriedTag, false,
+				RatingTag, 10.0, AgeTag, 45, NumEpisodesTag, uint64(150),
+				UuidTag, uuid.MustParse("00000000-0000-0000-0000-000000000050"))),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name: "update one row, set columns to existing values",
+		UpdateQuery: `update people set first = "Homer", last = "Simpson", is_married = true, rating = 8.5, age = 40,
+				num_episodes = null, uuid = null
+				where id = 0`,
+		SelectQuery:    `select * from people where id = 0`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, Homer),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name: "update one row, null out existing values",
+		UpdateQuery: `update people set first = "Homer", last = "Simpson", is_married = null, rating = null, age = null,
+				num_episodes = null, uuid = null
+				where first = "Homer"`,
+		SelectQuery:    `select * from people where first = "Homer"`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, MutateRow(Homer, IsMarriedTag, nil, RatingTag, nil, AgeTag, nil)),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name: "update multiple rows, set two columns",
+		UpdateQuery: `update people set first = "Changed", rating = 0.0
+				where last = "Simpson"`,
+		SelectQuery: `select * from people where last = "Simpson"`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Marge, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Bart, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Lisa, FirstTag, "Changed", RatingTag, 0.0),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:           "update no matching rows",
+		UpdateQuery:    `update people set first = "Changed", rating = 0.0 where last = "Flanders"`,
+		SelectQuery:    `select * from people`,
+		ExpectedRows:   CompressRows(PeopleTestSchema, Homer, Marge, Bart, Lisa, Moe, Barney),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update without where clause",
+		UpdateQuery: `update people set first = "Changed", rating = 0.0`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Marge, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Bart, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Lisa, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Moe, FirstTag, "Changed", RatingTag, 0.0),
+			MutateRow(Barney, FirstTag, "Changed", RatingTag, 0.0),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update set first = last",
+		UpdateQuery: `update people set first = last`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, FirstTag, "Simpson"),
+			MutateRow(Marge, FirstTag, "Simpson"),
+			MutateRow(Bart, FirstTag, "Simpson"),
+			MutateRow(Lisa, FirstTag, "Simpson"),
+			MutateRow(Moe, FirstTag, "Szyslak"),
+			MutateRow(Barney, FirstTag, "Gumble"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update increment age",
+		UpdateQuery: `update people set age = age + 1`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, AgeTag, 41),
+			MutateRow(Marge, AgeTag, 39),
+			MutateRow(Bart, AgeTag, 11),
+			MutateRow(Lisa, AgeTag, 9),
+			MutateRow(Moe, AgeTag, 49),
+			MutateRow(Barney, AgeTag, 41),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update reverse rating",
+		UpdateQuery: `update people set rating = -rating`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, RatingTag, -8.5),
+			MutateRow(Marge, RatingTag, -8.0),
+			MutateRow(Bart, RatingTag, -9.0),
+			MutateRow(Lisa, RatingTag, -10.0),
+			MutateRow(Moe, RatingTag, -6.5),
+			MutateRow(Barney, RatingTag, -4.0),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, =",
+		UpdateQuery: `update people set first = "Homer" where last = "Simpson"`,
+		SelectQuery: `select * from people where last = "Simpson"`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			Homer,
+			MutateRow(Marge, FirstTag, "Homer"),
+			MutateRow(Bart, FirstTag, "Homer"),
+			MutateRow(Lisa, FirstTag, "Homer"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, <>",
+		UpdateQuery: `update people set last = "Simpson" where last <> "Simpson"`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			Homer,
+			Marge,
+			Bart,
+			Lisa,
+			MutateRow(Moe, LastTag, "Simpson"),
+			MutateRow(Barney, LastTag, "Simpson"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, >",
+		UpdateQuery: `update people set first = "Homer" where age > 10`,
+		SelectQuery: `select * from people where age > 10`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			Homer,
+			MutateRow(Marge, FirstTag, "Homer"),
+			MutateRow(Moe, FirstTag, "Homer"),
+			MutateRow(Barney, FirstTag, "Homer"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, >=",
+		UpdateQuery: `update people set first = "Homer" where age >= 10`,
+		SelectQuery: `select * from people where age >= 10`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			Homer,
+			MutateRow(Marge, FirstTag, "Homer"),
+			MutateRow(Bart, FirstTag, "Homer"),
+			MutateRow(Moe, FirstTag, "Homer"),
+			MutateRow(Barney, FirstTag, "Homer"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, <",
+		UpdateQuery: `update people set first = "Bart" where age < 40`,
+		SelectQuery: `select * from people where age < 40`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Marge, FirstTag, "Bart"),
+			Bart,
+			MutateRow(Lisa, FirstTag, "Bart"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows, <=",
+		UpdateQuery: `update people set first = "Homer" where age <= 40`,
+		SelectQuery: `select * from people where age <= 40`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			Homer,
+			MutateRow(Marge, FirstTag, "Homer"),
+			MutateRow(Bart, FirstTag, "Homer"),
+			MutateRow(Lisa, FirstTag, "Homer"),
+			MutateRow(Barney, FirstTag, "Homer"),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows pk increment order by desc",
+		UpdateQuery: `update people set id = id + 1 order by id desc`,
+		SelectQuery: `select * from people`,
+		ExpectedRows: CompressRows(PeopleTestSchema,
+			MutateRow(Homer, IdTag, homerId+1),
+			MutateRow(Marge, IdTag, margeId+1),
+			MutateRow(Bart, IdTag, bartId+1),
+			MutateRow(Lisa, IdTag, lisaId+1),
+			MutateRow(Moe, IdTag, moeId+1),
+			MutateRow(Barney, IdTag, barneyId+1),
+		),
+		ExpectedSchema: CompressSchema(PeopleTestSchema),
+	},
+	{
+		Name:        "update multiple rows pk increment order by asc",
+		UpdateQuery: `update people set id = id + 1 order by id asc`,
+		ExpectedErr: "cannot update primary key column",
+	},
+	{
+		Name:        "update primary key col",
+		UpdateQuery: `update people set id = 0 where first = "Marge"`,
+		ExpectedErr: "Cannot update primary key column 'id'",
+	},
+	{
+		Name:        "null constraint failure",
+		UpdateQuery: `update people set first = null where id = 0`,
+		ExpectedErr: "Constraint failed for column 'first': Not null",
+	},
+	{
+		Name:        "type mismatch list -> string",
+		UpdateQuery: `update people set first = ("one", "two") where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch int -> uuid",
+		UpdateQuery: `update people set uuid = 0 where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch string -> int",
+		UpdateQuery: `update people set age = "pretty old" where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch string -> float",
+		UpdateQuery: `update people set rating = "great" where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch string -> uint",
+		UpdateQuery: `update people set num_episodes = "all of them" where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch string -> uuid",
+		UpdateQuery: `update people set uuid = "not a uuid string" where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:        "type mismatch bool -> uuid",
+		UpdateQuery: `update people set uuid = false where id = 0`,
+		ExpectedErr: "Type mismatch",
+	},
+	{
+		Name:            "type mismatch in where clause",
+		UpdateQuery:     `update people set first = "Homer" where id = "id"`,
+		ExpectedErr:     "Type mismatch",
+		SkipOnSqlEngine: true,
+	},
+}

--- a/go/libraries/doltcore/sqle/sqlupdate_test.go
+++ b/go/libraries/doltcore/sqle/sqlupdate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqle
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/dtestutils"
+	. "github.com/liquidata-inc/dolt/go/libraries/doltcore/sql/sqltestutil"
+)
+
+// Set to the name of a single test to run just that test, useful for debugging
+const singleUpdateQueryTest = "" //"Natural join with join clause"
+
+// Set to false to run tests known to be broken
+const skipBrokenUpdate = true
+
+func TestExecuteUpdate(t *testing.T) {
+	for _, test := range BasicUpdateTests {
+		t.Run(test.Name, func(t *testing.T) {
+			testUpdateQuery(t, test)
+		})
+	}
+}
+
+// Tests the given query on a freshly created dataset, asserting that the result has the given schema and rows. If
+// expectedErr is set, asserts instead that the execution returns an error that matches.
+func testUpdateQuery(t *testing.T, test UpdateTest) {
+	if (test.ExpectedRows == nil) != (test.ExpectedSchema == nil) {
+		require.Fail(t, "Incorrect test setup: schema and rows must both be provided if one is")
+	}
+
+	if len(singleUpdateQueryTest) > 0 && test.Name != singleUpdateQueryTest {
+		t.Skip("Skipping tests until " + singleUpdateQueryTest)
+	}
+
+	if len(singleUpdateQueryTest) == 0 && test.SkipOnSqlEngine && skipBrokenUpdate {
+		t.Skip("Skipping test broken on SQL engine")
+	}
+
+	dEnv := dtestutils.CreateTestEnv()
+	CreateTestDatabase(dEnv, t)
+
+	if test.AdditionalSetup != nil {
+		test.AdditionalSetup(t, dEnv)
+	}
+
+	var err error
+	root, _ := dEnv.WorkingRoot(context.Background())
+	root, err = executeModify(context.Background(), root, test.UpdateQuery)
+	if len(test.ExpectedErr) > 0 {
+		require.Error(t, err)
+		return
+	} else {
+		require.NoError(t, err)
+	}
+
+	actualRows, sch, err := executeSelect(context.Background(), test.ExpectedSchema, root, test.SelectQuery)
+	require.NoError(t, err)
+
+	assert.Equal(t, test.ExpectedRows, actualRows)
+	assert.Equal(t, test.ExpectedSchema, sch)
+}


### PR DESCRIPTION
I think we should delete the old SQL methods that are in the `sql.go` file. I know at first you mentioned keeping them there for reference, but they're not being used at all at this point, and they're still in git history if we want to look at them again in the future for some reason. It's clutter at this point.

I'm skipping that one test at the end because of a WHERE decision in `go-mysql-server`. The code looks intentional, in that converting strings to ints will return 0 if the string is not parsable. I'll file it as a non-conforming bug on their end, but for now I'm skipping the test.