### PR TITLE
go/libraries/doltcore/row: tagged_values.go: Fix n^2 behavior in ParseTaggedValues.

### DIFF
--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -138,15 +138,18 @@ func ParseTaggedValues(tpl types.Tuple) (TaggedValues, error) {
 	}
 
 	taggedTuple := make(TaggedValues, tpl.Len()/2)
-	for i := uint64(0); i < tpl.Len(); i += 2 {
-		tag, err := tpl.Get(i)
-
+	i, err := tpl.Iterator()
+	if err != nil {
+		return nil, err
+	}
+	for i.HasMore() {
+		_, tag, err := i.Next()
 		if err != nil {
 			return nil, err
 		}
 
-		val, err := tpl.Get(i + 1)
-
+		// i.HasMore() is true here because of assertion above.
+		_, val, err := i.Next()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
ParseTaggedValues used to call Tuple.Get(0)...Tuple.Get(n), but Tuple.Get(x)
has O(n) perf, so the function did O(n^2) decoding work to decode a tuple.

Use a TupleIterator instead.