### PR TITLE
dolt diff --summary

### DIFF
--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -115,7 +115,6 @@ teardown() {
     dolt table put-row test pk:2 c1:11 c2:0 c3:0 c4:0 c5:0
     dolt table put-row employees id:1 "first name":brian "last name":hendriks title:founder "start date":"" "end date":""
     run dolt diff --summary
-    echo "$output"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "diff --dolt a/test b/test" ]] || false
     [[ "$output" =~ "--- a/test @" ]] || false

--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -14,7 +14,7 @@ teardown() {
     rm -rf "$BATS_TMPDIR/dolt-repo-$$"
 }
 
-@test "diff summary works" {
+@test "diff summary comparing working table to last commit" {
     dolt table create -s=`batshelper 1pk5col-ints.schema` test
     dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
     dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
@@ -24,47 +24,103 @@ teardown() {
     dolt table put-row test pk:3 c1:11 c2:0 c3:0 c4:0 c5:0
     run dolt diff --summary
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "2 Rows Unmodified" ]] || false
-    [[ "$output" =~ "2 Rows Added" ]] || false
-    [[ "$output" =~ "0 Rows Deleted" ]] || false
-    [[ "$output" =~ "0 Rows Modified" ]] || false
-    [[ "$output" =~ "(2 entries vs 4 entries)" ]] || false
+    [[ "$output" =~ "2 Rows Unmodified (100.00%)" ]] || false
+    [[ "$output" =~ "2 Rows Added (100.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Deleted (0.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Modified (0.00%)" ]] || false
+    [[ "$output" =~ "0 Cells Modified (0.00%)" ]] || false
+    [[ "$output" =~ "(2 Entries vs 4 Entries)" ]] || false
 
     dolt add test
     dolt commit -m "added two rows"
-    dolt table put-row test pk:0 c1:11 c2:0 c3:0 c4:0 c5:0
+    dolt table put-row test pk:0 c1:11 c2:0 c3:0 c4:0 c5:6
     run dolt diff --summary
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "3 Rows Unmodified" ]] || false
-    [[ "$output" =~ "0 Rows Added" ]] || false
-    [[ "$output" =~ "0 Rows Deleted" ]] || false
-    [[ "$output" =~ "1 Row Modified" ]] || false
-    [[ "$output" =~ "(4 entries vs 4 entries)" ]] || false
+    [[ "$output" =~ "3 Rows Unmodified (75.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Added (0.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Deleted (0.00%)" ]] || false
+    [[ "$output" =~ "1 Row Modified (25.00%)" ]] || false
+    [[ "$output" =~ "2 Cells Modified (8.33%)" ]] || false
+    [[ "$output" =~ "(4 Entries vs 4 Entries)" ]] || false
 
     dolt add test
     dolt commit -m "modified first row"
     dolt table rm-row test 0
     run dolt diff --summary
-    echo "OUTPUT = $output"
-    [ "$status" -eq 1 ]
-    [[ "$output" =~ "3 Rows Unmodified" ]] || false
-    [[ "$output" =~ "0 Rows Added" ]] || false
-    [[ "$output" =~ "1 Row Deleted" ]] || false
-    [[ "$output" =~ "0 Rows Modified" ]] || false
-    [[ "$output" =~ "(4 entries vs 3 entries)" ]] || false
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3 Rows Unmodified (75.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Added (0.00%)" ]] || false
+    [[ "$output" =~ "1 Row Deleted (25.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Modified (0.00%)" ]] || false
+    [[ "$output" =~ "0 Cells Modified (0.00%)" ]] || false
+    [[ "$output" =~ "(4 Entries vs 3 Entries)" ]] || false
 }
 
-@test "diff summary comparing commits" {
-  dolt checkout -b firstbranch
-  dolt table create -s=`batshelper 1pk5col-ints.schema` test
-  dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
-  dolt add test
-  dolt commit -m "Added one row"
-  dolt checkout -b newbranch
-  dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
-  dolt add test
-  dolt commit -m "Added another row"
-  run dolt diff --summary firstbranch newbranch 
-  echo "OUTPUT = $output"
-  [ "$status" -eq 1 ]
+@test "diff summary comparing two branches" {
+    dolt checkout -b firstbranch
+    dolt table create -s=`batshelper 1pk5col-ints.schema` test
+    dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
+    dolt add test
+    dolt commit -m "Added one row"
+    dolt checkout -b newbranch
+    dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
+    dolt add test
+    dolt commit -m "Added another row"
+    run dolt diff --summary newbranch firstbranch 
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "1 Row Unmodified (100.00%)" ]] || false
+    [[ "$output" =~ "1 Row Added (100.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Deleted (0.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Modified (0.00%)" ]] || false
+    [[ "$output" =~ "0 Cells Modified (0.00%)" ]] || false
+    [[ "$output" =~ "(1 Entry vs 2 Entries)" ]] || false
+}
+
+@test "diff summary shows correct changes after schema change" {
+    dolt table import -c -s=`batshelper employees-sch.json` employees `batshelper employees-tbl.json`
+    dolt add employees
+    dolt commit -m "Added employees table with data"
+    dolt schema --add-column employees city string
+    run dolt diff --summary
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "No data changes. See schema changes by using -s or --schema." ]] || false
+    dolt table put-row employees id:3 "first name":taylor "last name":bantle title:"software engineer" "start date":"" "end date":"" city:"Santa Monica"
+    run dolt diff --summary
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3 Rows Unmodified (100.00%)" ]] || false
+    [[ "$output" =~ "1 Row Added (33.33%)" ]] || false
+    [[ "$output" =~ "0 Rows Deleted (0.00%)" ]] || false
+    [[ "$output" =~ "0 Rows Modified (0.00%)" ]] || false
+    [[ "$output" =~ "0 Cells Modified (0.00%)" ]] || false
+    [[ "$output" =~ "(3 Entries vs 4 Entries)" ]] || false
+    dolt table put-row employees id:0 "first name":tim "last name":sehn title:ceo "start date":"2 years ago" "end date":"" city:"Santa Monica"
+    run dolt diff --summary
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2 Rows Unmodified (66.67%)" ]] || false
+    [[ "$output" =~ "1 Row Added (33.33%)" ]] || false
+    [[ "$output" =~ "0 Rows Deleted (0.00%)" ]] || false
+    [[ "$output" =~ "1 Row Modified (33.33%)" ]] || false
+    [[ "$output" =~ "2 Cells Modified (11.11%)" ]] || false
+    [[ "$output" =~ "(3 Entries vs 4 Entries)" ]] || false
+}
+
+@test "diff summary gets summaries for all tables with changes" {
+    dolt table create -s=`batshelper 1pk5col-ints.schema` test
+    dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
+    dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
+    dolt table create -s=`batshelper employees-sch.json` employees
+    dolt table put-row employees id:0 "first name":tim "last name":sehn title:ceo "start date":"" "end date":""
+    dolt add test employees
+    dolt commit -m "test tables created"
+    dolt table put-row test pk:2 c1:11 c2:0 c3:0 c4:0 c5:0
+    dolt table put-row employees id:1 "first name":brian "last name":hendriks title:founder "start date":"" "end date":""
+    run dolt diff --summary
+    echo "$output"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "diff --dolt a/test b/test" ]] || false
+    [[ "$output" =~ "--- a/test @" ]] || false
+    [[ "$output" =~ "+++ b/test @" ]] || false
+    [[ "$output" =~ "diff --dolt a/employees b/employees" ]] || false
+    [[ "$output" =~ "--- a/employees @" ]] || false
+    [[ "$output" =~ "+++ b/employees @" ]] || false
 }

--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+setup() {
+    load $BATS_TEST_DIRNAME/helper/common.bash
+    export PATH=$PATH:~/go/bin
+    export NOMS_VERSION_NEXT=1
+    cd $BATS_TMPDIR
+    mkdir "dolt-repo-$$"
+    cd "dolt-repo-$$"
+    dolt init
+}
+
+teardown() {
+    rm -rf "$BATS_TMPDIR/dolt-repo-$$"
+}
+
+@test "diff summary works" {
+    dolt table create -s=`batshelper 1pk5col-ints.schema` test
+    dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
+    dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
+    dolt add test
+    dolt commit -m "table created"
+    dolt table put-row test pk:2 c1:11 c2:0 c3:0 c4:0 c5:0
+    dolt table put-row test pk:3 c1:11 c2:0 c3:0 c4:0 c5:0
+    run dolt diff --summary
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "2 Rows Unmodified" ]] || false
+    [[ "$output" =~ "2 Rows Added" ]] || false
+    [[ "$output" =~ "0 Rows Deleted" ]] || false
+    [[ "$output" =~ "0 Rows Modified" ]] || false
+    [[ "$output" =~ "(2 entries vs 4 entries)" ]] || false
+
+    dolt add test
+    dolt commit -m "added two rows"
+    dolt table put-row test pk:0 c1:11 c2:0 c3:0 c4:0 c5:0
+    run dolt diff --summary
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "3 Rows Unmodified" ]] || false
+    [[ "$output" =~ "0 Rows Added" ]] || false
+    [[ "$output" =~ "0 Rows Deleted" ]] || false
+    [[ "$output" =~ "1 Row Modified" ]] || false
+    [[ "$output" =~ "(4 entries vs 4 entries)" ]] || false
+
+    dolt add test
+    dolt commit -m "modified first row"
+    dolt table rm-row test 0
+    run dolt diff --summary
+    echo "OUTPUT = $output"
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "3 Rows Unmodified" ]] || false
+    [[ "$output" =~ "0 Rows Added" ]] || false
+    [[ "$output" =~ "1 Row Deleted" ]] || false
+    [[ "$output" =~ "0 Rows Modified" ]] || false
+    [[ "$output" =~ "(4 entries vs 3 entries)" ]] || false
+}
+
+@test "diff summary comparing commits" {
+  dolt checkout -b firstbranch
+  dolt table create -s=`batshelper 1pk5col-ints.schema` test
+  dolt table put-row test pk:0 c1:0 c2:0 c3:0 c4:0 c5:0
+  dolt add test
+  dolt commit -m "Added one row"
+  dolt checkout -b newbranch
+  dolt table put-row test pk:1 c1:1 c2:1 c3:1 c4:1 c5:1
+  dolt add test
+  dolt commit -m "Added another row"
+  run dolt diff --summary firstbranch newbranch 
+  echo "OUTPUT = $output"
+  [ "$status" -eq 1 ]
+}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -302,7 +302,8 @@ func diffRoots(ctx context.Context, r1, r2 *doltdb.RootValue, tblNames []string,
 		var verr errhand.VerboseError
 
 		if summary {
-			verr = diff.Summary(ctx, rowData2, rowData1)
+			colLen := sch2.GetAllCols().Size()
+			verr = diff.Summary(ctx, rowData1, rowData2, colLen)
 		}
 
 		if diffParts&SchemaOnlyDiff != 0 && sch1Hash != sch2Hash && !summary {

--- a/go/libraries/doltcore/diff/diff_summary.go
+++ b/go/libraries/doltcore/diff/diff_summary.go
@@ -1,0 +1,298 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	humanize "github.com/dustin/go-humanize"
+
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	"github.com/liquidata-inc/dolt/go/store/atomicerr"
+	"github.com/liquidata-inc/dolt/go/store/diff"
+	"github.com/liquidata-inc/dolt/go/store/types"
+	"github.com/liquidata-inc/dolt/go/store/util/status"
+)
+
+type diffFunc func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{})
+
+func Summary(ctx context.Context, v1, v2 types.Value) errhand.VerboseError {
+	// if is1, err := datas.IsCommit(v1); err != nil {
+	// 	return errhand.BuildDError("").AddCause(err).Build()
+	// } else if is1 {
+	// 	if is2, err := datas.IsCommit(v2); err != nil {
+	// 		return errhand.BuildDError("").AddCause(err).Build()
+	// 	} else if is2 {
+	// 		cli.Println("Comparing commit values")
+
+	// 		var err error
+	// 		v1, _, err = v1.(types.Struct).MaybeGet(datas.ValueField)
+	// 		if err != nil {
+	// 			return errhand.BuildDError("").AddCause(err).Build()
+	// 		}
+
+	// 		v2, _, err = v2.(types.Struct).MaybeGet(datas.ValueField)
+	// 		if err != nil {
+	// 			return errhand.BuildDError("").AddCause(err).Build()
+	// 		}
+	// 	}
+	// }
+
+	// will values ever not be MapKind?
+	var singular, plural string
+	if v1.Kind() == v2.Kind() {
+		switch v1.Kind() {
+		case types.StructKind:
+			singular = "field"
+			plural = "fields"
+		case types.MapKind:
+			singular = "entry"
+			plural = "entries"
+		default:
+			singular = "value"
+			plural = "values"
+		}
+	}
+
+	var rp atomic.Value
+	var verr errhand.VerboseError
+	ae := atomicerr.New()
+	ch := make(chan diffSummaryProgress)
+	go func() {
+		defer close(ch)
+		defer func() {
+			if r := recover(); r != nil {
+				rp.Store(r)
+			}
+		}()
+		verr = diffSummary(ctx, ae, ch, v1, v2)
+	}()
+
+	if verr != nil {
+		return verr
+	}
+
+	acc := diffSummaryProgress{}
+	for p := range ch {
+		if ae.IsSet() {
+			break
+		}
+
+		acc.Adds += p.Adds
+		acc.Removes += p.Removes
+		acc.Changes += p.Changes
+		acc.NewSize += p.NewSize
+		acc.OldSize += p.OldSize
+	}
+
+	if err := ae.Get(); err != nil {
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+
+	if r := rp.Load(); r != nil {
+		err := fmt.Errorf("panic occured during closing: %v", r)
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+
+	formatStatus(acc, singular, plural)
+	status.Done()
+
+	return nil
+}
+
+type diffSummaryProgress struct {
+	Adds, Removes, Changes, NewSize, OldSize uint64
+}
+
+func diffSummary(ctx context.Context, ae *atomicerr.AtomicError, ch chan diffSummaryProgress, v1, v2 types.Value) errhand.VerboseError {
+	var verr errhand.VerboseError
+	if !v1.Equals(v2) {
+		if diff.ShouldDescend(v1, v2) {
+			switch v1.Kind() {
+			case types.ListKind:
+				verr = diffSummaryList(ctx, ae, ch, v1.(types.List), v2.(types.List))
+			case types.MapKind:
+				verr = diffSummaryMap(ctx, ae, ch, v1.(types.Map), v2.(types.Map))
+			case types.SetKind:
+				verr = diffSummarySet(ctx, ae, ch, v1.(types.Set), v2.(types.Set))
+			case types.StructKind:
+				verr = diffSummaryStructs(ae, ch, v1.(types.Struct), v2.(types.Struct))
+			default:
+				return errhand.BuildDError("Unrecognized type in diff function").Build()
+			}
+		} else {
+			ch <- diffSummaryProgress{Adds: 1, Removes: 1, NewSize: 1, OldSize: 1}
+		}
+	}
+	if verr != nil {
+		return verr
+	}
+	return nil
+}
+
+func diffSummaryList(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.List) errhand.VerboseError {
+	ch <- diffSummaryProgress{OldSize: v1.Len(), NewSize: v2.Len()}
+
+	spliceChan := make(chan types.Splice)
+	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
+
+	var rp atomic.Value
+	var err error
+	go func() {
+		defer close(spliceChan)
+		defer func() {
+			if r := recover(); r != nil {
+				rp.Store(r)
+			}
+		}()
+		err = v2.Diff(ctx, v1, spliceChan, stopChan)
+	}()
+
+	if err != nil {
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+
+	for splice := range spliceChan {
+		if splice.SpRemoved == splice.SpAdded {
+			ch <- diffSummaryProgress{Changes: splice.SpRemoved}
+		} else {
+			ch <- diffSummaryProgress{Adds: splice.SpAdded, Removes: splice.SpRemoved}
+		}
+	}
+
+	if r := rp.Load(); r != nil {
+		err := fmt.Errorf("panic occured during closing: %v", r)
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+
+	return nil
+}
+
+func diffSummaryMap(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Map) errhand.VerboseError {
+	verr := diffSummaryValueChanged(ae, ch, v1.Len(), v2.Len(), func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
+		v2.Diff(ctx, v1, ae, changeChan, stopChan)
+	})
+	if verr != nil {
+		return verr
+	}
+	return nil
+}
+
+func diffSummarySet(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Set) errhand.VerboseError {
+	verr := diffSummaryValueChanged(ae, ch, v1.Len(), v2.Len(), func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
+		v2.Diff(ctx, v1, ae, changeChan, stopChan)
+	})
+	if verr != nil {
+		return verr
+	}
+	return nil
+}
+
+func diffSummaryStructs(ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Struct) errhand.VerboseError {
+	// TODO: Operate on values directly
+	t1, err := types.TypeOf(v1)
+
+	if ae.SetIfError(err) {
+		return nil
+	}
+
+	t2, err := types.TypeOf(v2)
+
+	if ae.SetIfError(err) {
+		return nil
+	}
+
+	size1 := uint64(t1.Desc.(types.StructDesc).Len())
+	size2 := uint64(t2.Desc.(types.StructDesc).Len())
+	verr := diffSummaryValueChanged(ae, ch, size1, size2, func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
+		err := v2.Diff(v1, changeChan, stopChan)
+		ae.SetIfError(err)
+	})
+	if verr != nil {
+		return verr
+	}
+	return nil
+}
+
+func diffSummaryValueChanged(ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, oldSize, newSize uint64, f diffFunc) errhand.VerboseError {
+	ch <- diffSummaryProgress{OldSize: oldSize, NewSize: newSize}
+
+	changeChan := make(chan types.ValueChanged)
+	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
+
+	var rp atomic.Value
+	go func() {
+		defer close(changeChan)
+		defer func() {
+			if r := recover(); r != nil {
+				rp.Store(r)
+			}
+		}()
+		f(changeChan, stopChan)
+	}()
+	reportChanges(ch, changeChan)
+	if r := rp.Load(); r != nil {
+		err := fmt.Errorf("panic occured during closing: %v", r)
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+	return nil
+}
+
+func reportChanges(ch chan<- diffSummaryProgress, changeChan chan types.ValueChanged) errhand.VerboseError {
+	for change := range changeChan {
+		switch change.ChangeType {
+		case types.DiffChangeAdded:
+			ch <- diffSummaryProgress{Adds: 1}
+		case types.DiffChangeRemoved:
+			ch <- diffSummaryProgress{Removes: 1}
+		case types.DiffChangeModified:
+			ch <- diffSummaryProgress{Changes: 1}
+		default:
+			return errhand.BuildDError("unknown change type").Build()
+		}
+	}
+	return nil
+}
+
+func formatStatus(acc diffSummaryProgress, singular, plural string) {
+	pluralize := func(singular, plural string, n uint64) string {
+		var noun string
+		if n != 1 {
+			noun = plural
+		} else {
+			noun = singular
+		}
+		return fmt.Sprintf("%s %s", humanize.Comma(int64(n)), noun)
+	}
+
+	rowsUnmodified := uint64(acc.OldSize - acc.Changes - acc.Removes)
+	unmodified := pluralize("Row Unmodified", "Rows Unmodified", rowsUnmodified)
+	insertions := pluralize("Row Added", "Rows Added", acc.Adds)
+	deletions := pluralize("Row Deleted", "Rows Deleted", acc.Removes)
+	changes := pluralize("Row Modified", "Rows Modified", acc.Changes)
+	// cellChanges := pluralize("cell modified", "cells modified", acc.CellsModified)
+
+	oldValues := pluralize(singular, plural, acc.OldSize)
+	newValues := pluralize(singular, plural, acc.NewSize)
+
+	cli.Printf("%s (%.2f%%)\n", unmodified, (float64(100*rowsUnmodified) / float64(acc.OldSize)))
+	cli.Printf("%s (%.2f%%)\n", insertions, (float64(100*acc.Adds) / float64(acc.OldSize)))
+	cli.Printf("%s (%.2f%%)\n", deletions, (float64(100*acc.Removes) / float64(acc.OldSize)))
+	cli.Printf("%s (%.2f%%)\n", changes, (float64(100*acc.Changes) / float64(acc.OldSize)))
+	cli.Printf("(%s vs %s)\n", oldValues, newValues)
+}

--- a/go/libraries/doltcore/diff/diff_summary.go
+++ b/go/libraries/doltcore/diff/diff_summary.go
@@ -16,323 +16,71 @@ package diff
 
 import (
 	"context"
-	"fmt"
-	"sync/atomic"
+	"errors"
 
-	humanize "github.com/dustin/go-humanize"
-
-	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
-	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/store/atomicerr"
-	"github.com/liquidata-inc/dolt/go/store/datas"
 	"github.com/liquidata-inc/dolt/go/store/diff"
 	"github.com/liquidata-inc/dolt/go/store/types"
-	"github.com/liquidata-inc/dolt/go/store/util/status"
 )
 
 type diffFunc func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{})
 
-// Summary prints a summary of the diff between two values
-func Summary(ctx context.Context, v1, v2 types.Value, colLen int) errhand.VerboseError {
-	if is1, err := datas.IsCommit(v1); err != nil {
-		return errhand.BuildDError("").AddCause(err).Build()
-	} else if is1 {
-		if is2, err := datas.IsCommit(v2); err != nil {
-			return errhand.BuildDError("").AddCause(err).Build()
-		} else if is2 {
-			cli.Println("Comparing commit values")
-
-			var err error
-			v1, _, err = v1.(types.Struct).MaybeGet(datas.ValueField)
-			if err != nil {
-				return errhand.BuildDError("").AddCause(err).Build()
-			}
-
-			v2, _, err = v2.(types.Struct).MaybeGet(datas.ValueField)
-			if err != nil {
-				return errhand.BuildDError("").AddCause(err).Build()
-			}
-		}
-	}
-
-	var singular, plural string
-	if v1.Kind() == v2.Kind() {
-		switch v1.Kind() {
-		case types.StructKind:
-			singular = "Field"
-			plural = "Fields"
-		case types.MapKind:
-			singular = "Entry"
-			plural = "Entries"
-		default:
-			singular = "Value"
-			plural = "Values"
-		}
-	}
-
-	var rp atomic.Value
-	var verr errhand.VerboseError
-	ae := atomicerr.New()
-	ch := make(chan diffSummaryProgress)
-	go func() {
-		defer close(ch)
-		defer func() {
-			if r := recover(); r != nil {
-				rp.Store(r)
-			}
-		}()
-		verr = diffSummary(ctx, ae, ch, v2, v1)
-	}()
-
-	if verr != nil {
-		return verr
-	}
-
-	acc := diffSummaryProgress{}
-	for p := range ch {
-		if ae.IsSet() {
-			break
-		}
-
-		acc.Adds += p.Adds
-		acc.Removes += p.Removes
-		acc.Changes += p.Changes
-		acc.CellChanges += p.CellChanges
-		acc.NewSize += p.NewSize
-		acc.OldSize += p.OldSize
-	}
-
-	if err := ae.Get(); err != nil {
-		return errhand.BuildDError("").AddCause(err).Build()
-	}
-
-	if r := rp.Load(); r != nil {
-		err := fmt.Errorf("panic occured during closing: %v", r)
-		return errhand.BuildDError("").AddCause(err).Build()
-	}
-	if acc.NewSize > 0 || acc.OldSize > 0 {
-		formatStatus(acc, singular, plural, colLen)
-	} else {
-		cli.Println("No data changes. See schema changes by using -s or --schema.")
-	}
-	status.Done()
-
-	return nil
-}
-
-type diffSummaryProgress struct {
+type DiffSummaryProgress struct {
 	Adds, Removes, Changes, CellChanges, NewSize, OldSize uint64
 }
 
-func diffSummary(ctx context.Context, ae *atomicerr.AtomicError, ch chan diffSummaryProgress, v1, v2 types.Value) errhand.VerboseError {
-	var verr errhand.VerboseError
+// Summary reports a summary of diff changes between two values
+func Summary(ctx context.Context, ae *atomicerr.AtomicError, ch chan DiffSummaryProgress, v1, v2 types.Map) {
 	if !v1.Equals(v2) {
 		if diff.ShouldDescend(v1, v2) {
-			switch v1.Kind() {
-			case types.ListKind:
-				verr = diffSummaryList(ctx, ae, ch, v1.(types.List), v2.(types.List))
-			case types.MapKind:
-				verr = diffSummaryMap(ctx, ae, ch, v1.(types.Map), v2.(types.Map))
-			case types.SetKind:
-				verr = diffSummarySet(ctx, ae, ch, v1.(types.Set), v2.(types.Set))
-			case types.StructKind:
-				verr = diffSummaryStructs(ae, ch, v1.(types.Struct), v2.(types.Struct))
-			default:
-				return errhand.BuildDError("Unrecognized type in diff function").Build()
-			}
+			diffSummaryValueChanged(ae, ch, v1.Len(), v2.Len(), func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
+				v2.Diff(ctx, v1, ae, changeChan, stopChan)
+			})
 		} else {
-			ch <- diffSummaryProgress{Adds: 1, Removes: 1, NewSize: 1, OldSize: 1}
+			ch <- DiffSummaryProgress{Adds: 1, Removes: 1, NewSize: 1, OldSize: 1}
 		}
 	}
-	if verr != nil {
-		return verr
-	}
-	return nil
 }
 
-func diffSummaryList(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.List) errhand.VerboseError {
-	ch <- diffSummaryProgress{OldSize: v1.Len(), NewSize: v2.Len()}
-
-	spliceChan := make(chan types.Splice)
-	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
-
-	var rp atomic.Value
-	var err error
-	go func() {
-		defer close(spliceChan)
-		defer func() {
-			if r := recover(); r != nil {
-				rp.Store(r)
-			}
-		}()
-		err = v2.Diff(ctx, v1, spliceChan, stopChan)
-	}()
-
-	if err != nil {
-		return errhand.BuildDError("").AddCause(err).Build()
-	}
-
-	for splice := range spliceChan {
-		if splice.SpRemoved == splice.SpAdded {
-			ch <- diffSummaryProgress{Changes: splice.SpRemoved}
-		} else {
-			ch <- diffSummaryProgress{Adds: splice.SpAdded, Removes: splice.SpRemoved}
-		}
-	}
-
-	if r := rp.Load(); r != nil {
-		err := fmt.Errorf("panic occured during closing: %v", r)
-		return errhand.BuildDError("").AddCause(err).Build()
-	}
-
-	return nil
-}
-
-func diffSummaryMap(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Map) errhand.VerboseError {
-	verr := diffSummaryValueChanged(ae, ch, v1.Len(), v2.Len(), func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
-		v2.Diff(ctx, v1, ae, changeChan, stopChan)
-	})
-	if verr != nil {
-		return verr
-	}
-	return nil
-}
-
-func diffSummarySet(ctx context.Context, ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Set) errhand.VerboseError {
-	verr := diffSummaryValueChanged(ae, ch, v1.Len(), v2.Len(), func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
-		v2.Diff(ctx, v1, ae, changeChan, stopChan)
-	})
-	if verr != nil {
-		return verr
-	}
-	return nil
-}
-
-func diffSummaryStructs(ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, v1, v2 types.Struct) errhand.VerboseError {
-	// TODO: Operate on values directly
-	t1, err := types.TypeOf(v1)
-
-	if ae.SetIfError(err) {
-		return nil
-	}
-
-	t2, err := types.TypeOf(v2)
-
-	if ae.SetIfError(err) {
-		return nil
-	}
-
-	size1 := uint64(t1.Desc.(types.StructDesc).Len())
-	size2 := uint64(t2.Desc.(types.StructDesc).Len())
-	verr := diffSummaryValueChanged(ae, ch, size1, size2, func(changeChan chan<- types.ValueChanged, stopChan <-chan struct{}) {
-		err := v2.Diff(v1, changeChan, stopChan)
-		ae.SetIfError(err)
-	})
-	if verr != nil {
-		return verr
-	}
-	return nil
-}
-
-func diffSummaryValueChanged(ae *atomicerr.AtomicError, ch chan<- diffSummaryProgress, oldSize, newSize uint64, f diffFunc) errhand.VerboseError {
-	ch <- diffSummaryProgress{OldSize: oldSize, NewSize: newSize}
+func diffSummaryValueChanged(ae *atomicerr.AtomicError, ch chan<- DiffSummaryProgress, oldSize, newSize uint64, f diffFunc) {
+	ch <- DiffSummaryProgress{OldSize: oldSize, NewSize: newSize}
 
 	changeChan := make(chan types.ValueChanged)
 	stopChan := make(chan struct{}, 1) // buffer size of 1, so this won't block if diff already finished
 
-	var rp atomic.Value
 	go func() {
 		defer close(changeChan)
-		defer func() {
-			if r := recover(); r != nil {
-				rp.Store(r)
-			}
-		}()
 		f(changeChan, stopChan)
 	}()
-	verr := reportChanges(ch, changeChan)
-	if verr != nil {
-		return verr
-	}
-	if r := rp.Load(); r != nil {
-		err := fmt.Errorf("panic occured during closing: %v", r)
-		return errhand.BuildDError("").AddCause(err).Build()
-	}
-	return nil
+
+	reportChanges(ae, ch, changeChan)
 }
 
-func reportChanges(ch chan<- diffSummaryProgress, changeChan chan types.ValueChanged) errhand.VerboseError {
-	var verr errhand.VerboseError
+func reportChanges(ae *atomicerr.AtomicError, ch chan<- DiffSummaryProgress, changeChan chan types.ValueChanged) {
+	var err error
 	for change := range changeChan {
 		switch change.ChangeType {
 		case types.DiffChangeAdded:
-			ch <- diffSummaryProgress{Adds: 1}
+			ch <- DiffSummaryProgress{Adds: 1}
 		case types.DiffChangeRemoved:
-			ch <- diffSummaryProgress{Removes: 1}
+			ch <- DiffSummaryProgress{Removes: 1}
 		case types.DiffChangeModified:
-			ch <- diffSummaryProgress{Changes: 1}
-			cellChanges, err := getCellChanges(change.NewValue, change.OldValue, change.Key)
-			if err != nil {
-				verr = errhand.BuildDError("").AddCause(err).Build()
-			}
-			ch <- diffSummaryProgress{CellChanges: cellChanges}
+			var cellChanges uint64
+			cellChanges, err = getCellChanges(change.NewValue, change.OldValue, change.Key)
+			ch <- DiffSummaryProgress{Changes: 1, CellChanges: cellChanges}
 		default:
-			return errhand.BuildDError("unknown change type").Build()
+			err = errors.New("unknown change type")
 		}
 	}
-	if verr != nil {
-		return verr
-	}
-	return nil
+	ae.SetIfError(err)
 }
 
 func getCellChanges(oldVal, newVal, key types.Value) (uint64, error) {
-	var cellsChanged uint64
-	var err error
-
 	oldTuple := oldVal.(types.Tuple)
 	newTuple := newVal.(types.Tuple)
 
 	if oldTuple.Len() > newTuple.Len() {
-		cellsChanged, err = oldTuple.CountDifferencesBetweenTupleFields(newTuple)
-	} else {
-		cellsChanged, err = newTuple.CountDifferencesBetweenTupleFields(oldTuple)
+		return oldTuple.CountDifferencesBetweenTupleFields(newTuple)
 	}
-
-	if err != nil {
-		return 0, err
-	}
-
-	return cellsChanged, nil
-}
-
-func formatStatus(acc diffSummaryProgress, singular, plural string, colLen int) {
-	pluralize := func(singular, plural string, n uint64) string {
-		var noun string
-		if n != 1 {
-			noun = plural
-		} else {
-			noun = singular
-		}
-		return fmt.Sprintf("%s %s", humanize.Comma(int64(n)), noun)
-	}
-
-	rowsUnmodified := uint64(acc.OldSize - acc.Changes - acc.Removes)
-	unmodified := pluralize("Row Unmodified", "Rows Unmodified", rowsUnmodified)
-	insertions := pluralize("Row Added", "Rows Added", acc.Adds)
-	deletions := pluralize("Row Deleted", "Rows Deleted", acc.Removes)
-	changes := pluralize("Row Modified", "Rows Modified", acc.Changes)
-	cellChanges := pluralize("Cell Modified", "Cells Modified", acc.CellChanges)
-
-	oldValues := pluralize(singular, plural, acc.OldSize)
-	newValues := pluralize(singular, plural, acc.NewSize)
-
-	percentCellsChanged := float64(100*acc.CellChanges) / (float64(acc.OldSize) * float64(colLen))
-
-	cli.Printf("%s (%.2f%%)\n", unmodified, (float64(100*rowsUnmodified) / float64(acc.OldSize)))
-	cli.Printf("%s (%.2f%%)\n", insertions, (float64(100*acc.Adds) / float64(acc.OldSize)))
-	cli.Printf("%s (%.2f%%)\n", deletions, (float64(100*acc.Removes) / float64(acc.OldSize)))
-	cli.Printf("%s (%.2f%%)\n", changes, (float64(100*acc.Changes) / float64(acc.OldSize)))
-	cli.Printf("%s (%.2f%%)\n", cellChanges, percentCellsChanged)
-	cli.Printf("(%s vs %s)\n", oldValues, newValues)
+	return newTuple.CountDifferencesBetweenTupleFields(oldTuple)
 }

--- a/go/libraries/doltcore/diff/schema_diff.go
+++ b/go/libraries/doltcore/diff/schema_diff.go
@@ -39,7 +39,7 @@ type SchemaDifference struct {
 	New      *schema.Column
 }
 
-// DiffSchemas compares two schemas by looking at column's with the same tag.
+// DiffSchemas compares two schemas by looking at columns with the same tag.
 func DiffSchemas(sch1, sch2 schema.Schema) (map[uint64]SchemaDifference, error) {
 	colPairMap, err := pairColumns(sch1, sch2)
 

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -456,15 +456,14 @@ func (t Tuple) CountDifferencesBetweenTupleFields(other Tuple) (uint64, error) {
 		if index%2 == 1 {
 			if index >= count {
 				changed++
-				return false, nil
 			} else {
 				for i := uint64(0); i < index; i++ {
 					err := dec.skipValue(other.format())
-
 					if err != nil {
 						return true, err
 					}
 				}
+
 				otherVal, err := dec.readValue(other.format())
 				if err != nil {
 					return true, err

--- a/go/store/types/tuple.go
+++ b/go/store/types/tuple.go
@@ -443,3 +443,43 @@ func (t Tuple) Less(nbf *NomsBinFormat, other LesserValuable) (bool, error) {
 
 	return TupleKind < other.Kind(), nil
 }
+
+// CountDifferencesBetweenTupleFields returns the number of fields that are different between two
+// tuples and does not panic if tuples are different lengths.
+func (t Tuple) CountDifferencesBetweenTupleFields(other Tuple) (uint64, error) {
+	changed := 0
+
+	err := t.IterFields(func(index uint64, val Value) (stop bool, err error) {
+		dec, count := other.decoderSkipToFields()
+
+		// Prevents comparing column tags
+		if index%2 == 1 {
+			if index >= count {
+				changed++
+				return false, nil
+			} else {
+				for i := uint64(0); i < index; i++ {
+					err := dec.skipValue(other.format())
+
+					if err != nil {
+						return true, err
+					}
+				}
+				otherVal, err := dec.readValue(other.format())
+				if err != nil {
+					return true, err
+				}
+				if !otherVal.Equals(val) {
+					changed++
+				}
+			}
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return 0, err
+	}
+	return uint64(changed), nil
+}


### PR DESCRIPTION
Example output using [Liquidata/tatoeba-sentence-translations](https://www.dolthub.com/repositories/Liquidata/tatoeba-sentence-translations):
```
$ dolt diff --summary rnfm50gmumlettuebt2latmer617ni3t

diff --dolt a/sentences b/sentences
--- a/sentences @ gd1v6fsc04k5676c105d046m04hla3ia
+++ b/sentences @ 2ttci8id13mijhv8u94qlioqegh7lgpo
7,800,102 Rows Unmodified (99.99%)
15,030 Rows Added (0.19%)
108 Rows Deleted (0.00%)
960 Rows Modified (0.01%)
1,888 Cells Modified (0.00%)
(7,801,170 Entries vs 7,816,092 Entries)

diff --dolt a/translations b/translations
--- a/translations @ p2355o6clst8ssvr9jha2bfgqbrstkmm
+++ b/translations @ 62ri8lmohbhs1mc01m9o4rbvj6rbl8ee
5,856,845 Rows Unmodified (90.91%)
468,173 Rows Added (7.27%)
578,242 Rows Deleted (8.98%)
7,626 Rows Modified (0.12%)
7,626 Cells Modified (0.06%)
(6,442,713 Entries vs 6,332,494 Entries)
```
Fixes #77 