### PR TITLE
go/store/nbs: s3_table_reader: Be certain to close body readers when reading from S3.

### DIFF
--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -336,6 +336,7 @@ func (s3p awsTablePersister) loadIntoCache(ctx context.Context, name addr) error
 	if err != nil {
 		return err
 	}
+	defer result.Body.Close()
 
 	return s3p.tc.store(name, result.Body, uint64(*result.ContentLength))
 }

--- a/go/store/nbs/s3_table_reader.go
+++ b/go/store/nbs/s3_table_reader.go
@@ -145,10 +145,10 @@ func (s3or *s3ObjectReader) readRange(ctx context.Context, name addr, p []byte, 
 		}
 
 		result, err := s3or.s3.GetObjectWithContext(ctx, input)
-
 		if err != nil {
 			return 0, err
 		}
+		defer result.Body.Close()
 
 		if *result.ContentLength != int64(len(p)) {
 			return 0, fmt.Errorf("failed to read get entire range")


### PR DESCRIPTION
It is necessary and correct that we close these readers. Helps with persistent
connection reuse, accurate logging and timing metrics, timely resource
finalization, etc.