### PR TITLE
Batch inserts handle backslashes better

### DIFF
--- a/bats/1pk5col-strings.bats
+++ b/bats/1pk5col-strings.bats
@@ -97,4 +97,7 @@ teardown() {
     run dolt sql <<< "insert into test (pk,c1) values ('test2', 'this; should; work')"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "Rows inserted: 1" ]]
+    run dolt sql <<< "insert into test (pk,c1) values ('test3', 'this \\\\'' should \\\\'' work')"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Rows inserted: 1" ]]
 }


### PR DESCRIPTION
Added a new bats test to demonstrate, but originally the function didn't handle `\\''` properly, and now it does. Had to add 4 backslashes on the test because bash does its own escaping before passing it to dolt.