### PR TITLE
fix branch name panic with period

### DIFF
--- a/bats/empty-repo.bats
+++ b/bats/empty-repo.bats
@@ -203,9 +203,8 @@ teardown() {
     [ "$output" = "" ]
 }
 
-@test "unsupported branch characters" {
-    run dolt branch "are.dots.supported"
-    skip "branch names with . panic right now"
-    [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+@test "branch names do not support ." {
+    run dolt branch "dots.are.not.supported"
+    [ "$status" -eq 1 ]
+    [ "$output" = "fatal: 'dots.are.not.supported' is an invalid branch name." ]
 }

--- a/go/go.sum
+++ b/go/go.sum
@@ -260,6 +260,8 @@ github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191003230430-3a1a09c79ada h1
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191003230430-3a1a09c79ada/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191017183442-4b9329eafa5b h1:fdht6iaUhHYJEfSUY1m1KAghyi6zfyfv+12gaSsaQ+o=
 github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191017183442-4b9329eafa5b/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
+github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191102000214-fa72192f51a9 h1:Pux1QrTx2Q2WF0Ayyz9doIlYJP/REAhfRP7mRyoiowE=
+github.com/liquidata-inc/go-mysql-server v0.4.1-0.20191102000214-fa72192f51a9/go.mod h1:DdWE0ku/mNfuLsRJIrHeHpDtB7am+6oopxEsQKmVkx8=
 github.com/liquidata-inc/ishell v0.0.0-20190514193646-693241f1f2a0 h1:phMgajKClMUiIr+hF2LGt8KRuUa2Vd2GI1sNgHgSXoU=
 github.com/liquidata-inc/ishell v0.0.0-20190514193646-693241f1f2a0/go.mod h1:YC1rI9k5gx8D02ljlbxDfZe80s/iq8bGvaaQsvR+qxs=
 github.com/liquidata-inc/mmap-go v1.0.3 h1:2LndAeAtup9rpvUmu4wZSYCsjCQ0Zpc+NqE+6+PnT7g=

--- a/go/libraries/doltcore/ref/branchname.go
+++ b/go/libraries/doltcore/ref/branchname.go
@@ -21,12 +21,12 @@ import (
 
 // The following list of patterns are all forbidden in a branch name.
 var InvalidBranchNameRegex = regexp.MustCompile(strings.Join([]string{
+	// Any appearance of a period, currently unsupported by noms layer
+	`[.*]`,
 	// Any appearance of the following characters: :, ?, [, \, ^, ~, SPACE, TAB, *
 	`:`, `\?`, `\[`, `\\`, `\^`, `~`, ` `, `\t`, `\*`,
 	// Any ASCII control character.
 	`[\x00-\x1f]`, `\x7f`,
-	// Any component starting with a "."
-	`\A\.`, `/\.`,
 	// Any component ending with ".lock"
 	`\.lock\z`, `\.lock\/`,
 	// An exact name of "", "HEAD" or "-"

--- a/go/libraries/doltcore/ref/branchname_test.go
+++ b/go/libraries/doltcore/ref/branchname_test.go
@@ -25,8 +25,8 @@ func TestBranchName(t *testing.T) {
 	assert.Equal(t, true, IsValidBranchName("☃️"))
 	assert.Equal(t, true, IsValidBranchName("user/in-progress/do-some-things"))
 	assert.Equal(t, true, IsValidBranchName("user/in-progress/{}"))
-	assert.Equal(t, true, IsValidBranchName("user/{/a.tt/}"))
 
+	assert.Equal(t, false, IsValidBranchName("user/{/a.tt/}"))
 	assert.Equal(t, false, IsValidBranchName(""))
 	assert.Equal(t, false, IsValidBranchName("this-is-a-..-test"))
 	assert.Equal(t, false, IsValidBranchName("this-is-a-@{-test"))


### PR DESCRIPTION
Looked into supporting periods in branch names, but it looks like `noms` relies on periods specifically pretty heavily. Seems to be excluded from the regex below by design, since they build some types on the expectation that a branch name or `ref` contain  a period.

My understanding is that a user's branch name is used to look up a particular dataset within the `noms` layer and this variable (go/store/datas/dataset.go): 
```
// DatasetRe is a regexp that matches a legal Dataset name anywhere within the
// target string.
var DatasetRe = regexp.MustCompile(`[a-zA-Z0-9\-_/]+`)
```
acts as the regex source of "truth" for branch names/ dataset look ups, and I believe more. 
Noms also expects to be able to append a `.` to this string in order to parse the string later and correctly create it's `Path` types...

I went down a rabbit hole trying to change all of the `noms` `Path` delimiters to be a different character, but the changes go pretty deep and start breaking a lot of things. Happy to continue down that course in order to support periods in branch names, but it might take me a bit of time change everything. I'm also not sure what character should replace the period... asterisk? Anyway, this PR seemed like low hanging fruit fix to resolve the panic at least.