### PR TITLE
Fix diff where clause

### DIFF
--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -182,6 +182,26 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ "44" ]] || false
     ! [[ "$output" =~ "55" ]] || false
+
+    run dolt diff test1 test2 --where "to_pk=4"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "44" ]] || false
+    ! [[ "$output" =~ "55" ]] || false
+
+    run dolt diff test1 test2 --where "to_pk=5"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "44" ]] || false
+    ! [[ "$output" =~ "55" ]] || false
+
+    run dolt diff test1 test2 --where "from_pk=5"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "55" ]] || false
+    ! [[ "$output" =~ "44" ]] || false
+
+    run dolt diff test1 test2 --where "from_pk=4"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" =~ "44" ]] || false
+    ! [[ "$output" =~ "55" ]] || false
 }
 
 @test "diff with where clause errors" {

--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -201,7 +201,7 @@ teardown() {
     dolt commit -m "added two rows"
     
     run dolt diff --where "poop=0"
-    skip "Bad where clause noy found because the argument parsing logic is only triggered on existance of a diff"
+    skip "Bad where clause not found because the argument parsing logic is only triggered on existance of a diff"
     [ "$status" -eq 1 ]
     [[ "$output" =~ "failed to parse where clause" ]] || false
 }

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -655,7 +655,7 @@ func buildPipeline(dArgs *diffArgs, joiner *rowconv.Joiner, ds *diff.DiffSplitte
 	where, err := ParseWhere(joiner.GetSchema(), dArgs.where)
 
 	if err != nil {
-		return nil, errhand.BuildDError("error: failed to parse where cause").AddCause(err).SetPrintUsage().Build()
+		return nil, errhand.BuildDError("error: failed to parse where clause").AddCause(err).SetPrintUsage().Build()
 	}
 
 	transforms := pipeline.NewTransformCollection()


### PR DESCRIPTION
Fixes diff where so that you no longer need to use to_col or from_col.

    --where col=val

is evaluated as:

    where to_col=val || from_col=val