### PR TITLE
fix select on system table that doesn't exist

### DIFF
--- a/go/libraries/doltcore/sql/sqltestutil/selectqueries.go
+++ b/go/libraries/doltcore/sql/sqltestutil/selectqueries.go
@@ -671,6 +671,16 @@ var BasicSelectTests = []SelectTest{
 		ExpectedErr: `Unknown table: 'dne'`,
 	},
 	{
+		Name:        "unknown diff table",
+		Query:       "select * from dolt_diff_dne",
+		ExpectedErr: `Unknown table: 'dolt_diff_dne'`,
+	},
+	{
+		Name:        "unknown history table",
+		Query:       "select * from dolt_history_dne",
+		ExpectedErr: `Unknown table: 'dolt_history_dne'`,
+	},
+	{
 		Name:        "unknown table in join",
 		Query:       "select * from people join dne",
 		ExpectedErr: `Unknown table: 'dne'`,

--- a/go/libraries/doltcore/sqle/diff_table.go
+++ b/go/libraries/doltcore/sqle/diff_table.go
@@ -66,6 +66,10 @@ func NewDiffTable(ctx context.Context, name string, ddb *doltdb.DoltDB, rs *env.
 
 	sch := ss.GetSchema()
 
+	if sch.GetAllCols().Size() <= 1 {
+		return nil, sql.ErrTableNotFound.New(DoltDiffTablePrefix + name)
+	}
+
 	j, err := rowconv.NewJoiner(
 		[]rowconv.NamedSchema{{Name: diff.To, Sch: sch}, {Name: diff.From, Sch: sch}},
 		map[string]rowconv.ColNamingFunc{

--- a/go/libraries/doltcore/sqle/history_table.go
+++ b/go/libraries/doltcore/sqle/history_table.go
@@ -79,6 +79,10 @@ func NewHistoryTable(ctx context.Context, name string, ddb *doltdb.DoltDB) (*His
 
 	sch := ss.GetSchema()
 
+	if sch.GetAllCols().Size() <= 3 {
+		return nil, sql.ErrTableNotFound.New(DoltHistoryTablePrefix + name)
+	}
+
 	err = cmItr.Reset(ctx)
 
 	if err != nil {


### PR DESCRIPTION
fix select on a system table that has a valid prefix but whose suffix does not match a valid table.

What makes this a little bit tough is that you can query diffs or the history of a table that no longer exists. So need to process the entire history and then see if at any time there was a schema'd table with the given name.