### PR TITLE
go/store/types: Improve perf of value decoding for primitive types.

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/gocraft/dbr v0.0.0-20190708200302-a54124dfc613
 	github.com/golang/protobuf v1.3.2
 	github.com/golang/snappy v0.0.1
-	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/uuid v1.1.1
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go/store/types/noms_kind.go
+++ b/go/store/types/noms_kind.go
@@ -81,6 +81,8 @@ var KindToType = map[NomsKind]Value{
 	TimestampKind:  Timestamp{},
 }
 
+var KindToTypeSlice []Value
+
 var KindToString = map[NomsKind]string{
 	UnknownKind:    "unknown",
 	BlobKind:       "Blob",
@@ -112,8 +114,8 @@ func (k NomsKind) String() string {
 
 // IsPrimitiveKind returns true if k represents a Noms primitive type, which excludes collections (List, Map, Set), Refs, Structs, Symbolic and Unresolved types.
 func IsPrimitiveKind(k NomsKind) bool {
-	_, ok := PrimitiveTypeMap[k]
-	return ok
+	i := int(k)
+	return i < len(PrimitiveKindMask) && PrimitiveKindMask[i]
 }
 
 // isKindOrderedByValue determines if a value is ordered by its value instead of its hash.

--- a/go/store/types/value.go
+++ b/go/store/types/value.go
@@ -32,6 +32,9 @@ type ValueCallback func(v Value) error
 type RefCallback func(ref Ref) error
 type MarshalCallback func(val Value) (Value, error)
 
+var MaxPrimitiveKind int
+var PrimitiveKindMask []bool
+
 func init() {
 	for _, value := range KindToType {
 		if value != nil && value.isPrimitive() {
@@ -39,6 +42,27 @@ func init() {
 			PrimitiveTypeMap[nomsKind] = makePrimitiveType(nomsKind)
 		}
 	}
+	for k := range PrimitiveTypeMap {
+		if int(k) > MaxPrimitiveKind {
+			MaxPrimitiveKind = int(k)
+		}
+	}
+	PrimitiveKindMask = make([]bool, MaxPrimitiveKind+1)
+	for k := range PrimitiveTypeMap {
+		PrimitiveKindMask[int(k)] = true
+	}
+
+	maxKindInKindToType := 0
+	for k := range KindToType {
+		if int(k) > maxKindInKindToType {
+			maxKindInKindToType = int(k)
+		}
+	}
+	KindToTypeSlice = make([]Value, maxKindInKindToType+1)
+	for k, v := range KindToType {
+		KindToTypeSlice[int(k)] = v
+	}
+
 }
 
 // Valuable is an interface from which a Value can be retrieved.


### PR DESCRIPTION
This fixes a performance regression in value decoding after the work to make it easier to add primitive types to the storage layer.

First, we change some map lookups into slice lookups, because hashing the small integers on hot decode paths dominates CPU profiles.

Next, we inline logic for some frequently used primitive types in `value_decoder.go`, as opposed to going through the table indirection. This is about a 30% perf improvement for linear scans on `skipValue()`, which is worth the duplication here.

Code for adding a kind remains correct if the decoder isn't changed to include an inlined decode path. We omit inlining `UUID` and `InlineBlob` here for now.