### PR TITLE
Fixed SQL batch insert breaking on semicolons in strings

### DIFF
--- a/bats/1pk5col-strings.bats
+++ b/bats/1pk5col-strings.bats
@@ -95,8 +95,6 @@ teardown() {
     run dolt sql -q "insert into test (pk,c1) values ('test', 'this; should; work')"
     [ "$status" -eq 0 ]
     run dolt sql <<< "insert into test (pk,c1) values ('test2', 'this; should; work')"
-    # This should probably not return 0
     [ "$status" -eq 0 ]
-    skip "Parsing semicolons piped into sql in strings is busted"
-    [[ ! "$output" =~ "Error" ]]
+    [[ "$output" =~ "Rows inserted: 1" ]]
 }

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -203,7 +203,7 @@ func batchInsertEarlySemicolon(query string) bool {
 			midSingleQuote = true
 			for ; i < queryLength; i++ {
 				if query[i] == '\'' {
-					if query[i - 1] != '\\' {
+					if query[i-1] != '\\' {
 						midSingleQuote = false
 						break
 					}
@@ -214,7 +214,7 @@ func batchInsertEarlySemicolon(query string) bool {
 			midDoubleQuote = true
 			for ; i < queryLength; i++ {
 				if query[i] == '"' {
-					if query[i - 1] != '\\' {
+					if query[i-1] != '\\' {
 						midDoubleQuote = false
 						break
 					}


### PR DESCRIPTION
Fixes SQL bug as found in new Bats test introduced here: https://github.com/liquidata-inc/dolt/pull/124