### PR TITLE
Missed Kind to String

### DIFF
--- a/bats/1pk5col-ints.bats
+++ b/bats/1pk5col-ints.bats
@@ -608,24 +608,24 @@ if rows[2] != "9,8,7,6,5,4".split(","):
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test @ working" ]] || false
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
     run dolt schema show test
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test @ working" ]] || false
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
 }
 
 @test "dolt schema show on non existant table" {

--- a/bats/create-tables.bats
+++ b/bats/create-tables.bats
@@ -200,7 +200,7 @@ teardown() {
 }
 
 @test "create a basic table (int types) using sql" {
-    run dolt sql -q "create table test (pk int, c1 int, c2 int, c3 int, c4 int, c5 int, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT, c1 BIGINT, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run dolt ls
@@ -210,90 +210,90 @@ teardown() {
     run bash -c "dolt schema show"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
 }
 
 @test "create a table with sql with multiple primary keys" {
-    run dolt sql -q "create table test (pk1 int, pk2 int, c1 int, c2 int, c3 int, c4 int, c5 int, primary key (pk1), primary key (pk2))"
+    run dolt sql -q "CREATE TABLE test (pk1 BIGINT, pk2 BIGINT, c1 BIGINT, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, PRIMARY KEY (pk1), PRIMARY KEY (pk2))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run bash -c "dolt schema show"
     [ "$status" -eq 0 ]
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk1\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`pk2\` int not null comment 'tag:1'" ]] || false
-    [[ "$output" =~ "\`c1\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:6'" ]] || false
-    [[ "$output" =~ "primary key (\`pk1\`,\`pk2\`)" ]] || false
+    [[ "$output" =~ "\`pk1\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`pk2\` BIGINT NOT NULL COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "\`c1\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:6'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk1\`,\`pk2\`)" ]] || false
 }
 
 @test "create a table using sql with not null constraint" {
-    run dolt sql -q "create table test (pk int not null, c1 int, c2 int, c3 int, c4 int, c5 int, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT NOT NULL, c1 BIGINT, c2 BIGINT, c3 BIGINT, c4 BIGINT, c5 BIGINT, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run dolt schema show test
     [ "$status" -eq 0 ]
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
 }
 
 @test "create a table using sql with a float" {
-    run dolt sql -q "create table test (pk int not null, c1 float, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT NOT NULL, c1 DOUBLE, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run dolt schema show test
     [ "$status" -eq 0 ]
     [[ "$output" =~ "CREATE TABLE \`test\` " ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` float comment 'tag:1'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` DOUBLE COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
 }
 
    
 @test "create a table using sql with a string" {
-    run dolt sql -q "create table test (pk int not null, c1 varchar, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT NOT NULL, c1 LONGTEXT, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run dolt schema show test
     [ "$status" -eq 0 ]
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c1\` varchar(1024) comment 'tag:1'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c1\` LONGTEXT COMMENT 'tag:1'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
 }
 
 
 @test "create a table using sql with an unsigned int" {
-    run dolt sql -q "create table test (pk int not null, c1 int unsigned, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT NOT NULL, c1 BIGINT UNSIGNED, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
     run dolt schema show test
-    [[ "$output" =~ "int unsigned" ]] || false
+    [[ "$output" =~ "BIGINT UNSIGNED" ]] || false
 }
 
 @test "create a table using sql with a boolean" {
-    run dolt sql -q "create table test (pk int not null, c1 bool, primary key (pk))"
+    run dolt sql -q "CREATE TABLE test (pk BIGINT NOT NULL, c1 BOOLEAN, PRIMARY KEY (pk))"
     [ "$status" -eq 0 ]
     [ -z "$output" ]
 }
 
 @test "create table with sql and dolt table create table. match success/failure" {
-    run dolt sql -q "create table 1pk (pk int not null, c1 int, primary key(pk))"
+    run dolt sql -q "CREATE TABLE 1pk (pk BIGINT NOT NULL, c1 BIGINT, PRIMARY KEY(pk))"
     [ "$status" -eq 1 ]
     skip "This case needs a lot of work."
     [ "$output" = "Invalid table name. Table names cannot start with digits." ] 
@@ -301,7 +301,7 @@ teardown() {
     dolt table create -s=`batshelper 1pk5col-ints.schema` 1pk
     [ "$status" -eq 1 ]
     [ "$output" = "Invalid table name. Table names cannot start with digits." ]
-    run dolt sql -q "create table one-pk (pk int not null, c1 int, primary key(pk))"
+    run dolt sql -q "CREATE TABLE one-pk (pk BIGINT NOT NULL, c1 BIGINT, PRIMARY KEY(pk))"
     [ "$status" -eq 1 ]
     skip "Need better error message"
     [ "$output" = "Invalid table name. Table names cannot contain dashes." ]
@@ -311,7 +311,7 @@ teardown() {
 }
 
 @test "create a table with a mispelled primary key" {
-    run dolt sql -q "create table test (pk int, c1 int, c2 int, primary key
+    run dolt sql -q "CREATE TABLE test (pk BIGINT, c1 BIGINT, c2 BIGINT, PRIMARY KEY
 (pk,noexist))"
     skip "This succeeds right now and creates a table with just one primary key pk"
     [ "$status" -eq 1 ]

--- a/bats/helper/1pk5col-ints.sql
+++ b/bats/helper/1pk5col-ints.sql
@@ -1,11 +1,11 @@
 DROP TABLE IF EXISTS `test`;
 CREATE TABLE `test` (
-  `pk` int not null comment 'tag:0',
-  `c1` int comment 'tag:1',
-  `c2` int comment 'tag:2',
-  `c3` int comment 'tag:3',
-  `c4` int comment 'tag:4',
-  `c5` int comment 'tag:5',
-  primary key (`pk`)
+  `pk` BIGINT NOT NULL COMMENT 'tag:0',
+  `c1` BIGINT COMMENT 'tag:1',
+  `c2` BIGINT COMMENT 'tag:2',
+  `c3` BIGINT COMMENT 'tag:3',
+  `c4` BIGINT COMMENT 'tag:4',
+  `c5` BIGINT COMMENT 'tag:5',
+  PRIMARY KEY (`pk`)
 );
 INSERT INTO `test` (`pk`,`c1`,`c2`,`c3`,`c4`,`c5`) VALUES (0,1,2,3,4,5);

--- a/bats/schema-changes.bats
+++ b/bats/schema-changes.bats
@@ -12,15 +12,15 @@ teardown() {
 @test "changing column types should not produce a data diff error" {
     dolt table import -c --pk=pk test `batshelper 1pk5col-ints.csv`
     run dolt schema show
-    [[ "$output" =~ "varchar" ]] || false
+    [[ "$output" =~ "LONGTEXT" ]] || false
     dolt add test
     dolt commit -m "Added test table"
     dolt table import -c -f -pk=pk -s=`batshelper 1pk5col-ints.schema` test `batshelper 1pk5col-ints.csv`
     run dolt diff
     skip "This produces a failed to merge schemas error message right now"
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "int" ]] || false
-    [[ ! "$output" =~ "varchar" ]] || false
+    [[ "$output" =~ "BIGINT" ]] || false
+    [[ ! "$output" =~ "LONGTEXT" ]] || false
     [[ ! "$ouput" =~ "Failed to merge schemas" ]] || false
 }
 
@@ -33,14 +33,14 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test @ working" ]] || false
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
-    [[ "$output" =~ "\`c0\` int comment 'tag:1'" ]] || false
-    [[ ! "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
+    [[ "$output" =~ "\`c0\` BIGINT COMMENT 'tag:1'" ]] || false
+    [[ ! "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
     dolt table select test
 }
 
@@ -53,13 +53,13 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "test @ working" ]] || false
     [[ "$output" =~ "CREATE TABLE \`test\`" ]] || false
-    [[ "$output" =~ "\`pk\` int not null comment 'tag:0'" ]] || false
-    [[ "$output" =~ "\`c2\` int comment 'tag:2'" ]] || false
-    [[ "$output" =~ "\`c3\` int comment 'tag:3'" ]] || false
-    [[ "$output" =~ "\`c4\` int comment 'tag:4'" ]] || false
-    [[ "$output" =~ "\`c5\` int comment 'tag:5'" ]] || false
-    [[ "$output" =~ "primary key (\`pk\`)" ]] || false
-    [[ ! "$output" =~ "\`c1\` int comment 'tag:1'" ]] || false
+    [[ "$output" =~ "\`pk\` BIGINT NOT NULL COMMENT 'tag:0'" ]] || false
+    [[ "$output" =~ "\`c2\` BIGINT COMMENT 'tag:2'" ]] || false
+    [[ "$output" =~ "\`c3\` BIGINT COMMENT 'tag:3'" ]] || false
+    [[ "$output" =~ "\`c4\` BIGINT COMMENT 'tag:4'" ]] || false
+    [[ "$output" =~ "\`c5\` BIGINT COMMENT 'tag:5'" ]] || false
+    [[ "$output" =~ "PRIMARY KEY (\`pk\`)" ]] || false
+    [[ ! "$output" =~ "\`c1\` BIGINT COMMENT 'tag:1'" ]] || false
     dolt table select test
 }
 
@@ -101,7 +101,7 @@ teardown() {
     run dolt diff --schema
     [ "$status" -eq 0 ]
     skip "Schema diff output does not handle changing primary keys"
-    [[ "$output" =~ "primary key" ]] || false
+    [[ "$output" =~ "PRIMARY KEY" ]] || false
 }
 
 @test "adding and dropping column should produce no diff" {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -33,6 +33,7 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/rowconv"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/sql"
+	dtypes "github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle/types"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/pipeline"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/fwt"
@@ -359,8 +360,17 @@ func diffSchemas(tableName string, sch1 schema.Schema, sch2 schema.Schema) errha
 			cli.Println(color.RedString("- " + sql.FmtCol(2, 0, 0, *dff.Old)))
 		case diff.SchDiffColModified:
 			// changed in sch2
-			n0, t0 := dff.Old.Name, sql.DoltToSQLType[dff.Old.Kind]
-			n1, t1 := dff.New.Name, sql.DoltToSQLType[dff.New.Kind]
+			oldType, err := dtypes.NomsKindToSqlTypeString(dff.Old.Kind)
+			if err != nil {
+				return errhand.BuildDError("error: failed to diff schemas").AddCause(err).Build()
+			}
+			newType, err := dtypes.NomsKindToSqlTypeString(dff.New.Kind)
+			if err != nil {
+				return errhand.BuildDError("error: failed to diff schemas").AddCause(err).Build()
+			}
+
+			n0, t0 := dff.Old.Name, oldType
+			n1, t1 := dff.New.Name, newType
 
 			nameLen := 0
 			typeLen := 0

--- a/go/go.mod
+++ b/go/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/gocraft/dbr v0.0.0-20190708200302-a54124dfc613
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go/libraries/doltcore/sql/schema_test.go
+++ b/go/libraries/doltcore/sql/schema_test.go
@@ -25,15 +25,15 @@ import (
 )
 
 const expectedSQL = "CREATE TABLE `table_name` (\n" +
-	"  `id` int not null comment 'tag:0',\n" +
-	"  `first` varchar(1024) not null comment 'tag:1',\n" +
-	"  `last` varchar(1024) not null comment 'tag:2',\n" +
-	"  `is_married` bool comment 'tag:3',\n" +
-	"  `age` int comment 'tag:4',\n" +
-	"  `rating` float comment 'tag:6',\n" +
-	"  `uuid` uuid comment 'tag:7',\n" +
-	"  `num_episodes` int unsigned comment 'tag:8',\n" +
-	"  primary key (`id`)\n" +
+	"  `id` BIGINT NOT NULL COMMENT 'tag:0',\n" +
+	"  `first` LONGTEXT NOT NULL COMMENT 'tag:1',\n" +
+	"  `last` LONGTEXT NOT NULL COMMENT 'tag:2',\n" +
+	"  `is_married` BOOLEAN COMMENT 'tag:3',\n" +
+	"  `age` BIGINT COMMENT 'tag:4',\n" +
+	"  `rating` DOUBLE COMMENT 'tag:6',\n" +
+	"  `uuid` CHAR(36) COMMENT 'tag:7',\n" +
+	"  `num_episodes` BIGINT UNSIGNED COMMENT 'tag:8',\n" +
+	"  PRIMARY KEY (`id`)\n" +
 	");"
 
 func TestSchemaAsCreateStmt(t *testing.T) {
@@ -56,28 +56,28 @@ func TestFmtCol(t *testing.T) {
 			0,
 			0,
 			0,
-			"`first` varchar(1024) comment 'tag:0'",
+			"`first` LONGTEXT COMMENT 'tag:0'",
 		},
 		{
 			schema.NewColumn("last", 123, types.IntKind, true),
 			2,
 			0,
 			0,
-			"  `last` int comment 'tag:123'",
+			"  `last` BIGINT COMMENT 'tag:123'",
 		},
 		{
 			schema.NewColumn("title", 2, types.UintKind, true),
 			0,
 			10,
 			0,
-			"   `title` int unsigned comment 'tag:2'",
+			"   `title` BIGINT UNSIGNED COMMENT 'tag:2'",
 		},
 		{
 			schema.NewColumn("aoeui", 52, types.UintKind, true),
 			0,
 			10,
 			15,
-			"   `aoeui`    int unsigned comment 'tag:52'",
+			"   `aoeui` BIGINT UNSIGNED COMMENT 'tag:52'",
 		},
 	}
 

--- a/go/libraries/doltcore/sql/sqlshow.go
+++ b/go/libraries/doltcore/sql/sqlshow.go
@@ -24,6 +24,7 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
+	dtypes "github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle/types"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/pipeline"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
@@ -217,9 +218,14 @@ func describeColumn(nbf *types.NomsBinFormat, col schema.Column) (row.Row, error
 		keyStr = "PRI"
 	}
 
+	sqlTypeStr, err := dtypes.NomsKindToSqlTypeString(col.Kind)
+	if err != nil {
+		return nil, err
+	}
+
 	taggedVals := row.TaggedValues{
 		0: types.String(col.Name),
-		1: types.String(DoltToSQLType[col.Kind]),
+		1: types.String(sqlTypeStr),
 		2: types.String(nullStr),
 		3: types.String(keyStr),
 		4: types.String("NULL"), // TODO: when schemas store defaults, use them here

--- a/go/libraries/doltcore/sql/sqlshow_test.go
+++ b/go/libraries/doltcore/sql/sqlshow_test.go
@@ -33,14 +33,14 @@ func TestExecuteShow(t *testing.T) {
 	peopleSchemaStr := SchemaAsCreateStmt("people", PeopleTestSchema)
 
 	peopleSchemaRows := Rs(
-		NewResultSetRow(types.String("id"), types.String("int"), types.String("NO"), types.String("PRI"), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("first"), types.String("varchar(1024)"), types.String("NO"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("last"), types.String("varchar(1024)"), types.String("NO"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("is_married"), types.String("bool"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("age"), types.String("int"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("rating"), types.String("float"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("uuid"), types.String("uuid"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("num_episodes"), types.String("int unsigned"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("id"), types.String("BIGINT"), types.String("NO"), types.String("PRI"), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("first"), types.String("LONGTEXT"), types.String("NO"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("last"), types.String("LONGTEXT"), types.String("NO"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("is_married"), types.String("BOOLEAN"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("age"), types.String("BIGINT"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("rating"), types.String("DOUBLE"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("uuid"), types.String("CHAR(36)"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("num_episodes"), types.String("BIGINT UNSIGNED"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
 	)
 
 	tests := []struct {

--- a/go/libraries/doltcore/sqle/types/bool.go
+++ b/go/libraries/doltcore/sqle/types/bool.go
@@ -63,6 +63,10 @@ func (boolType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (boolType) SqlTypeString() string {
+	return "BOOLEAN"
+}
+
 func (boolType) String() string {
 	return "boolType"
 }

--- a/go/libraries/doltcore/sqle/types/float.go
+++ b/go/libraries/doltcore/sqle/types/float.go
@@ -78,6 +78,10 @@ func (floatType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (floatType) SqlTypeString() string {
+	return "DOUBLE"
+}
+
 func (floatType) String() string {
 	return "floatType"
 }

--- a/go/libraries/doltcore/sqle/types/int.go
+++ b/go/libraries/doltcore/sqle/types/int.go
@@ -82,6 +82,10 @@ func (intType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (intType) SqlTypeString() string {
+	return "BIGINT"
+}
+
 func (intType) String() string {
 	return "intType"
 }

--- a/go/libraries/doltcore/sqle/types/string.go
+++ b/go/libraries/doltcore/sqle/types/string.go
@@ -55,6 +55,10 @@ func (stringType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (stringType) SqlTypeString() string {
+	return "LONGTEXT"
+}
+
 func (stringType) String() string {
 	return "stringType"
 }

--- a/go/libraries/doltcore/sqle/types/uint.go
+++ b/go/libraries/doltcore/sqle/types/uint.go
@@ -89,6 +89,10 @@ func (uintType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (uintType) SqlTypeString() string {
+	return "BIGINT UNSIGNED"
+}
+
 func (uintType) String() string {
 	return "uintType"
 }

--- a/go/libraries/doltcore/sqle/types/uuid.go
+++ b/go/libraries/doltcore/sqle/types/uuid.go
@@ -59,6 +59,10 @@ func (uuidType) GetSqlToValue() SqlToValue {
 	}
 }
 
+func (uuidType) SqlTypeString() string {
+	return "CHAR(36)"
+}
+
 func (uuidType) String() string {
 	return "uuidType"
 }


### PR DESCRIPTION
In my last PR, it looks like I missed that we were using the old `DoltToSQLType` hardcoded map from the original SQL implementation. I didn't change it everywhere (it's used heavily in the old SQL code that isn't even being called anymore), but it's changed where it matters. Added a new interface function and changed the printing code to be a bit more consistent (we were mixing uppercase with lowercase).

I'm also returning different values, such as `BIGINT` for `sql.Int64`, as `int` parses in MySQL to a 32-bit integer, which isn't correct. Essentially made it so that if you took the `CREATE` statement exactly as-is and exported your data to a bunch of inserts and ran it in MySQL then it wouldn't error out, as it previously would have.