### PR TITLE
dolt reset --soft and --hard for dolt docs

### DIFF
--- a/bats/dolt-docs.bats
+++ b/bats/dolt-docs.bats
@@ -163,11 +163,88 @@ teardown() {
     [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
 }
 
-# @test "dolt reset should remove docs from staging area" {
-    
-# }
+@test "dolt reset --hard should move doc files to untracked files when there are no doc values on the head commit" {
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Untracked files" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset --hard 
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch master" ]] || false
+    [[ "$output" =~ "Untracked files" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run ls
+    [[ "$output" =~ "LICENSE.md" ]] || false
+    [[ "$output" =~ "README.md" ]] || false
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset --hard
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Untracked files" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+}
 
-# @test "dolt reset --hard should set doc values to head commit doc values" {
+ @test "dolt reset --hard should update doc files on the fs when doc values exist on the head commit" {
+    touch LICENSE.md
+    echo license-text > LICENSE.md
+    touch README.md
+    echo readme-text > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt commit -m "first docs commit"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "first docs commit" ]]
+    echo 'updated readme' > README.md
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run cat README.md
+    [ "$output" = "updated readme" ]
+    run dolt reset --hard
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch master" ]] || false
+    [[ "$output" =~ "nothing to commit, working tree clean" ]] || false
+    run cat README.md
+    [ "$output" = "readme-text" ]
+    echo newLicenseText > LICENSE.md
+    run dolt table create -s `batshelper 1pk5col-ints.schema` test
+    [ "$status" -eq 0 ]
+    run dolt add test LICENSE.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new table:[[:space:]]*test) ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*LICENSE.md) ]] || false
+    run dolt reset --hard
+    [ "$status" -eq 0 ]
+    run dolt status
+    echo "otuput = $output"
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "On branch master" ]] || false
+    [[ "$output" =~ "Untracked files" ]] || false
+    [[ "$output" =~ ([[:space:]]*new table:[[:space:]]*test) ]] || false
+    [[ ! "$output" =~ "LICENSE.md" ]] || false
+    run cat LICENSE.md
+    [ "$output" = "license-text" ]
+ }
+
+ # @test "dolt reset should remove docs from staging area" {
     
 # }
 

--- a/bats/dolt-docs.bats
+++ b/bats/dolt-docs.bats
@@ -197,9 +197,7 @@ teardown() {
 }
 
  @test "dolt reset --hard should update doc files on the fs when doc values exist on the head commit" {
-    touch LICENSE.md
     echo license-text > LICENSE.md
-    touch README.md
     echo readme-text > README.md
     run dolt add .
     [ "$status" -eq 0 ]
@@ -244,9 +242,195 @@ teardown() {
     [ "$output" = "license-text" ]
  }
 
- # @test "dolt reset should remove docs from staging area" {
-    
-# }
+@test "dolt reset . should remove docs from staging area" {
+    echo ~license~ > LICENSE.md
+    echo ~readme~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt commit -m "initial doc commit"
+    [ "$status" -eq 0 ]
+    echo ~new-text~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run dolt reset .
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run cat README.md
+    [[ "$output" =~ "~new-text~" ]] 
+}
+
+@test "dolt reset --soft should remove docs from staging area" {
+    echo ~license~ > LICENSE.md
+    echo ~readme~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset --soft
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt commit -m "initial doc commit"
+    [ "$status" -eq 0 ]
+    echo ~new-text~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run dolt reset --soft
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run cat README.md
+    [[ "$output" =~ "~new-text~" ]] 
+}
+
+@test "dolt reset should remove docs from staging area" {
+    echo ~license~ > LICENSE.md
+    echo ~readme~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt commit -m "initial doc commit"
+    [ "$status" -eq 0 ]
+    echo ~new-text~ > README.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run dolt reset
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*README.md) ]] || false
+    run cat README.md
+    [[ "$output" =~ "~new-text~" ]] 
+}
+
+@test "dolt reset <doc> should remove doc from staging area" {
+    run dolt add LICENSE.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    run dolt reset LICENSE.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt reset LICENSE.md invalid
+    [ "$status" -eq 1 ]
+    [[ "$output" =~ "Invalid Table(s)" ]] || false
+    [[ "$output" =~ "invalid" ]] || false
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    run dolt reset README.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    run dolt commit -m "initial license commit"
+    [ "$status" -eq 0 ]
+    echo new > LICENSE.md
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset README.md LICENSE.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes not staged for commit:" ]] || false
+    [[ "$output" =~ ([[:space:]]*modified:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+}
+
+@test "dolt reset <table> <doc> resets tables and docs from staging area" {
+    run dolt add .
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt table create -s `batshelper 1pk5col-ints.schema` test
+    [ "$status" -eq 0 ]
+    run dolt add test
+    [ "$status" -eq 0 ]
+    run dolt status
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new table:[[:space:]]*test) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+    run dolt reset test LICENSE.md README.md
+    [ "$status" -eq 0 ]
+    run dolt status
+    [[ ! "$output" =~ "Changes to be committed:" ]] || false
+    [[ "$output" =~ "Untracked files:" ]] || false
+    [[ "$output" =~ ([[:space:]]*new table:[[:space:]]*test) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*LICENSE.md) ]] || false
+    [[ "$output" =~ ([[:space:]]*new doc:[[:space:]]*README.md) ]] || false
+}
 
 #  @test "dolt ls should not show dolt_docs table" {
 

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -120,12 +120,7 @@ func resetHard(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseRe
 		return errhand.BuildDError("error: failed to read dolt docs from fs").AddCause(err).Build()
 	}
 
-	headDocTbl, headDocTblFound, err := headRoot.GetTable(ctx, doltdb.DocTableName)
-	if err != nil {
-		return errhand.BuildDError("error: failed to read dolt docs from head").AddCause(err).Build()
-	}
-
-	err = dEnv.UpdateFSDocsToHeadDocs(ctx, headRoot, headDocTblFound, headDocTbl)
+	err = dEnv.UpdateFSDocsToRootDocs(ctx, headRoot, nil)
 	if err != nil {
 		localDocs.Save(dEnv.FS)
 		return errhand.BuildDError("error: failed to update dolt docs from head").AddCause(err).Build()
@@ -147,6 +142,16 @@ func resetHard(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseRe
 	return nil
 }
 
+func removeDocsTbl(tbls []string) []string {
+	var result []string
+	for _, tblName := range tbls {
+		if tblName != doltdb.DocTableName {
+			result = append(result, tblName)
+		}
+	}
+	return result
+}
+
 func resetSoft(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseResults, stagedRoot, headRoot *doltdb.RootValue) errhand.VerboseError {
 	tbls := apr.Args()
 
@@ -159,20 +164,54 @@ func resetSoft(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgParseRe
 		}
 	}
 
-	verr := ValidateTablesWithVErr(tbls, stagedRoot, headRoot)
+	tables, docs, err := actions.GetTblsAndDocDetails(dEnv, tbls)
+	if err != nil {
+		return errhand.BuildDError("error: failed to get all tables").AddCause(err).Build()
+	}
+
+	if len(docs) > 0 {
+		tables = removeDocsTbl(tables)
+	}
+
+	verr := ValidateTablesWithVErr(tables, stagedRoot, headRoot)
 
 	if verr != nil {
 		return verr
 	}
 
-	stagedRoot, verr = resetStaged(ctx, dEnv, tbls, stagedRoot, headRoot)
+	localDocs, err := env.LoadDocs(dEnv.FS)
+	if err != nil {
+		return errhand.BuildDError("error: failed to read dolt docs from fs").AddCause(err).Build()
+	}
+
+	stagedRoot, err = resetDocs(ctx, dEnv, headRoot, docs)
+	if err != nil {
+		return errhand.BuildDError("error: failed to reset docs").AddCause(err).Build()
+	}
+
+	stagedRoot, verr = resetStaged(ctx, dEnv, tables, stagedRoot, headRoot)
 
 	if verr != nil {
+		localDocs.Save(dEnv.FS)
 		return verr
 	}
 
 	printNotStaged(ctx, dEnv, stagedRoot)
 	return nil
+}
+
+func resetDocs(ctx context.Context, dEnv *env.DoltEnv, headRoot *doltdb.RootValue, docDetails env.Docs) (newStgRoot *doltdb.RootValue, err error) {
+	docs, err := dEnv.GetDocsFromRootDocs(ctx, headRoot, docDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	err = dEnv.PutDocsToWorking(ctx, docs)
+	if err != nil {
+		return nil, err
+	}
+
+	return dEnv.PutDocsToStaged(ctx, docs)
 }
 
 func printNotStaged(ctx context.Context, dEnv *env.DoltEnv, staged *doltdb.RootValue) {
@@ -183,21 +222,32 @@ func printNotStaged(ctx context.Context, dEnv *env.DoltEnv, staged *doltdb.RootV
 		return
 	}
 
-	notStaged, err := actions.NewTableDiffs(ctx, working, staged)
-
+	notStagedTbls, err := actions.NewTableDiffs(ctx, working, staged)
 	if err != nil {
 		return
 	}
 
-	if notStaged.NumRemoved+notStaged.NumModified > 0 {
+	notStagedDocs, err := actions.NewDocDiffs(ctx, dEnv, working, nil, nil)
+	if err != nil {
+		return
+	}
+
+	if notStagedTbls.NumRemoved+notStagedTbls.NumModified+notStagedDocs.NumRemoved+notStagedDocs.NumModified > 0 {
 		cli.Println("Unstaged changes after reset:")
 
-		lines := make([]string, 0, notStaged.Len())
-		for _, tblName := range notStaged.Tables {
-			tdt := notStaged.TableToType[tblName]
+		lines := make([]string, 0, notStagedTbls.Len()+notStagedDocs.Len())
+		for _, tblName := range notStagedTbls.Tables {
+			tdt := notStagedTbls.TableToType[tblName]
 
-			if tdt != actions.AddedTable {
+			if tdt != actions.AddedTable && tblName != doltdb.DocTableName {
 				lines = append(lines, fmt.Sprintf("%s\t%s", tblDiffTypeToShortLabel[tdt], tblName))
+			}
+		}
+
+		for _, docName := range notStagedDocs.Docs {
+			ddt := notStagedDocs.DocToType[docName]
+			if ddt != actions.AddedDoc {
+				lines = append(lines, fmt.Sprintf("%s\t%s", docDiffTypeToShortLabel[ddt], docName))
 			}
 		}
 

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -75,16 +75,22 @@ var tblDiffTypeToLabel = map[actions.TableDiffType]string{
 	actions.AddedTable:    "new table:",
 }
 
+var tblDiffTypeToShortLabel = map[actions.TableDiffType]string{
+	actions.ModifiedTable: "M",
+	actions.RemovedTable:  "D",
+	actions.AddedTable:    "N",
+}
+
 var docDiffTypeToLabel = map[actions.DocDiffType]string{
 	actions.ModifiedDoc: "modified:",
 	actions.RemovedDoc:  "deleted:",
 	actions.AddedDoc:    "new doc:",
 }
 
-var tblDiffTypeToShortLabel = map[actions.TableDiffType]string{
-	actions.ModifiedTable: "M",
-	actions.RemovedTable:  "D",
-	actions.AddedTable:    "N",
+var docDiffTypeToShortLabel = map[actions.DocDiffType]string{
+	actions.ModifiedDoc: "M",
+	actions.RemovedDoc:  "D",
+	actions.AddedDoc:    "N",
 }
 
 const (

--- a/go/libraries/doltcore/doltdb/root_val.go
+++ b/go/libraries/doltcore/doltdb/root_val.go
@@ -49,7 +49,7 @@ type DocDetails struct {
 	NewerText []byte
 	DocPk     string
 	Value     types.Value
-	DocFile   string
+	File      string
 }
 
 func NewRootValue(ctx context.Context, vrw types.ValueReadWriter, tables map[string]hash.Hash) (*RootValue, error) {

--- a/go/libraries/doltcore/env/actions/staged.go
+++ b/go/libraries/doltcore/env/actions/staged.go
@@ -26,7 +26,7 @@ import (
 var ErrTablesInConflict = errors.New("table is in conflict")
 
 func StageTables(ctx context.Context, dEnv *env.DoltEnv, tbls []string, allowConflicts bool) error {
-	tables, docDetails, err := getTblsAndDocDetails(dEnv, tbls)
+	tables, docDetails, err := GetTblsAndDocDetails(dEnv, tbls)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,9 @@ func StageTables(ctx context.Context, dEnv *env.DoltEnv, tbls []string, allowCon
 	return nil
 }
 
-func getTblsAndDocDetails(dEnv *env.DoltEnv, tbls []string) (tables []string, docsDetails []*doltdb.DocDetails, err error) {
+// GetTblsAndDocDetails takes a slice of strings where valid doc names are replaced with doc table name. Doc names are
+// appended to a docDetails slice. We return a tuple of tables, docDetails and error.
+func GetTblsAndDocDetails(dEnv *env.DoltEnv, tbls []string) (tables []string, docsDetails []*doltdb.DocDetails, err error) {
 	var docDetails []*doltdb.DocDetails
 	for i, tbl := range tbls {
 		docDetail, err := dEnv.GetOneDocDetail(tbl)

--- a/go/libraries/doltcore/env/dolt_docs.go
+++ b/go/libraries/doltcore/env/dolt_docs.go
@@ -22,13 +22,13 @@ import (
 var initialReadme = "This is a repository level README. Either edit it, add it, and commit it, or remove the file."
 var initialLicense = "This is a repository level LICENSE. Either edit it, add it, and commit it, or remove the file."
 
-type Docs map[string]*doltdb.DocDetails
+type Docs []*doltdb.DocDetails
 
 // AllValidDocDetails is a list of all valid docs with static fields DocPk and File. All other DocDetail fields
 // are dynamic and must be added, modified or removed as needed.
 var AllValidDocDetails = &Docs{
-	doltdb.ReadmePk:  &doltdb.DocDetails{DocPk: doltdb.ReadmePk, File: ReadmeFile},
-	doltdb.LicensePk: &doltdb.DocDetails{DocPk: doltdb.LicensePk, File: LicenseFile},
+	&doltdb.DocDetails{DocPk: doltdb.ReadmePk, File: ReadmeFile},
+	&doltdb.DocDetails{DocPk: doltdb.LicensePk, File: LicenseFile},
 }
 
 func LoadDocs(fs filesys.ReadWriteFS) (*Docs, error) {
@@ -49,8 +49,8 @@ func LoadDocs(fs filesys.ReadWriteFS) (*Docs, error) {
 
 func CreateDocs(fs filesys.ReadWriteFS) (*Docs, error) {
 	docs := *AllValidDocDetails
-	for key, value := range docs {
-		value.NewerText = getInitialDocText(key)
+	for _, doc := range docs {
+		doc.NewerText = getInitialDocText(doc.DocPk)
 	}
 	err := docs.Save(fs)
 	if err != nil {
@@ -60,13 +60,13 @@ func CreateDocs(fs filesys.ReadWriteFS) (*Docs, error) {
 }
 
 func (docs *Docs) Save(fs filesys.ReadWriteFS) error {
-	for key, value := range *docs {
-		if !isValidDoc(key) {
+	for _, doc := range *docs {
+		if !isValidDoc(doc.DocPk) {
 			continue
 		}
-		filePath := getDocFile(value.File)
-		if value.NewerText != nil {
-			err := fs.WriteFile(filePath, value.NewerText)
+		filePath := getDocFile(doc.File)
+		if doc.NewerText != nil {
+			err := fs.WriteFile(filePath, doc.NewerText)
 			if err != nil {
 				return err
 			}
@@ -87,8 +87,8 @@ func getInitialDocText(docName string) []byte {
 }
 
 func isValidDoc(docName string) bool {
-	for key := range *AllValidDocDetails {
-		if key == docName {
+	for _, doc := range *AllValidDocDetails {
+		if doc.DocPk == docName {
 			return true
 		}
 	}

--- a/go/libraries/doltcore/env/environment_test.go
+++ b/go/libraries/doltcore/env/environment_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -60,8 +61,8 @@ func createTestEnv(isInitialized bool, hasLocalConfig bool) *DoltEnv {
 
 		initialFiles[getRepoStateFile()] = []byte(repoStateData)
 
-		initialFiles[getFile(ReadmeFile)] = []byte(initialReadme)
-		initialFiles[getFile(LicenseFile)] = []byte(initialLicense)
+		initialFiles[getDocFile(ReadmeFile)] = []byte(initialReadme)
+		initialFiles[getDocFile(LicenseFile)] = []byte(initialLicense)
 
 		if hasLocalConfig {
 			initialFiles[getLocalConfigPath()] = []byte(`{"user.name":"bheni"}`)
@@ -95,8 +96,8 @@ func TestNonRepoDir(t *testing.T) {
 		t.Error("File doesn't exist.  There should be an error if the directory doesn't exist.")
 	}
 
-	if dEnv.DocsLoadErr == nil {
-		t.Error("Files don't exist. There should be an error if the directory doesn't exist.")
+	if dEnv.DocsLoadErr != nil {
+		t.Error("There shouldn't be an error if the directory doesn't exist.")
 	}
 }
 
@@ -177,14 +178,11 @@ func TestInitRepo(t *testing.T) {
 		t.Error("Failed to get staged root value.")
 	}
 
-	readmePath := getFile(ReadmeFile)
-	if readmePath != "README.md" {
-		t.Error("Readme file path should exist.")
-	}
-
-	licensePath := getFile(LicenseFile)
-	if licensePath != "LICENSE.md" {
-		t.Error("License file path should exist.")
+	for _, doc := range *AllValidDocDetails {
+		docPath := getDocFile(doc.File)
+		if len(docPath) > 0 && !strings.Contains(doc.File, docPath) {
+			t.Error("Doc file path should exist: ", doc.File)
+		}
 	}
 }
 

--- a/go/libraries/doltcore/env/paths.go
+++ b/go/libraries/doltcore/env/paths.go
@@ -88,6 +88,6 @@ func getHomeDir(hdp HomeDirProvider) (string, error) {
 	return homeDir, nil
 }
 
-func getFile(file string) string {
-	return filepath.Join(dbfactory.DoltDir, file)
+func getDocFile(filename string) string {
+	return filepath.Join(dbfactory.DoltDir, filename)
 }


### PR DESCRIPTION
This PR includes:
* Adding docs to `dolt reset --hard`, with tests
* Adding docs to `dolt reset --soft`, `dolt reset .`, `dolt reset`, `dolt reset <doc>`, with tests
* Refactor `doltcore/env/dolt_docs` to more general use
* ...and other helper functions in `doltcore/env/environment.go` to help stage and unstage docs