### PR TITLE
Added Timestamp to Dolt and Datetime to SQL

### DIFF
--- a/go/Godeps/LICENSES
+++ b/go/Godeps/LICENSES
@@ -717,6 +717,34 @@ SOFTWARE.
 ================================================================================
 
 ================================================================================
+= github.com/araddon/dateparse licensed under: =
+
+The MIT License (MIT)
+
+Copyright (c) 2015-2017 Aaron Raddon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+= LICENSE 99cb99e77c872d66840a2ae14e143620771335a758e6dd7d20f9fb23 =
+================================================================================
+
+================================================================================
 = github.com/asaskevich/govalidator licensed under: =
 
 The MIT License (MIT)

--- a/go/cmd/dolt/commands/sqlserver/server.go
+++ b/go/cmd/dolt/commands/sqlserver/server.go
@@ -32,8 +32,8 @@ import (
 	dsqle "github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle"
 )
 
-// serve starts a MySQL-compatible server. Returns any errors that were encountered.
-func serve(ctx context.Context, serverConfig *ServerConfig, rootValue *doltdb.RootValue, serverController *ServerController) (startError error, closeError error) {
+// Serve starts a MySQL-compatible server. Returns any errors that were encountered.
+func Serve(ctx context.Context, serverConfig *ServerConfig, rootValue *doltdb.RootValue, serverController *ServerController) (startError error, closeError error) {
 	if serverConfig == nil {
 		cli.Println("No configuration given, using defaults")
 		serverConfig = DefaultServerConfig()

--- a/go/cmd/dolt/commands/sqlserver/server_test.go
+++ b/go/cmd/dolt/commands/sqlserver/server_test.go
@@ -47,7 +47,7 @@ var (
 func TestServerArgs(t *testing.T) {
 	serverController := CreateServerController()
 	go func() {
-		sqlServerImpl(context.Background(), "dolt sql-server", []string{
+		SqlServerImpl(context.Background(), "dolt sql-server", []string{
 			"-H", "localhost",
 			"-P", "15200",
 			"-u", "username",
@@ -85,7 +85,7 @@ func TestServerBadArgs(t *testing.T) {
 		t.Run(strings.Join(test, " "), func(t *testing.T) {
 			serverController := CreateServerController()
 			go func(serverController *ServerController) {
-				sqlServerImpl(context.Background(), "dolt sql-server", test, env, serverController)
+				SqlServerImpl(context.Background(), "dolt sql-server", test, env, serverController)
 			}(serverController)
 			// In the event that a test fails, we need to prevent a test from hanging due to a running server
 			err := serverController.WaitForStart()
@@ -121,7 +121,7 @@ func TestServerGoodParams(t *testing.T) {
 		t.Run(test.String(), func(t *testing.T) {
 			sc := CreateServerController()
 			go func(config *ServerConfig, sc *ServerController) {
-				serve(context.Background(), config, root, sc)
+				_, _ = Serve(context.Background(), config, root, sc)
 			}(test, sc)
 			err := sc.WaitForStart()
 			require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestServerSelect(t *testing.T) {
 	sc := CreateServerController()
 	defer sc.StopServer()
 	go func() {
-		serve(context.Background(), serverConfig, root, sc)
+		_, _ = Serve(context.Background(), serverConfig, root, sc)
 	}()
 	err := sc.WaitForStart()
 	require.NoError(t, err)

--- a/go/cmd/dolt/commands/sqlserver/servercontroller.go
+++ b/go/cmd/dolt/commands/sqlserver/servercontroller.go
@@ -29,7 +29,7 @@ type ServerController struct {
 	closeError      error
 }
 
-// CreateServerController creates a `ServerController` for use with synchronizing on `serve`.
+// CreateServerController creates a `ServerController` for use with synchronizing on `Serve`.
 func CreateServerController() *ServerController {
 	sc := &ServerController{
 		serverClosed:    &sync.WaitGroup{},
@@ -43,7 +43,7 @@ func CreateServerController() *ServerController {
 	return sc
 }
 
-// registerCloseFunction is called within `serve` to associate the close function with a future `StopServer` call.
+// registerCloseFunction is called within `Serve` to associate the close function with a future `StopServer` call.
 // Only the first call will register and unblock, thus it is safe to be called multiple times.
 func (controller *ServerController) registerCloseFunction(startError error, closeFunc func() error) {
 	controller.closeRegistered.Do(func() {
@@ -55,7 +55,7 @@ func (controller *ServerController) registerCloseFunction(startError error, clos
 	})
 }
 
-// serverStopped is called within `serve` to signal that the server has stopped and set the exit code.
+// serverStopped is called within `Serve` to signal that the server has stopped and set the exit code.
 // Only the first call will register and unblock, thus it is safe to be called multiple times.
 func (controller *ServerController) serverStopped(closeError error) {
 	controller.stopRegistered.Do(func() {

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -45,10 +45,10 @@ var sqlServerSynopsis = []string{
 }
 
 func SqlServer(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
-	return sqlServerImpl(ctx, commandStr, args, dEnv, nil)
+	return SqlServerImpl(ctx, commandStr, args, dEnv, nil)
 }
 
-func sqlServerImpl(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, serverController *ServerController) int {
+func SqlServerImpl(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, serverController *ServerController) int {
 	serverConfig := DefaultServerConfig()
 
 	ap := argparser.NewArgParser()
@@ -90,7 +90,7 @@ func sqlServerImpl(ctx context.Context, commandStr string, args []string, dEnv *
 	if logLevel, ok := apr.GetValue(logLevelFlag); ok {
 		serverConfig.LogLevel = LogLevel(logLevel)
 	}
-	if startError, closeError := serve(ctx, serverConfig, root, serverController); startError != nil || closeError != nil {
+	if startError, closeError := Serve(ctx, serverConfig, root, serverController); startError != nil || closeError != nil {
 		if startError != nil {
 			cli.PrintErrln(startError)
 		}

--- a/go/go.mod
+++ b/go/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/attic-labs/kingpin v2.2.7-0.20180312050558-442efcfac769+incompatible
 	github.com/aws/aws-sdk-go v1.21.2
 	github.com/bcicen/jstream v0.0.0-20190220045926-16c1f8af81c2
@@ -22,6 +23,7 @@ require (
 	github.com/gocraft/dbr v0.0.0-20190708200302-a54124dfc613
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
+	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -43,6 +43,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1C
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195 h1:c4mLfegoDw6OhSJXTd2jUEQgZUQuJWtocudb97Qn9EM=
+github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da h1:8GUt8eRujhVEGZFFEjBj46YV4rDjvGrNxb0KMWYkL2I=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=

--- a/go/libraries/doltcore/rowconv/row_converter_test.go
+++ b/go/libraries/doltcore/rowconv/row_converter_test.go
@@ -17,6 +17,7 @@ package rowconv
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -34,7 +35,8 @@ var srcCols, _ = schema.NewColCollection(
 	schema.NewColumn("booltostr", 3, types.BoolKind, false),
 	schema.NewColumn("inttostr", 4, types.IntKind, false),
 	schema.NewColumn("stringtostr", 5, types.StringKind, false),
-	schema.NewColumn("nulltostr", 6, types.NullKind, false),
+	schema.NewColumn("timestamptostr", 6, types.TimestampKind, false),
+	schema.NewColumn("nulltostr", 7, types.NullKind, false),
 )
 
 var srcSch = schema.SchemaFromCols(srcCols)
@@ -51,6 +53,7 @@ func TestRowConverter(t *testing.T) {
 	}
 
 	id, _ := uuid.NewRandom()
+	tt := types.Timestamp(time.Now())
 	inRow, err := row.New(types.Format_7_18, srcSch, row.TaggedValues{
 		0: types.UUID(id),
 		1: types.Float(1.25),
@@ -58,7 +61,8 @@ func TestRowConverter(t *testing.T) {
 		3: types.Bool(true),
 		4: types.Int(-1234),
 		5: types.String("string string string"),
-		6: types.NullValue,
+		6: tt,
+		7: types.NullValue,
 	})
 
 	assert.NoError(t, err)
@@ -73,7 +77,8 @@ func TestRowConverter(t *testing.T) {
 		3: types.String("true"),
 		4: types.String("-1234"),
 		5: types.String("string string string"),
-		6: types.NullValue,
+		6: types.String(tt.String()),
+		7: types.NullValue,
 	})
 
 	assert.NoError(t, err)

--- a/go/libraries/doltcore/sql/schema_test.go
+++ b/go/libraries/doltcore/sql/schema_test.go
@@ -31,7 +31,7 @@ const expectedSQL = "CREATE TABLE `table_name` (\n" +
 	"  `is_married` BOOLEAN COMMENT 'tag:3',\n" +
 	"  `age` BIGINT COMMENT 'tag:4',\n" +
 	"  `rating` DOUBLE COMMENT 'tag:6',\n" +
-	"  `uuid` CHAR(36) COMMENT 'tag:7',\n" +
+	"  `uuid` LONGTEXT COMMENT 'tag:7',\n" +
 	"  `num_episodes` BIGINT UNSIGNED COMMENT 'tag:8',\n" +
 	"  PRIMARY KEY (`id`)\n" +
 	");"

--- a/go/libraries/doltcore/sql/sqlshow_test.go
+++ b/go/libraries/doltcore/sql/sqlshow_test.go
@@ -39,7 +39,7 @@ func TestExecuteShow(t *testing.T) {
 		NewResultSetRow(types.String("is_married"), types.String("BOOLEAN"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
 		NewResultSetRow(types.String("age"), types.String("BIGINT"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
 		NewResultSetRow(types.String("rating"), types.String("DOUBLE"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
-		NewResultSetRow(types.String("uuid"), types.String("CHAR(36)"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
+		NewResultSetRow(types.String("uuid"), types.String("LONGTEXT"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
 		NewResultSetRow(types.String("num_episodes"), types.String("BIGINT UNSIGNED"), types.String("YES"), types.String(""), types.String("NULL"), types.String("")),
 	)
 

--- a/go/libraries/doltcore/sqle/types/datetime.go
+++ b/go/libraries/doltcore/sqle/types/datetime.go
@@ -16,53 +16,52 @@ package types
 
 import (
 	"fmt"
-	"math"
+	"time"
 
+	"github.com/araddon/dateparse"
 	"github.com/src-d/go-mysql-server/sql"
 
 	dtypes "github.com/liquidata-inc/dolt/go/store/types"
 )
 
-type boolType struct{}
+type datetimeType struct{}
 
-func (boolType) NomsKind() dtypes.NomsKind {
-	return dtypes.BoolKind
+func (datetimeType) NomsKind() dtypes.NomsKind {
+	return dtypes.TimestampKind
 }
 
-func (boolType) SqlType() sql.Type {
-	return sql.Boolean
+func (datetimeType) SqlType() sql.Type {
+	return sql.Datetime
 }
 
-func (boolType) SqlTypes() []sql.Type {
-	return []sql.Type{sql.Boolean}
+func (datetimeType) SqlTypes() []sql.Type {
+	return []sql.Type{sql.Date, sql.Datetime, sql.Timestamp}
 }
 
-func (boolType) GetValueToSql() ValueToSql {
+func (datetimeType) GetValueToSql() ValueToSql {
 	return func(val dtypes.Value) (interface{}, error) {
-		if v, ok := val.(dtypes.Bool); ok {
-			return bool(v), nil
+		if v, ok := val.(dtypes.Timestamp); ok {
+			return time.Time(v), nil
 		}
-		return nil, fmt.Errorf("expected Bool, recevied %v", val.Kind())
+		return nil, fmt.Errorf("expected Timestamp, recevied %v", val.Kind())
 	}
 }
 
-func (boolType) GetSqlToValue() SqlToValue {
+func (datetimeType) GetSqlToValue() SqlToValue {
 	return func(val interface{}) (dtypes.Value, error) {
 		switch e := val.(type) {
-		case bool:
-			return dtypes.Bool(e), nil
-		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-			return dtypes.Bool(e != 0), nil
-		case float32, float64:
-			return dtypes.Bool(int(math.Round(e.(float64))) != 0), nil
 		case string:
-			return dtypes.Bool(false), nil
+			t, err := dateparse.ParseStrict(e)
+			if err != nil {
+				return nil, err
+			}
+			return dtypes.Timestamp(t), nil
 		default:
-			return nil, fmt.Errorf("cannot convert SQL type <%T> val <%v> to Bool", val, val)
+			return nil, fmt.Errorf("cannot convert SQL type <%T> val <%v> to Timestamp", val, val)
 		}
 	}
 }
 
-func (boolType) String() string {
-	return "boolType"
+func (datetimeType) String() string {
+	return "datetimeType"
 }

--- a/go/libraries/doltcore/sqle/types/float.go
+++ b/go/libraries/doltcore/sqle/types/float.go
@@ -78,10 +78,6 @@ func (floatType) GetSqlToValue() SqlToValue {
 	}
 }
 
-func (floatType) SqlTypeString() string {
-	return "DOUBLE"
-}
-
 func (floatType) String() string {
 	return "floatType"
 }

--- a/go/libraries/doltcore/sqle/types/int.go
+++ b/go/libraries/doltcore/sqle/types/int.go
@@ -82,10 +82,6 @@ func (intType) GetSqlToValue() SqlToValue {
 	}
 }
 
-func (intType) SqlTypeString() string {
-	return "BIGINT"
-}
-
 func (intType) String() string {
 	return "intType"
 }

--- a/go/libraries/doltcore/sqle/types/string.go
+++ b/go/libraries/doltcore/sqle/types/string.go
@@ -55,10 +55,6 @@ func (stringType) GetSqlToValue() SqlToValue {
 	}
 }
 
-func (stringType) SqlTypeString() string {
-	return "LONGTEXT"
-}
-
 func (stringType) String() string {
 	return "stringType"
 }

--- a/go/libraries/doltcore/sqle/types/tests/datetime_test.go
+++ b/go/libraries/doltcore/sqle/types/tests/datetime_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/src-d/go-mysql-server/sql"
+
+	"github.com/liquidata-inc/dolt/go/store/types"
+)
+
+func TestDatetimeQueries(t *testing.T) {
+	tests := []struct {
+		inputSQLVal interface{}
+		inputValue  types.Timestamp
+	}{
+		{"1000-01-01 00:00:00 +1300", types.Timestamp(time.Date(1000, 1, 1, 0, 0, 0, 0, time.FixedZone("UTC+13", 46800)))},
+		{"9999-12-31 23:59:59 -1200", types.Timestamp(time.Date(9999, 12, 31, 23, 59, 59, 0, time.FixedZone("UTC-12", -43200)))},
+		{"1970-01-01 00:00:00 +0300", types.Timestamp(time.Date(1970, 1, 1, 0, 0, 0, 0, time.FixedZone("UTC+3", 10800)))},
+		{"1610-06-08 09:10:37 -0230", types.Timestamp(time.Date(1610, 6, 8, 9, 10, 37, 0, time.FixedZone("UTC-2:30", -9000)))},
+		{"1945-05-08 19:33:41 -0900", types.Timestamp(time.Date(1945, 5, 8, 19, 33, 41, 0, time.FixedZone("UTC-9", -32400)))},
+		{"3005-02-14 10:02:25 +0100", types.Timestamp(time.Date(3005, 2, 14, 10, 02, 25, 0, time.FixedZone("UTC+1", 3600)))},
+		{"2019-11-01 03:23:48 -0700", types.Timestamp(time.Date(2019, 11, 1, 3, 23, 48, 0, time.FixedZone("UTC-7", -25200)))},
+		{"1000-01-01 00:00:00", types.Timestamp(time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"9999-12-31 23:59:59", types.Timestamp(time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC))},
+		{"1970-01-01 00:00:00", types.Timestamp(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"1610-06-08 09:10:37", types.Timestamp(time.Date(1610, 6, 8, 9, 10, 37, 0, time.UTC))},
+		{"1945-05-08 19:33:41", types.Timestamp(time.Date(1945, 5, 8, 19, 33, 41, 0, time.UTC))},
+		{"3005-02-14 10:02:25", types.Timestamp(time.Date(3005, 2, 14, 10, 02, 25, 0, time.UTC))},
+		{"2019-11-01 03:23:48", types.Timestamp(time.Date(2019, 11, 1, 3, 23, 48, 0, time.UTC))},
+		{"1000-01-01", types.Timestamp(time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"9999-12-31", types.Timestamp(time.Date(9999, 12, 31, 0, 0, 0, 0, time.UTC))},
+		{"1970-01-01", types.Timestamp(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"1610-06-08", types.Timestamp(time.Date(1610, 6, 8, 0, 0, 0, 0, time.UTC))},
+		{"1945-05-08", types.Timestamp(time.Date(1945, 5, 8, 0, 0, 0, 0, time.UTC))},
+		{"3005-02-14", types.Timestamp(time.Date(3005, 2, 14, 0, 0, 0, 0, time.UTC))},
+		{"2019-11-01", types.Timestamp(time.Date(2019, 11, 1, 0, 0, 0, 0, time.UTC))},
+		{"1000", types.Timestamp(time.Date(1000, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"9999", types.Timestamp(time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"1970", types.Timestamp(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"1610", types.Timestamp(time.Date(1610, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"1945", types.Timestamp(time.Date(1945, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"3005", types.Timestamp(time.Date(3005, 1, 1, 0, 0, 0, 0, time.UTC))},
+		{"2019", types.Timestamp(time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC))},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.inputSQLVal), func(t *testing.T) {
+			testParse(t, test.inputSQLVal, test.inputValue, sql.Datetime)
+		})
+	}
+}
+
+func TestDatetimeRoundtrip(t *testing.T) {
+	tests := []string{
+		"1000-01-01 00:00:00",
+		"9999-12-31 23:59:59",
+		"1970-01-01 00:00:00",
+		"1610-06-08 09:10:37",
+		"1945-05-08 19:33:41",
+		"3005-02-14 10:02:25",
+		"2019-11-01 03:23:48",
+	}
+
+	conn, serverController := runServer(t)
+	defer closeServer(t, conn, serverController)
+	for _, test := range tests {
+		t.Run(test, func(t *testing.T) {
+			roundTrip(t, test, sql.Datetime, conn)
+		})
+	}
+}

--- a/go/libraries/doltcore/sqle/types/tests/types_test.go
+++ b/go/libraries/doltcore/sqle/types/tests/types_test.go
@@ -1,0 +1,186 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"hash/fnv"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/gocraft/dbr"
+	sqlServer "github.com/src-d/go-mysql-server"
+	"github.com/src-d/go-mysql-server/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands/sqlserver"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/dtestutils"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle"
+	dtypes "github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle/types"
+	"github.com/liquidata-inc/dolt/go/store/types"
+)
+
+// Tests must be in this directory due to an import cycle with sqle and sqle/types
+
+func TestSqlTypes(t *testing.T) {
+	for _, sqlTypeInit := range dtypes.SqlTypeInitializers {
+		if sqlTypeInit.SqlType() == sql.Boolean {
+			t.Skip("Skipping tests involving Boolean until that's changed in go-mysql-server")
+		}
+		for _, sqlType := range sqlTypeInit.SqlTypes() {
+			sqlTypeStr, err := dtypes.SqlTypeToString(sqlType)
+			require.NoError(t, err)
+			root, dEnv := getEmptyRoot()
+			root, err = runQuery(root, dEnv, fmt.Sprintf("CREATE TABLE test (pk BIGINT, v %v, PRIMARY KEY (pk))", sqlTypeStr))
+			require.NoError(t, err)
+			table, exists, err := root.GetTable(context.Background(), "test")
+			require.NoError(t, err)
+			require.True(t, exists)
+			schema, err := table.GetSchema(context.Background())
+			require.NoError(t, err)
+			cols := schema.GetNonPKCols().GetColumns()
+			require.Len(t, cols, 1)
+			col := cols[0]
+			require.Equal(t, sqlTypeInit.NomsKind(), col.Kind, "Expected %v on %v but got %v", sqlTypeInit.NomsKind(), sqlTypeInit, col.Kind)
+		}
+	}
+}
+
+func closeServer(t *testing.T, conn *dbr.Connection, serverController *sqlserver.ServerController) {
+	err := conn.Close()
+	require.NoError(t, err)
+	serverController.StopServer()
+	err = serverController.WaitForClose()
+	assert.NoError(t, err)
+}
+
+func hash(t *testing.T, s string) string {
+	h := fnv.New64a()
+	_, err := h.Write([]byte(s))
+	require.NoError(t, err)
+	return fmt.Sprintf("a%v", h.Sum64())
+}
+
+func roundTrip(t *testing.T, originalValue string, sqlType sql.Type, conn *dbr.Connection) {
+	// Hash the value to get a (hopefully) unique table name
+	tableName := hash(t, originalValue)
+
+	// Create a table, insert a value into it, then read it back
+	sqlTypeStr, err := dtypes.SqlTypeToString(sqlType)
+	require.NoError(t, err)
+	_, err = conn.Exec(fmt.Sprintf("CREATE TABLE %v (pk BIGINT PRIMARY KEY, v %v)", tableName, sqlTypeStr))
+	require.NoError(t, err)
+	_, err = conn.Exec(fmt.Sprintf(`INSERT INTO %v VALUES (1, "%v")`, tableName, originalValue))
+	require.NoError(t, err)
+	rows, err := conn.Query(fmt.Sprintf(`SELECT v FROM %v WHERE pk = 1`, tableName))
+	require.NoError(t, err)
+	require.True(t, rows.Next())
+	fromServer := ""
+	require.NoError(t, rows.Scan(&fromServer))
+
+	// Get the CREATE TABLE statement as defined by the previous table
+	rows, err = conn.Query(fmt.Sprintf(`SHOW CREATE TABLE %v`, tableName))
+	require.NoError(t, err)
+	require.True(t, rows.Next())
+	createStatement := ""
+	require.NoError(t, rows.Scan(&tableName, &createStatement))
+	createStatement = strings.Replace(strings.ToLower(createStatement), tableName, tableName+"2", 1)
+	if !strings.Contains(createStatement, "primary key") {
+		createStatement = strings.Replace(createStatement, "not null", "not null primary key", 1)
+	}
+
+	// Create a table from the previous, insert the pulled value, and compare it to the original
+	_, err = conn.Exec(createStatement)
+	require.NoError(t, err)
+	_, err = conn.Exec(fmt.Sprintf(`INSERT INTO %v2 VALUES (1, "%v")`, tableName, fromServer))
+	require.NoError(t, err)
+	rows, err = conn.Query(fmt.Sprintf(`SELECT v FROM %v2 WHERE pk = 1`, tableName))
+	require.NoError(t, err)
+	require.True(t, rows.Next())
+	require.NoError(t, rows.Scan(&fromServer))
+	require.Equal(t, originalValue, fromServer)
+}
+
+// runQuery runs the given query and returns a new root value
+func runQuery(root *doltdb.RootValue, dEnv *env.DoltEnv, query string) (*doltdb.RootValue, error) {
+	db := sqle.NewDatabase("dolt", root, dEnv)
+	engine := sqlServer.NewDefault()
+	engine.AddDatabase(db)
+	_ = engine.Init()
+	sqlCtx := sql.NewContext(context.Background())
+	_, _, err := engine.Query(sqlCtx, query)
+	return db.Root(), err
+}
+
+func runServer(t *testing.T) (*dbr.Connection, *sqlserver.ServerController) {
+	serverController := sqlserver.CreateServerController()
+	port, err := rand.Int(rand.Reader, big.NewInt(1000))
+	require.NoError(t, err)
+	serverConfig := sqlserver.DefaultServerConfig().WithPort(16000 + int(port.Int64()))
+	go func() {
+		root, _ := getEmptyRoot()
+		_, _ = sqlserver.Serve(context.Background(), serverConfig, root, serverController)
+	}()
+	err = serverController.WaitForStart()
+	require.NoError(t, err)
+	conn, err := dbr.Open("mysql", serverConfig.ConnectionString(), nil)
+	if !assert.NoError(t, err) {
+		serverController.StopServer()
+		err = serverController.WaitForClose()
+		require.NoError(t, err)
+	}
+	return conn, serverController
+}
+
+func testParse(t *testing.T, sqlVal interface{}, val types.Value, sqlType sql.Type) {
+	sqlTypeStr, err := dtypes.SqlTypeToString(sqlType)
+	require.NoError(t, err)
+	root, dEnv := getEmptyRoot()
+	root, err = runQuery(root, dEnv, fmt.Sprintf("CREATE TABLE test (pk BIGINT COMMENT 'tag:0', v %v COMMENT 'tag:1', PRIMARY KEY (pk))", sqlTypeStr))
+	require.NoError(t, err)
+	if valString, ok := sqlVal.(string); ok {
+		root, err = runQuery(root, dEnv, fmt.Sprintf(`INSERT INTO test VALUES (1, "%v")`, valString))
+	} else {
+		root, err = runQuery(root, dEnv, fmt.Sprintf("INSERT INTO test VALUES (1, %v)", sqlVal))
+	}
+	require.NoError(t, err)
+	table, tableExists, err := root.GetTable(context.Background(), "test")
+	require.NoError(t, err)
+	require.True(t, tableExists)
+	schema, err := table.GetSchema(context.Background())
+	require.NoError(t, err)
+	dRow, err := row.New(table.Format(), schema, map[uint64]types.Value{0: types.Int(1)})
+	require.NoError(t, err)
+	nmkValue, err := dRow.NomsMapKey(schema).Value(context.Background())
+	require.NoError(t, err)
+	rowData, rowExists, err := table.GetRow(context.Background(), nmkValue.(types.Tuple), schema)
+	require.NoError(t, err)
+	require.True(t, rowExists)
+	colVal, _ := rowData.GetColVal(1)
+	require.True(t, val.Equals(colVal))
+}
+
+func getEmptyRoot() (*doltdb.RootValue, *env.DoltEnv) {
+	dEnv := dtestutils.CreateTestEnv()
+	root, _ := dEnv.WorkingRoot(context.Background())
+	return root, dEnv
+}

--- a/go/libraries/doltcore/sqle/types/uint.go
+++ b/go/libraries/doltcore/sqle/types/uint.go
@@ -89,10 +89,6 @@ func (uintType) GetSqlToValue() SqlToValue {
 	}
 }
 
-func (uintType) SqlTypeString() string {
-	return "BIGINT UNSIGNED"
-}
-
 func (uintType) String() string {
 	return "uintType"
 }

--- a/go/libraries/doltcore/sqle/types/uuid.go
+++ b/go/libraries/doltcore/sqle/types/uuid.go
@@ -59,10 +59,6 @@ func (uuidType) GetSqlToValue() SqlToValue {
 	}
 }
 
-func (uuidType) SqlTypeString() string {
-	return "CHAR(36)"
-}
-
 func (uuidType) String() string {
 	return "uuidType"
 }

--- a/go/libraries/doltcore/type_conversion_test.go
+++ b/go/libraries/doltcore/type_conversion_test.go
@@ -16,6 +16,7 @@ package doltcore
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -43,6 +44,9 @@ func TestConv(t *testing.T) {
 		{types.String("true"), types.Bool(true), true, false},
 		{types.String("61D184E19083F09D95AB"), types.InlineBlob([]byte{0x61, 0xd1, 0x84, 0xe1, 0x90, 0x83, 0xf0, 0x9d, 0x95, 0xab}),
 			true, false},
+		{types.String("1970/12/31"),
+			types.Timestamp(time.Date(1970, 12, 31, 0, 0, 0, 0, time.UTC)),
+			true, false},
 		{types.String("anything"), types.NullValue, true, false},
 
 		{types.UUID(zeroUUID), types.String(zeroUUIDStr), true, false},
@@ -52,6 +56,7 @@ func TestConv(t *testing.T) {
 		{types.UUID(zeroUUID), types.Float(0), false, false},
 		{types.UUID(zeroUUID), types.Bool(false), false, false},
 		{types.UUID(zeroUUID), types.InlineBlob{}, false, false},
+		{types.UUID(zeroUUID), types.Timestamp{}, false, false},
 		{types.UUID(zeroUUID), types.NullValue, true, false},
 
 		{types.Uint(10), types.String("10"), true, false},
@@ -61,7 +66,8 @@ func TestConv(t *testing.T) {
 		{types.Uint(100000), types.Float(100000), true, false},
 		{types.Uint(1000000), types.Bool(true), true, false},
 		{types.Uint(10000000), types.InlineBlob{}, false, false},
-		{types.Uint(100000000), types.NullValue, true, false},
+		{types.Uint(100000000), types.Timestamp(time.Unix(100000000, 0).UTC()), true, false},
+		{types.Uint(1000000000), types.NullValue, true, false},
 
 		{types.Int(-10), types.String("-10"), true, false},
 		{types.Int(-100), types.UUID(zeroUUID), false, false},
@@ -70,7 +76,8 @@ func TestConv(t *testing.T) {
 		{types.Int(-100000), types.Float(-100000), true, false},
 		{types.Int(-1000000), types.Bool(true), true, false},
 		{types.Int(-10000000), types.InlineBlob{}, false, false},
-		{types.Int(-100000000), types.NullValue, true, false},
+		{types.Int(-100000000), types.Timestamp(time.Unix(-100000000, 0).UTC()), true, false},
+		{types.Int(-1000000000), types.NullValue, true, false},
 
 		{types.Float(1.5), types.String("1.5"), true, false},
 		{types.Float(10.5), types.UUID(zeroUUID), false, false},
@@ -79,7 +86,8 @@ func TestConv(t *testing.T) {
 		{types.Float(10000.5), types.Float(10000.5), true, false},
 		{types.Float(100000.5), types.Bool(true), true, false},
 		{types.Float(1000000.5), types.InlineBlob{}, false, false},
-		{types.Float(10000000.5), types.NullValue, true, false},
+		{types.Float(10000000.5), types.Timestamp(time.Unix(10000000, 500000000).UTC()), true, false},
+		{types.Float(100000000.5), types.NullValue, true, false},
 
 		{types.Bool(true), types.String("true"), true, false},
 		{types.Bool(false), types.UUID(zeroUUID), false, false},
@@ -88,6 +96,7 @@ func TestConv(t *testing.T) {
 		{types.Bool(true), types.Float(1), true, false},
 		{types.Bool(false), types.Bool(false), true, false},
 		{types.Bool(false), types.InlineBlob{}, false, true},
+		{types.Bool(false), types.Timestamp{}, false, true},
 		{types.Bool(true), types.NullValue, true, false},
 
 		{types.InlineBlob([]byte{0x61, 0xd1, 0x84, 0xe1, 0x90, 0x83, 0xf0, 0x9d, 0x95, 0xab}),
@@ -99,6 +108,23 @@ func TestConv(t *testing.T) {
 		{types.InlineBlob([]byte{}), types.Bool(false), false, true},
 		{types.InlineBlob([]byte{1, 10, 100}), types.InlineBlob([]byte{1, 10, 100}), true, false},
 		{types.InlineBlob([]byte{}), types.NullValue, true, false},
+
+		{types.Timestamp(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)),
+			types.String("2000-01-01 00:00:00 +0000"), true, false},
+		{types.Timestamp(time.Date(2010, 2, 2, 1, 1, 1, 0, time.UTC)),
+			types.UUID(zeroUUID), false, false},
+		{types.Timestamp(time.Date(2020, 3, 3, 2, 2, 2, 0, time.UTC)),
+			types.Uint(1583200922), true, false},
+		{types.Timestamp(time.Date(2030, 4, 4, 3, 3, 3, 0, time.UTC)),
+			types.Int(1901502183), true, false},
+		{types.Timestamp(time.Date(2040, 5, 5, 4, 4, 4, 400000000, time.UTC)),
+			types.Float(2219803444.4), true, false},
+		{types.Timestamp(time.Date(2050, 6, 6, 5, 5, 5, 0, time.UTC)),
+			types.Bool(false), false, true},
+		{types.Timestamp(time.Date(2060, 7, 7, 6, 6, 6, 678912345, time.UTC)),
+			types.Timestamp(time.Unix(2856405966, 678912345).UTC()), true, false},
+		{types.Timestamp(time.Date(2070, 8, 8, 7, 7, 7, 0, time.UTC)),
+			types.NullValue, true, false},
 	}
 
 	for _, test := range tests {

--- a/go/store/types/float.go
+++ b/go/store/types/float.go
@@ -24,6 +24,7 @@ package types
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/liquidata-inc/dolt/go/store/hash"
 )
@@ -128,6 +129,25 @@ func (Float) GetMarshalFunc(targetKind NomsKind) (MarshalCallback, error) {
 			fl := float64(val.(Float))
 			str := strconv.FormatFloat(fl, 'f', -1, 64)
 			return String(str), nil
+		}, nil
+	case TimestampKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			fl := float64(val.(Float))
+			// If Float is too large, we'll clamp it to the max time representable
+			// There are comparison issues for times too large, so "200000000-12-31 23:59:59 UTC" seems like a reasonable maximum.
+			if fl > 6311328264403199 {
+				fl = 6311328264403199
+				// I could not find anything pointing to a minimum allowed time, so "-200000000-01-01 00:00:00 UTC" seems reasonable
+			} else if fl < -6311452567219200 {
+				fl = -6311452567219200
+			}
+			// We treat a Float as seconds and nanoseconds, unlike integers which are just seconds
+			seconds := int64(fl)
+			nanoseconds := int64((fl - float64(seconds)) * float64(time.Second/time.Nanosecond))
+			return Timestamp(time.Unix(seconds, nanoseconds).UTC()), nil
 		}, nil
 	case UintKind:
 		return func(val Value) (Value, error) {

--- a/go/store/types/int.go
+++ b/go/store/types/int.go
@@ -24,6 +24,7 @@ package types
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/liquidata-inc/dolt/go/store/hash"
 )
@@ -129,6 +130,21 @@ func (Int) GetMarshalFunc(targetKind NomsKind) (MarshalCallback, error) {
 			n := int64(val.(Int))
 			str := strconv.FormatInt(n, 10)
 			return String(str), nil
+		}, nil
+	case TimestampKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			n := int64(val.(Int))
+			// There are comparison issues for times too large, so "200000000-12-31 23:59:59 UTC" seems like a reasonable maximum.
+			if n > 6311328264403199 {
+				n = 6311328264403199
+				// I could not find anything pointing to a minimum allowed time, so "-200000000-01-01 00:00:00" seems reasonable
+			} else if n < -6311452567219200 {
+				n = -6311452567219200
+			}
+			return Timestamp(time.Unix(n, 0).UTC()), nil
 		}, nil
 	case UintKind:
 		return func(val Value) (Value, error) {

--- a/go/store/types/map_test.go
+++ b/go/store/types/map_test.go
@@ -28,6 +28,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -1645,6 +1646,26 @@ func TestMapOrdering(t *testing.T) {
 			InlineBlob([]byte{00, 01, 7}),
 			InlineBlob([]byte{00, 01, 8}),
 			InlineBlob([]byte{00, 01, 9}),
+		},
+	)
+
+	testMapOrder(assert, vrw,
+		PrimitiveTypeMap[TimestampKind], PrimitiveTypeMap[StringKind],
+		[]Value{
+			Timestamp(time.Unix(1000, 0).UTC()), String("unused"),
+			Timestamp(time.Unix(9000, 0).UTC()), String("unused"),
+			Timestamp(time.Unix(2000, 0).UTC()), String("unused"),
+			Timestamp(time.Unix(8000, 0).UTC()), String("unused"),
+			Timestamp(time.Unix(3000, 0).UTC()), String("unused"),
+			Timestamp(time.Unix(7000, 0).UTC()), String("unused"),
+		},
+		[]Value{
+			Timestamp(time.Unix(1000, 0).UTC()),
+			Timestamp(time.Unix(2000, 0).UTC()),
+			Timestamp(time.Unix(3000, 0).UTC()),
+			Timestamp(time.Unix(7000, 0).UTC()),
+			Timestamp(time.Unix(8000, 0).UTC()),
+			Timestamp(time.Unix(9000, 0).UTC()),
 		},
 	)
 }

--- a/go/store/types/noms_kind.go
+++ b/go/store/types/noms_kind.go
@@ -53,6 +53,7 @@ const (
 	NullKind
 	TupleKind
 	InlineBlobKind
+	TimestampKind
 
 	UnknownKind NomsKind = 255
 )
@@ -77,6 +78,7 @@ var KindToType = map[NomsKind]Value{
 	NullKind:       NullValue,
 	TupleKind:      EmptyTuple(Format_7_18),
 	InlineBlobKind: InlineBlob{},
+	TimestampKind:  Timestamp{},
 }
 
 var KindToString = map[NomsKind]string{
@@ -100,6 +102,7 @@ var KindToString = map[NomsKind]string{
 	NullKind:       "Null",
 	TupleKind:      "Tuple",
 	InlineBlobKind: "InlineBlob",
+	TimestampKind:  "Timestamp",
 }
 
 // String returns the name of the kind.

--- a/go/store/types/string.go
+++ b/go/store/types/string.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/araddon/dateparse"
 	"github.com/google/uuid"
 
 	"github.com/liquidata-inc/dolt/go/store/hash"
@@ -200,6 +201,21 @@ func (String) GetMarshalFunc(targetKind NomsKind) (MarshalCallback, error) {
 	case StringKind:
 		return func(val Value) (Value, error) {
 			return val, nil
+		}, nil
+	case TimestampKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			s := val.(String)
+			if len(s) == 0 {
+				return NullValue, nil
+			}
+			t, err := dateparse.ParseStrict(string(s))
+			if err != nil {
+				return nil, err
+			}
+			return Timestamp(t), nil
 		}, nil
 	case UintKind:
 		return func(val Value) (Value, error) {

--- a/go/store/types/timestamp.go
+++ b/go/store/types/timestamp.go
@@ -1,0 +1,165 @@
+// Copyright 2019 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	"time"
+
+	"github.com/liquidata-inc/dolt/go/store/hash"
+)
+
+const (
+	timestampNumBytes = 15
+	timestampFormat   = "2006-01-02 15:04:05.999999999 -0700"
+)
+
+type Timestamp time.Time
+
+func (v Timestamp) Value(ctx context.Context) (Value, error) {
+	return v, nil
+}
+
+func (v Timestamp) Equals(other Value) bool {
+	v2, ok := other.(Timestamp)
+	if !ok {
+		return false
+	}
+
+	return time.Time(v).Equal(time.Time(v2))
+}
+
+func (v Timestamp) Less(nbf *NomsBinFormat, other LesserValuable) (bool, error) {
+	if v2, ok := other.(Timestamp); ok {
+		return time.Time(v).Before(time.Time(v2)), nil
+	}
+	return TimestampKind < other.Kind(), nil
+}
+
+func (v Timestamp) Hash(nbf *NomsBinFormat) (hash.Hash, error) {
+	return getHash(v, nbf)
+}
+
+func (v Timestamp) isPrimitive() bool {
+	return true
+}
+
+func (v Timestamp) WalkValues(ctx context.Context, cb ValueCallback) error {
+	return nil
+}
+
+func (v Timestamp) WalkRefs(nbf *NomsBinFormat, cb RefCallback) error {
+	return nil
+}
+
+func (v Timestamp) typeOf() (*Type, error) {
+	return PrimitiveTypeMap[TimestampKind], nil
+}
+
+func (v Timestamp) Kind() NomsKind {
+	return TimestampKind
+}
+
+func (v Timestamp) valueReadWriter() ValueReadWriter {
+	return nil
+}
+
+func (v Timestamp) writeTo(w nomsWriter, nbf *NomsBinFormat) error {
+	data, err := time.Time(v).MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	err = TimestampKind.writeTo(w, nbf)
+	if err != nil {
+		return err
+	}
+
+	w.writeRaw(data)
+	return nil
+}
+
+func (v Timestamp) readFrom(nbf *NomsBinFormat, b *binaryNomsReader) (Value, error) {
+	data := b.readBytes(timestampNumBytes)
+	t := time.Time{}
+	err := t.UnmarshalBinary(data)
+	if err != nil {
+		return nil, err
+	}
+	return Timestamp(t), nil
+}
+
+func (v Timestamp) skip(nbf *NomsBinFormat, b *binaryNomsReader) {
+	b.skipBytes(timestampNumBytes)
+}
+
+func (Timestamp) GetMarshalFunc(targetKind NomsKind) (MarshalCallback, error) {
+	switch targetKind {
+	case FloatKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			t := time.Time(val.(Timestamp))
+			seconds := t.Unix()
+			// Since Float allows decimals, we represent the nanoseconds as a decimal
+			nanoseconds := t.Nanosecond()
+			combination := float64(seconds) + (float64(nanoseconds) / float64(time.Second/time.Nanosecond))
+			return Float(combination), nil
+		}, nil
+	case IntKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			t := time.Time(val.(Timestamp))
+			return Int(t.Unix()), nil
+		}, nil
+	case NullKind:
+		return func(Value) (Value, error) {
+			return NullValue, nil
+		}, nil
+	case StringKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			t := val.(Timestamp)
+			return String(t.String()), nil
+		}, nil
+	case TimestampKind:
+		return func(val Value) (Value, error) {
+			return val, nil
+		}, nil
+	case UintKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			t := time.Time(val.(Timestamp))
+			return Uint(t.Unix()), nil
+		}, nil
+	}
+
+	return nil, CreateNoConversionError(TimestampKind, targetKind)
+}
+
+func (v Timestamp) String() string {
+	return time.Time(v).Format(timestampFormat)
+}
+
+func (v Timestamp) HumanReadableString() string {
+	return v.String()
+}

--- a/go/store/types/uint.go
+++ b/go/store/types/uint.go
@@ -24,6 +24,7 @@ package types
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/liquidata-inc/dolt/go/store/hash"
 )
@@ -134,6 +135,18 @@ func (Uint) GetMarshalFunc(targetKind NomsKind) (MarshalCallback, error) {
 			n := uint64(val.(Uint))
 			str := strconv.FormatUint(n, 10)
 			return String(str), nil
+		}, nil
+	case TimestampKind:
+		return func(val Value) (Value, error) {
+			if val == nil {
+				return nil, nil
+			}
+			n := uint64(val.(Uint))
+			// There are comparison issues for times too large, so "200000000-12-31 23:59:59 UTC" seems like a reasonable maximum.
+			if n > 6311328264403199 {
+				n = 6311328264403199
+			}
+			return Timestamp(time.Unix(int64(n), 0).UTC()), nil
 		}, nil
 	case UintKind:
 		return func(val Value) (Value, error) {


### PR DESCRIPTION
Have a look!

I ran into an import cycle issue that I just could not figure out how to avoid, except by putting the tests into their own test folder (`sqle/types/tests`), so that's why they're in there. In particular, the cycle was that `sqle` imports `sqle/types`, and the tests rely on (and thus must import) `sqle`, causing the cycle.

I'm thinking of adding tests for the other SQL types later so that we have a few more built-in tests using the server portion, rather than everything using the `-q` pathway. That will be a different/future PR though.