### PR TITLE
First cut at generating CLI docs for docs site

### DIFF
--- a/go/cmd/dolt/cli/arg_helpers.go
+++ b/go/cmd/dolt/cli/arg_helpers.go
@@ -50,21 +50,15 @@ func ParseArgs(ap *argparser.ArgParser, args []string, usagePrinter UsagePrinter
 	return apr
 }
 
-func HelpAndUsagePrinters(commandStr string, cmdDoc CommandDocumentation, ap *argparser.ArgParser) (UsagePrinter, UsagePrinter) {
+func HelpAndUsagePrinters(cmdDoc CommandDocumentation) (UsagePrinter, UsagePrinter) {
 	// TODO handle error states
 	longDesc, _ := cmdDoc.GetLongDesc(CliFormat)
-	//if longDescErr != nil {
-	//	return 1
-	//}
 	synopsis, _ := cmdDoc.GetSynopsis(CliFormat)
-	//if synopsisErr != nil {
-	//	return 1
-	//}
 
 	return func() {
-			PrintHelpText(commandStr, cmdDoc.GetShortDesc(), longDesc, synopsis, ap)
+			PrintHelpText(cmdDoc.CommandStr, cmdDoc.GetShortDesc(), longDesc, synopsis, cmdDoc.ArgParser)
 		}, func() {
-			PrintUsage(commandStr, synopsis, ap)
+			PrintUsage(cmdDoc.CommandStr, synopsis, cmdDoc.ArgParser)
 		}
 }
 

--- a/go/cmd/dolt/cli/arg_helpers.go
+++ b/go/cmd/dolt/cli/arg_helpers.go
@@ -50,9 +50,19 @@ func ParseArgs(ap *argparser.ArgParser, args []string, usagePrinter UsagePrinter
 	return apr
 }
 
-func HelpAndUsagePrinters(commandStr, shortDesc, longDesc string, synopsis []string, ap *argparser.ArgParser) (UsagePrinter, UsagePrinter) {
+func HelpAndUsagePrinters(commandStr string, cmdDoc CommandDocumentation, ap *argparser.ArgParser) (UsagePrinter, UsagePrinter) {
+	// TODO handle error states
+	longDesc, _ := cmdDoc.GetLongDesc(CliFormat)
+	//if longDescErr != nil {
+	//	return 1
+	//}
+	synopsis, _ := cmdDoc.GetSynopsis(CliFormat)
+	//if synopsisErr != nil {
+	//	return 1
+	//}
+
 	return func() {
-			PrintHelpText(commandStr, shortDesc, longDesc, synopsis, ap)
+			PrintHelpText(commandStr, cmdDoc.GetShortDesc(), longDesc, synopsis, ap)
 		}, func() {
 			PrintUsage(commandStr, synopsis, ap)
 		}

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -58,7 +58,7 @@ type Command interface {
 	CreateMarkdown(fs filesys.Filesys, path, commandStr string) error
 }
 
-// This type is to store the content of a documented command, elsehwere we can transform this struct into
+// This type is to store the content of a documented command, elsewhere we can transform this struct into
 // other structs that are used to generate documentation at the command line and in markdown files.
 type CommandDocumentationContent struct {
 	ShortDesc string

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -62,8 +62,8 @@ type Command interface {
 // other structs that are used to generate documentation at the command line and in markdown files.
 type CommandDocumentationContent struct {
 	ShortDesc string
-	LongDesc string
-	Synopsis []string
+	LongDesc  string
+	Synopsis  []string
 }
 
 //type CommandDocumentation

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -58,6 +58,16 @@ type Command interface {
 	CreateMarkdown(fs filesys.Filesys, path, commandStr string) error
 }
 
+// This type is to store the content of a documented command, elsehwere we can transform this struct into
+// other structs that are used to generate documentation at the command line and in markdown files.
+type CommandDocumentationContent struct {
+	ShortDesc string
+	LongDesc string
+	Synopsis []string
+}
+
+//type CommandDocumentation
+
 // RepoNotRequiredCommand is an optional interface that commands can implement if the command can be run without
 // the current directory being a valid Dolt data repository.  Any commands not implementing this interface are
 // assumed to require that they be run from a directory containing a Dolt data repository.

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -108,8 +108,9 @@ func (cmdDoc CommandDocumentation) GetLongDesc(format DocFormat) (string, error)
 }
 
 func templateDocStringHelper(docString string, docFormat DocFormat) (string, error) {
-	templ, err := template.New("shortDesc").Parse(docString)
+	templ, err := template.New("description").Parse(docString)
 	if err != nil {
+		Printf(docString)
 		return "", err
 	}
 	var templBuffer bytes.Buffer

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"bytes"
+	"text/template"
+	//"context"
+	//"fmt"
+	//"io"
+	//"path/filepath"
+	//"strings"
+	//"text/template"
+	//
+	//"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
+	//"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	//"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
+	//"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
+	//"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
+	//"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
+)
+
+type CommandDocumentation struct {
+	ShortDesc string
+	LongDesc string
+	Synopsis []string
+}
+
+func (cmdDoc CommandDocumentation) GetShortDesc() string {
+	return cmdDoc.ShortDesc
+}
+
+func (cmdDoc CommandDocumentation) GetLongDesc(format DocFormat) (string, error) {
+	return templateDocString(cmdDoc.LongDesc, format)
+}
+
+func (cmdDoc CommandDocumentation) GetSynopsis(format DocFormat) ([]string, error) {
+	return templateSynopsis(cmdDoc.Synopsis, format)
+}
+
+type DocFormat struct {
+	LessThan string
+	GreaterThan string
+	EmphasisLeft string
+	EmphasisRight string
+}
+
+var MarkdownFormat = DocFormat{"`<", ">`", "`", "`"}
+var CliFormat = DocFormat{"<", ">", "<b>", "</b>"}
+var SynopsisMarkdownFormat = DocFormat{"&lt;", "&gt;", "`", "`"}
+
+func templateDocString(docString string, docFormat DocFormat) (string, error) {
+	templ, err := template.New("shortDesc").Parse(docString)
+	if err != nil {
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, docFormat); err != nil {
+		return "", err
+	}
+	return templBuffer.String(), nil
+}
+
+func templateSynopsis(lines []string, docFormat DocFormat) ([]string, error) {
+	for i, line := range lines {
+		formatted, err := templateDocString(line, docFormat)
+		if err != nil {
+			return []string{}, err
+		}
+		lines[i] = formatted
+	}
+
+	return lines, nil
+}
+
+

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -45,7 +45,11 @@ func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argpars
 		// Iterate across arguments and template them
 		for _, kvTuple := range parser.ArgListHelp {
 			arg, desc := kvTuple[0], kvTuple[1]
-			argStruct := Agument{arg, desc}
+			templatedDesc, err := templateDocStringHelper(desc, MarkdownFormat)
+			if err != nil {
+				return "", err
+			}
+			argStruct := Agument{arg, templatedDesc}
 			outputStr, err := templateArgument(argStruct)
 			if err != nil {
 				return "", err
@@ -55,7 +59,11 @@ func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argpars
 
 		// Iterate accross supported options, templating each one of them
 		for _, supOpt := range parser.Supported {
-			argStruct := Supported{supOpt.Abbrev, supOpt.Name, supOpt.ValDesc}
+			templatedDesc, err := templateDocStringHelper(supOpt.Desc, MarkdownFormat)
+			if err != nil {
+				return "", err
+			}
+			argStruct := Supported{supOpt.Abbrev, supOpt.Name, templatedDesc}
 			outputStr, err := templateSupported(argStruct)
 			if err != nil {
 				return "", err
@@ -208,7 +216,6 @@ func templateSupported(supported Supported) (string, error) {
 		formatString = "`--{{.Name}}`\n\n"
 	} else if supported.Abbreviation == "" && supported.Description != ""  {
 		formatString = "`--{{.Name}}`:\n{{.Description}}\n\n"
-
 	} else if supported.Abbreviation != "" && supported.Description == "" {
 		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`\n\n"
 	} else {
@@ -226,7 +233,5 @@ func templateSupported(supported Supported) (string, error) {
 	ret := templBuffer.String()
 	return ret, nil
 }
-
-
 
 

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -106,13 +106,13 @@ type CommandDocumentation struct {
 	// The command/sub-command string passed to a command by the caller
 	CommandStr string
 	// The short description of the command
-	ShortDesc  string
+	ShortDesc string
 	// The long description of the command
-	LongDesc   string
+	LongDesc string
 	// The synopsis, an array of strings showing how to use the command
-	Synopsis   []string
+	Synopsis []string
 	// A structure that
-	ArgParser  *argparser.ArgParser
+	ArgParser *argparser.ArgParser
 }
 
 func (cmdDoc CommandDocumentation) cmdDocToCmdDocMd(options string) (commandDocumentForMarkdown, error) {
@@ -190,8 +190,10 @@ type docFormat struct {
 
 // mdx format
 var MarkdownFormat = docFormat{"`<", ">`", "`", "`"}
+
 // Shell help output format
 var CliFormat = docFormat{"<", ">", "<b>", "</b>"}
+
 // Special format for the synopsis which is rendered inside raw HTML in markdown
 var SynopsisMarkdownFormat = docFormat{"&lt;", "&gt;", "`", "`"}
 

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -16,8 +16,7 @@ type CmdMdDoc struct {
 	Options string
 }
 
-var cmdMdDocTempl = `
----
+var cmdMdDocTempl = `---
 title: {{.Command}}
 ---
 
@@ -69,7 +68,7 @@ func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argpars
 	if longDescErr != nil {
 		return "", longDescErr
 	}
-	synopsis, synopsisErr := cmdDoc.GetSynopsis(MarkdownFormat)
+	synopsis, synopsisErr := cmdDoc.GetSynopsis(SynopsisMarkdownFormat)
 	if synopsisErr != nil {
 		return "", synopsisErr
 	}
@@ -208,12 +207,12 @@ func templateSupported(supported Supported) (string, error) {
 	if supported.Abbreviation == "" && supported.Description == "" {
 		formatString = "`--{{.Name}}`\n\n"
 	} else if supported.Abbreviation == "" && supported.Description != ""  {
-		formatString = "`--{{.Name}}`:\n\n    {{.Description}}\n\n"
+		formatString = "`--{{.Name}}`:\n{{.Description}}\n\n"
 
 	} else if supported.Abbreviation != "" && supported.Description == "" {
 		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`\n\n"
 	} else {
-		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`:\n\n    {{.Description}}\n\n"
+		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`:\n{{.Description}}\n\n"
 	}
 
 	templ, err := template.New("argString").Parse(formatString)

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -2,21 +2,96 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
+	"strings"
 	"text/template"
-	//"context"
-	//"fmt"
-	//"io"
-	//"path/filepath"
-	//"strings"
-	//"text/template"
-	//
-	//"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
-	//"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
-	//"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
-	//"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	//"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-	//"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
+
+type CmdMdDoc struct {
+	Command string
+	CommandAndShortDesc string
+	Synopsis string
+	Description string
+	Options string
+}
+
+var cmdMdDocTempl = `
+---
+title: {{.Command}}
+---
+
+## Command
+{{.CommandAndShortDesc}}
+
+## Synopsis
+{{.Synopsis}}
+
+## Description
+{{.Description}}
+
+## Options
+{{.Options}}
+
+`
+
+func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argparser.ArgParser) (string, error) {
+
+	// Accumulate the options and args in a string
+	options := ""
+	if len(parser.Supported) > 0 || len(parser.ArgListHelp) > 0 {
+		// no need to write
+		//err = iohelp.WriteIfNoErr(wr, titleHelper("Options"), err)
+
+		// Iterate across arguments and template them
+		for _, kvTuple := range parser.ArgListHelp {
+			arg, desc := kvTuple[0], kvTuple[1]
+			argStruct := Agument{arg, desc}
+			outputStr, err := templateArgument(argStruct)
+			if err != nil {
+				return "", err
+			}
+			options += outputStr
+		}
+
+		// Iterate accross supported options, templating each one of them
+		for _, supOpt := range parser.Supported {
+			argStruct := Supported{supOpt.Abbrev, supOpt.Name, supOpt.ValDesc}
+			outputStr, err := templateSupported(argStruct)
+			if err != nil {
+				return "", err
+			}
+			options += outputStr
+		}
+	}
+
+	longDesc, longDescErr := cmdDoc.GetLongDesc(MarkdownFormat)
+	if longDescErr != nil {
+		return "", longDescErr
+	}
+	synopsis, synopsisErr := cmdDoc.GetSynopsis(MarkdownFormat)
+	if synopsisErr != nil {
+		return "", synopsisErr
+	}
+
+	cmdMdDoc := CmdMdDoc{
+		Command:			 commandStr,
+		CommandAndShortDesc: fmt.Sprintf("`%s` - %s\n\n", commandStr, cmdDoc.GetShortDesc()),
+		Synopsis:            getSynopsis(commandStr, synopsis),
+		Description:         longDesc,
+		Options:             options,
+	}
+
+	templ, err := template.New("shortDesc").Parse(cmdMdDocTempl)
+	if err != nil {
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, cmdMdDoc); err != nil {
+		return "", err
+	}
+	return templBuffer.String(), nil
+}
 
 type CommandDocumentation struct {
 	ShortDesc string
@@ -29,11 +104,32 @@ func (cmdDoc CommandDocumentation) GetShortDesc() string {
 }
 
 func (cmdDoc CommandDocumentation) GetLongDesc(format DocFormat) (string, error) {
-	return templateDocString(cmdDoc.LongDesc, format)
+	return templateDocStringHelper(cmdDoc.LongDesc, format)
+}
+
+func templateDocStringHelper(docString string, docFormat DocFormat) (string, error) {
+	templ, err := template.New("shortDesc").Parse(docString)
+	if err != nil {
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, docFormat); err != nil {
+		return "", err
+	}
+	return templBuffer.String(), nil
 }
 
 func (cmdDoc CommandDocumentation) GetSynopsis(format DocFormat) ([]string, error) {
-	return templateSynopsis(cmdDoc.Synopsis, format)
+	lines := cmdDoc.Synopsis
+	for i, line := range lines {
+		formatted, err := templateDocStringHelper(line, format)
+		if err != nil {
+			return []string{}, err
+		}
+		lines[i] = formatted
+	}
+
+	return lines, nil
 }
 
 type DocFormat struct {
@@ -47,28 +143,90 @@ var MarkdownFormat = DocFormat{"`<", ">`", "`", "`"}
 var CliFormat = DocFormat{"<", ">", "<b>", "</b>"}
 var SynopsisMarkdownFormat = DocFormat{"&lt;", "&gt;", "`", "`"}
 
-func templateDocString(docString string, docFormat DocFormat) (string, error) {
-	templ, err := template.New("shortDesc").Parse(docString)
+func getSynopsis(commandStr string, synopsis []string) string {
+	if len(synopsis) == 0 {
+		return ""
+	}
+	synopsisStr := fmt.Sprintf("%s %s<br />\n", commandStr, synopsis[0])
+	if len(synopsis) > 1 {
+		temp := make([]string, len(synopsis)-1)
+		for i, el := range(synopsis[1:]) {
+			temp[i] = fmt.Sprintf("\t\t\t%s %s<br />\n", commandStr, el)
+		}
+		synopsisStr += strings.Join(temp, "")
+	}
+
+	html := `
+<div class="gatsby-highlight" data-language="text">
+	<pre class="language-text">
+		<code class="language-text">
+			%s
+  		</code>
+	</pre>
+</div>
+
+`
+
+	return fmt.Sprintf(html, synopsisStr)
+}
+
+type Agument struct {
+	Name string
+	Description string
+}
+
+
+func templateArgument(supportedArg Agument) (string, error) {
+	var formatString string
+	if supportedArg.Description == "" {
+		formatString = "`<{{.Name}}>`\n\n"
+	} else {
+		formatString = "`<{{.Name}}>`:\n\n{{.Description}}\n\n"
+	}
+
+	templ, err := template.New("argString").Parse(formatString)
 	if err != nil {
 		return "", err
 	}
 	var templBuffer bytes.Buffer
-	if err := templ.Execute(&templBuffer, docFormat); err != nil {
+	if err := templ.Execute(&templBuffer, supportedArg); err != nil {
 		return "", err
 	}
-	return templBuffer.String(), nil
+	ret := templBuffer.String()
+	return ret, nil
 }
 
-func templateSynopsis(lines []string, docFormat DocFormat) ([]string, error) {
-	for i, line := range lines {
-		formatted, err := templateDocString(line, docFormat)
-		if err != nil {
-			return []string{}, err
-		}
-		lines[i] = formatted
+type Supported struct {
+	Abbreviation string
+	Name string
+	Description string
+}
+
+func templateSupported(supported Supported) (string, error) {
+	var formatString string
+	if supported.Abbreviation == "" && supported.Description == "" {
+		formatString = "`--{{.Name}}`\n\n"
+	} else if supported.Abbreviation == "" && supported.Description != ""  {
+		formatString = "`--{{.Name}}`:\n\n    {{.Description}}\n\n"
+
+	} else if supported.Abbreviation != "" && supported.Description == "" {
+		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`\n\n"
+	} else {
+		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`:\n\n    {{.Description}}\n\n"
 	}
 
-	return lines, nil
+	templ, err := template.New("argString").Parse(formatString)
+	if err != nil {
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, supported); err != nil {
+		return "", err
+	}
+	ret := templBuffer.String()
+	return ret, nil
 }
+
+
 
 

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -3,17 +3,18 @@ package cli
 import (
 	"bytes"
 	"fmt"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"strings"
 	"text/template"
+
+	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
 type CmdMdDoc struct {
-	Command string
+	Command             string
 	CommandAndShortDesc string
-	Synopsis string
-	Description string
-	Options string
+	Synopsis            string
+	Description         string
+	Options             string
 }
 
 var cmdMdDocTempl = `---
@@ -82,7 +83,7 @@ func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argpars
 	}
 
 	cmdMdDoc := CmdMdDoc{
-		Command:			 commandStr,
+		Command:             commandStr,
 		CommandAndShortDesc: fmt.Sprintf("`%s` - %s\n\n", commandStr, cmdDoc.GetShortDesc()),
 		Synopsis:            getSynopsis(commandStr, synopsis),
 		Description:         longDesc,
@@ -102,8 +103,8 @@ func (cmdDoc CommandDocumentation) CmdDocToMd(commandStr string, parser *argpars
 
 type CommandDocumentation struct {
 	ShortDesc string
-	LongDesc string
-	Synopsis []string
+	LongDesc  string
+	Synopsis  []string
 }
 
 func (cmdDoc CommandDocumentation) GetShortDesc() string {
@@ -141,9 +142,9 @@ func (cmdDoc CommandDocumentation) GetSynopsis(format DocFormat) ([]string, erro
 }
 
 type DocFormat struct {
-	LessThan string
-	GreaterThan string
-	EmphasisLeft string
+	LessThan      string
+	GreaterThan   string
+	EmphasisLeft  string
 	EmphasisRight string
 }
 
@@ -158,7 +159,7 @@ func getSynopsis(commandStr string, synopsis []string) string {
 	synopsisStr := fmt.Sprintf("%s %s<br />\n", commandStr, synopsis[0])
 	if len(synopsis) > 1 {
 		temp := make([]string, len(synopsis)-1)
-		for i, el := range(synopsis[1:]) {
+		for i, el := range synopsis[1:] {
 			temp[i] = fmt.Sprintf("\t\t\t%s %s<br />\n", commandStr, el)
 		}
 		synopsisStr += strings.Join(temp, "")
@@ -179,10 +180,9 @@ func getSynopsis(commandStr string, synopsis []string) string {
 }
 
 type Agument struct {
-	Name string
+	Name        string
 	Description string
 }
-
 
 func templateArgument(supportedArg Agument) (string, error) {
 	var formatString string
@@ -206,15 +206,15 @@ func templateArgument(supportedArg Agument) (string, error) {
 
 type Supported struct {
 	Abbreviation string
-	Name string
-	Description string
+	Name         string
+	Description  string
 }
 
 func templateSupported(supported Supported) (string, error) {
 	var formatString string
 	if supported.Abbreviation == "" && supported.Description == "" {
 		formatString = "`--{{.Name}}`\n\n"
-	} else if supported.Abbreviation == "" && supported.Description != ""  {
+	} else if supported.Abbreviation == "" && supported.Description != "" {
 		formatString = "`--{{.Name}}`:\n{{.Description}}\n\n"
 	} else if supported.Abbreviation != "" && supported.Description == "" {
 		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`\n\n"
@@ -233,5 +233,3 @@ func templateSupported(supported Supported) (string, error) {
 	ret := templBuffer.String()
 	return ret, nil
 }
-
-

--- a/go/cmd/dolt/cli/help.go
+++ b/go/cmd/dolt/cli/help.go
@@ -24,9 +24,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/funcitr"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
 
 var underline = color.New(color.Underline)
@@ -68,58 +66,6 @@ func PrintHelpText(commandStr, shortDesc, longDesc string, synopsis []string, pa
 	}
 }
 
-func CreateMarkdown(fs filesys.Filesys, path, commandStr, shortDesc, longDesc string, synopsis []string, parser *argparser.ArgParser) error {
-	wr, err := fs.OpenForWrite(path)
-
-	if err != nil {
-		return err
-	}
-
-	defer wr.Close()
-
-	err = iohelp.WriteIfNoErr(wr, []byte("## Command\n\n"), nil)
-	err = iohelp.WriteIfNoErr(wr, []byte(commandStr+" - "+shortDesc+"\n\n"), err)
-
-	if len(synopsis) > 0 {
-		err = iohelp.WriteIfNoErr(wr, []byte("## Synopsis\n\n"), err)
-
-		err = iohelp.WriteIfNoErr(wr, []byte("```sh\n"), err)
-		for _, synopsisLine := range synopsis {
-			err = iohelp.WriteIfNoErr(wr, []byte(commandStr+" "+synopsisLine+"\n"), err)
-		}
-		err = iohelp.WriteIfNoErr(wr, []byte("```\n\n"), err)
-	}
-
-	err = iohelp.WriteIfNoErr(wr, []byte("## Description\n\n"), err)
-	err = iohelp.WriteIfNoErr(wr, []byte(markdownEscape(longDesc)+"\n\n"), err)
-
-	if len(parser.Supported) > 0 || len(parser.ArgListHelp) > 0 {
-		err = iohelp.WriteIfNoErr(wr, []byte("## Options\n\n"), err)
-
-		for _, kvTuple := range parser.ArgListHelp {
-			k, v := kvTuple[0], kvTuple[1]
-			err = iohelp.WriteIfNoErr(wr, []byte("&lt;"+k+"&gt;\n"+v+"\n\n"), err)
-		}
-
-		for _, supOpt := range parser.Supported {
-			argHelpFmt := "--%[2]s"
-
-			if supOpt.Abbrev != "" && supOpt.ValDesc != "" {
-				argHelpFmt = "-%[1]s &lt;%[3]s&gt;, --%[2]s=&lt;%[3]s&gt;"
-			} else if supOpt.Abbrev != "" {
-				argHelpFmt = "-%[1]s, --%[2]s"
-			} else if supOpt.ValDesc != "" {
-				argHelpFmt = "--%[2]s=&lt;%[3]s&gt;"
-			}
-
-			argHelp := fmt.Sprintf(argHelpFmt, supOpt.Abbrev, supOpt.Name, supOpt.ValDesc)
-			err = iohelp.WriteIfNoErr(wr, []byte(argHelp+"\n"), err)
-			err = iohelp.WriteIfNoErr(wr, []byte(supOpt.Desc+"\n\n"), err)
-		}
-	}
-
-	return err
-}
 
 func PrintUsage(commandStr string, synopsis []string, parser *argparser.ArgParser) {
 	_, termWidth := terminalSize()
@@ -155,15 +101,6 @@ const (
 )
 
 var bold = color.New(color.Bold)
-
-func markdownEscape(str string) string {
-	str = strings.ReplaceAll(str, "<b>", "**")
-	str = strings.ReplaceAll(str, "</b>", "**")
-	str = strings.ReplaceAll(str, "<", "&lt;")
-	str = strings.ReplaceAll(str, ">", "&gt;")
-
-	return str
-}
 
 func embolden(str string) string {
 	res := ""

--- a/go/cmd/dolt/cli/help.go
+++ b/go/cmd/dolt/cli/help.go
@@ -66,7 +66,6 @@ func PrintHelpText(commandStr, shortDesc, longDesc string, synopsis []string, pa
 	}
 }
 
-
 func PrintUsage(commandStr string, synopsis []string, parser *argparser.ArgParser) {
 	_, termWidth := terminalSize()
 

--- a/go/cmd/dolt/cli/help_test.go
+++ b/go/cmd/dolt/cli/help_test.go
@@ -60,4 +60,3 @@ func TestEmbolden(t *testing.T) {
 		}
 	}
 }
-

--- a/go/cmd/dolt/cli/help_test.go
+++ b/go/cmd/dolt/cli/help_test.go
@@ -61,31 +61,3 @@ func TestEmbolden(t *testing.T) {
 	}
 }
 
-// not clear that we need this any more now that we are using templates
-//func TestMarkdownEscape(t *testing.T) {
-//	tests := []struct {
-//		name     string
-//		str      string
-//		expected string
-//	}{
-//		{"Nothing to do", "some text no angle brackets", "some text no angle brackets"},
-//		{"Open with no close", "x < y, ", "x &lt; y, "},
-//		{"Close with no open", "x &gt; y, ", "x &gt; y, "},
-//		{"Begin with open, no close", "<something", "&lt;something"},
-//		{"End with close with no begin", "something&gt;", "something&gt;"},
-//		{"Basic escape", "test <test> test", "test &lt;test&gt; test"},
-//		{"Start", "<test> test", "&lt;test&gt; test"},
-//		{"End", "test <test>", "test &lt;test&gt;"},
-//		{"Start and end", "<test>", "&lt;test&gt;"},
-//		{"Start after end", "this > that, <test>, that < this", "this &gt; that, &lt;test&gt;, that &lt; this"},
-//		{"has spaces", "<has spaces>", "&lt;has spaces&gt;"},
-//		{"bold tags", "regular text, <b>bolt text</b>, more regular", "regular text, **bolt text**, more regular"},
-//	}
-//
-//	for _, test := range tests {
-//		t.Run(test.name, func(t *testing.T) {
-//			res := markdownEscape(test.str)
-//			assert.Equal(t, test.expected, res)
-//		})
-//	}
-//}

--- a/go/cmd/dolt/cli/help_test.go
+++ b/go/cmd/dolt/cli/help_test.go
@@ -16,8 +16,6 @@ package cli
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestToIndentedParagraph(t *testing.T) {
@@ -63,30 +61,31 @@ func TestEmbolden(t *testing.T) {
 	}
 }
 
-func TestMarkdownEscape(t *testing.T) {
-	tests := []struct {
-		name     string
-		str      string
-		expected string
-	}{
-		{"Nothing to do", "some text no angle brackets", "some text no angle brackets"},
-		{"Open with no close", "x < y, ", "x &lt; y, "},
-		{"Close with no open", "x &gt; y, ", "x &gt; y, "},
-		{"Begin with open, no close", "<something", "&lt;something"},
-		{"End with close with no begin", "something&gt;", "something&gt;"},
-		{"Basic escape", "test <test> test", "test &lt;test&gt; test"},
-		{"Start", "<test> test", "&lt;test&gt; test"},
-		{"End", "test <test>", "test &lt;test&gt;"},
-		{"Start and end", "<test>", "&lt;test&gt;"},
-		{"Start after end", "this > that, <test>, that < this", "this &gt; that, &lt;test&gt;, that &lt; this"},
-		{"has spaces", "<has spaces>", "&lt;has spaces&gt;"},
-		{"bold tags", "regular text, <b>bolt text</b>, more regular", "regular text, **bolt text**, more regular"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			res := markdownEscape(test.str)
-			assert.Equal(t, test.expected, res)
-		})
-	}
-}
+// not clear that we need this any more now that we are using templates
+//func TestMarkdownEscape(t *testing.T) {
+//	tests := []struct {
+//		name     string
+//		str      string
+//		expected string
+//	}{
+//		{"Nothing to do", "some text no angle brackets", "some text no angle brackets"},
+//		{"Open with no close", "x < y, ", "x &lt; y, "},
+//		{"Close with no open", "x &gt; y, ", "x &gt; y, "},
+//		{"Begin with open, no close", "<something", "&lt;something"},
+//		{"End with close with no begin", "something&gt;", "something&gt;"},
+//		{"Basic escape", "test <test> test", "test &lt;test&gt; test"},
+//		{"Start", "<test> test", "&lt;test&gt; test"},
+//		{"End", "test <test>", "test &lt;test&gt;"},
+//		{"Start and end", "<test>", "&lt;test&gt;"},
+//		{"Start after end", "this > that, <test>, that < this", "this &gt; that, &lt;test&gt;, that &lt; this"},
+//		{"has spaces", "<has spaces>", "&lt;has spaces&gt;"},
+//		{"bold tags", "regular text, <b>bolt text</b>, more regular", "regular text, **bolt text**, more regular"},
+//	}
+//
+//	for _, test := range tests {
+//		t.Run(test.name, func(t *testing.T) {
+//			res := markdownEscape(test.str)
+//			assert.Equal(t, test.expected, res)
+//		})
+//	}
+//}

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -32,13 +32,20 @@ const (
 )
 
 var addShortDesc = `Add table contents to the list of staged tables`
-var addLongDesc = `This command updates the list of tables using the current content found in the working root, to prepare the content staged for the next commit. It adds the current content of existing tables as a whole or remove tables that do not exist in the working root anymore.
+var addLongDesc = `
+This command updates the list of tables using the current content found in the working root, to prepare the content staged for the next commit. It adds the current content of existing tables as a whole or remove tables that do not exist in the working root anymore.
 
 This command can be performed multiple times before a commit. It only adds the content of the specified table(s) at the time the add command is run; if you want subsequent changes included in the next commit, then you must run dolt add again to add the new content to the index.
 
 The dolt status command can be used to obtain a summary of which tables have changes that are staged for the next commit.`
 var addSynopsis = []string{
 	`[<table>...]`,
+}
+
+var AddDocumentation = cli.CommandDocumentation{
+	ShortDesc: addShortDesc,
+	LongDesc: addLongDesc,
+	Synopsis: addSynopsis,
 }
 
 type AddCmd struct{}
@@ -56,7 +63,7 @@ func (cmd AddCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd AddCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, addShortDesc, addLongDesc, addSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, AddDocumentation, ap)
 }
 
 func (cmd AddCmd) createArgParser() *argparser.ArgParser {
@@ -69,7 +76,7 @@ func (cmd AddCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPr, _ := cli.HelpAndUsagePrinters(commandStr, addShortDesc, addLongDesc, addSynopsis, ap)
+	helpPr, _ := cli.HelpAndUsagePrinters(commandStr, AddDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, helpPr)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -44,8 +44,8 @@ var addSynopsis = []string{
 
 var AddDocumentation = cli.CommandDocumentation{
 	ShortDesc: addShortDesc,
-	LongDesc: addLongDesc,
-	Synopsis: addSynopsis,
+	LongDesc:  addLongDesc,
+	Synopsis:  addSynopsis,
 }
 
 type AddCmd struct{}

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -39,7 +39,7 @@ This command can be performed multiple times before a commit. It only adds the c
 
 The dolt status command can be used to obtain a summary of which tables have changes that are staged for the next commit.`
 var addSynopsis = []string{
-	`[<table>...]`,
+	`[{{.LessThan}}table{{.GreaterThan}}...]`,
 }
 
 var AddDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -31,21 +31,17 @@ const (
 	allParam = "all"
 )
 
-var addShortDesc = `Add table contents to the list of staged tables`
-var addLongDesc = `
+var addDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Add table contents to the list of staged tables`,
+	LongDesc: `
 This command updates the list of tables using the current content found in the working root, to prepare the content staged for the next commit. It adds the current content of existing tables as a whole or remove tables that do not exist in the working root anymore.
 
 This command can be performed multiple times before a commit. It only adds the content of the specified table(s) at the time the add command is run; if you want subsequent changes included in the next commit, then you must run dolt add again to add the new content to the index.
 
-The dolt status command can be used to obtain a summary of which tables have changes that are staged for the next commit.`
-var addSynopsis = []string{
-	`[{{.LessThan}}table{{.GreaterThan}}...]`,
-}
-
-var AddDocumentation = cli.CommandDocumentation{
-	ShortDesc: addShortDesc,
-	LongDesc:  addLongDesc,
-	Synopsis:  addSynopsis,
+The dolt status command can be used to obtain a summary of which tables have changes that are staged for the next commit.`,
+	Synopsis: []string{
+		`[{{.LessThan}}table{{.GreaterThan}}...]`,
+	},
 }
 
 type AddCmd struct{}
@@ -63,7 +59,7 @@ func (cmd AddCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd AddCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, AddDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, addDocs, ap))
 }
 
 func (cmd AddCmd) createArgParser() *argparser.ArgParser {
@@ -76,7 +72,7 @@ func (cmd AddCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPr, _ := cli.HelpAndUsagePrinters(commandStr, AddDocumentation, ap)
+	helpPr, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, addDocs, ap))
 	apr := cli.ParseArgs(ap, args, helpPr)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -39,7 +39,13 @@ var blameShortDesc = `Show what revision and author last modified each row of a 
 var blameLongDesc = `Annotates each row in the given table with information from the revision which last modified the row. Optionally, start annotating from the given revision.`
 
 var blameSynopsis = []string{
-	`[<rev>] <tablename>`,
+	`[{{.LessThan}}rev{{.GreaterThan}}] {{.LessThan}}tablename{{.GreaterThan}}`,
+}
+
+var blameDocumentation = cli.CommandDocumentation{
+	ShortDesc: blameShortDesc,
+	LongDesc: blameLongDesc,
+	Synopsis: blameSynopsis,
 }
 
 // blameInfo contains blame information for a row
@@ -88,7 +94,7 @@ func (cmd BlameCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd BlameCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, blameShortDesc, blameLongDesc, blameSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, blameDocumentation, ap)
 }
 
 func (cmd BlameCmd) createArgParser() *argparser.ArgParser {
@@ -119,7 +125,7 @@ func (cmd BlameCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, blameShortDesc, blameLongDesc, blameSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, blameDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 || apr.NArg() > 2 {

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -44,8 +44,8 @@ var blameSynopsis = []string{
 
 var blameDocumentation = cli.CommandDocumentation{
 	ShortDesc: blameShortDesc,
-	LongDesc: blameLongDesc,
-	Synopsis: blameSynopsis,
+	LongDesc:  blameLongDesc,
+	Synopsis:  blameSynopsis,
 }
 
 // blameInfo contains blame information for a row

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -35,19 +35,13 @@ import (
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
-var blameShortDesc = `Show what revision and author last modified each row of a table`
-var blameLongDesc = `Annotates each row in the given table with information from the revision which last modified the row. Optionally, start annotating from the given revision.`
-
-var blameSynopsis = []string{
-	`[{{.LessThan}}rev{{.GreaterThan}}] {{.LessThan}}tablename{{.GreaterThan}}`,
+var blameDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Show what revision and author last modified each row of a table`,
+	LongDesc: `Annotates each row in the given table with information from the revision which last modified the row. Optionally, start annotating from the given revision.`,
+	Synopsis: []string{
+		`[{{.LessThan}}rev{{.GreaterThan}}] {{.LessThan}}tablename{{.GreaterThan}}`,
+	},
 }
-
-var blameDocumentation = cli.CommandDocumentation{
-	ShortDesc: blameShortDesc,
-	LongDesc:  blameLongDesc,
-	Synopsis:  blameSynopsis,
-}
-
 // blameInfo contains blame information for a row
 type blameInfo struct {
 	// Key represents the primary key of the row
@@ -94,7 +88,7 @@ func (cmd BlameCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd BlameCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, blameDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, blameDocs, ap))
 }
 
 func (cmd BlameCmd) createArgParser() *argparser.ArgParser {
@@ -125,7 +119,7 @@ func (cmd BlameCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, blameDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, blameDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 || apr.NArg() > 2 {

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -37,11 +37,12 @@ import (
 
 var blameDocs = cli.CommandDocumentationContent{
 	ShortDesc: `Show what revision and author last modified each row of a table`,
-	LongDesc: `Annotates each row in the given table with information from the revision which last modified the row. Optionally, start annotating from the given revision.`,
+	LongDesc:  `Annotates each row in the given table with information from the revision which last modified the row. Optionally, start annotating from the given revision.`,
 	Synopsis: []string{
 		`[{{.LessThan}}rev{{.GreaterThan}}] {{.LessThan}}tablename{{.GreaterThan}}`,
 	},
 }
+
 // blameInfo contains blame information for a row
 type blameInfo struct {
 	// Key represents the primary key of the row

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -48,14 +48,11 @@ With a {{.EmphasisLeft}}-d{{.EmphasisRight}}, {{.LessThan}}branchname{{.GreaterT
 
 var branchShortDesc = `List, create, or delete branches`
 
-var branchForceFlagDesc = "Reset <branchname> to <startpoint>, even if <branchname> exists already. Without -f, dolt branch " +
-	"refuses to change an existing branch. In combination with -d (or --delete), allow deleting the branch irrespective " +
-	"of its merged status. In combination with -m (or --move), allow renaming the branch even if the new branch name " +
-	"already exists, the same applies for -c (or --copy)."
+var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.LessThan}} to {{.LessThan}}startpoint{{.LessThan}}, even if {{.LessThan}}branchname{{.LessThan}} exists already. Without {{.EmphasisLeft}}-f{{.EmphasisRight}}, {{.EmphasisLeft}}dolt branch{{.EmphasisRight}} refuses to change an existing branch. In combination with {{.EmphasisLeft}}-d{{.EmphasisRight}} (or {{.EmphasisLeft}}--delete{{.EmphasisRight}}), allow deleting the branch irrespective of its merged status. In combination with -m (or {{.EmphasisLeft}}--move{{.EmphasisRight}}), allow renaming the branch even if the new branch name already exists, the same applies for {{.EmphasisLeft}}-c{{.EmphasisRight}} (or {{.EmphasisLeft}}--copy{{.EmphasisRight}})."
 
 var branchSynopsis = []string{
 		`[--list] [-v] [-a]`,
-		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start{{.GreaterThan}}point>]`,
+		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point>{{.GreaterThan}}]`,
 		`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
 		`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
 		`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,
@@ -104,7 +101,7 @@ func (cmd BranchCmd) createArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(copyFlag, "c", "Create a copy of a branch.")
 	ap.SupportsFlag(moveFlag, "m", "Move/rename a branch")
 	ap.SupportsFlag(deleteFlag, "d", "Delete a branch. The branch must be fully merged in its upstream branch.")
-	ap.SupportsFlag(deleteForceFlag, "", "Shortcut for --delete --force.")
+	ap.SupportsFlag(deleteForceFlag, "", "Shortcut for {{.EmphasisLeft}}--delete --force{{.EmphasisRight}}.")
 	ap.SupportsFlag(verboseFlag, "v", "When in list mode, show the hash and commit subject line for each head")
 	ap.SupportsFlag(allFlag, "a", "When in list mode, shows remote tracked branches")
 	return ap

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -17,7 +17,9 @@ package commands
 import (
 	"context"
 	"fmt"
+
 	"github.com/fatih/color"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -45,23 +47,22 @@ The {{.EmphasisLeft}}-c{{.EmphasisRight}} options have the exact same semantics 
 
 With a {{.EmphasisLeft}}-d{{.EmphasisRight}}, {{.LessThan}}branchname{{.GreaterThan}} will be deleted. You may specify more than one branch for deletion.`
 
-
 var branchShortDesc = `List, create, or delete branches`
 
 var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.LessThan}} to {{.LessThan}}startpoint{{.LessThan}}, even if {{.LessThan}}branchname{{.LessThan}} exists already. Without {{.EmphasisLeft}}-f{{.EmphasisRight}}, {{.EmphasisLeft}}dolt branch{{.EmphasisRight}} refuses to change an existing branch. In combination with {{.EmphasisLeft}}-d{{.EmphasisRight}} (or {{.EmphasisLeft}}--delete{{.EmphasisRight}}), allow deleting the branch irrespective of its merged status. In combination with -m (or {{.EmphasisLeft}}--move{{.EmphasisRight}}), allow renaming the branch even if the new branch name already exists, the same applies for {{.EmphasisLeft}}-c{{.EmphasisRight}} (or {{.EmphasisLeft}}--copy{{.EmphasisRight}})."
 
 var branchSynopsis = []string{
-		`[--list] [-v] [-a]`,
-		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
-		`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
-		`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
-		`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,
-	}
+	`[--list] [-v] [-a]`,
+	`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
+	`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
+	`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
+	`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,
+}
 
 var BranchDocumentation = cli.CommandDocumentation{
 	ShortDesc: branchShortDesc,
-	LongDesc: branchLongDesc,
-	Synopsis: branchSynopsis,
+	LongDesc:  branchLongDesc,
+	Synopsis:  branchSynopsis,
 }
 
 const (

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -17,6 +17,8 @@ package commands
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/fatih/color"
 
@@ -30,9 +32,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
-
-	"sort"
-	"strings"
 )
 
 var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.GreaterThan}} to {{.LessThan}}startpoint{{.GreaterThan}}, even if {{.LessThan}}branchname{{.GreaterThan}} exists already. Without {{.EmphasisLeft}}-f{{.EmphasisRight}}, {{.EmphasisLeft}}dolt branch{{.EmphasisRight}} refuses to change an existing branch. In combination with {{.EmphasisLeft}}-d{{.EmphasisRight}} (or {{.EmphasisLeft}}--delete{{.EmphasisRight}}), allow deleting the branch irrespective of its merged status. In combination with -m (or {{.EmphasisLeft}}--move{{.EmphasisRight}}), allow renaming the branch even if the new branch name already exists, the same applies for {{.EmphasisLeft}}-c{{.EmphasisRight}} (or {{.EmphasisLeft}}--copy{{.EmphasisRight}})."

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -35,7 +35,11 @@ import (
 	"strings"
 )
 
-var branchLongDesc = `If {{.EmphasisLeft}}--list{{.EmphasisRight}} is given, or if there are no non-option arguments, existing branches are listed; the current branch will be highlighted with an asterisk.
+var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.GreaterThan}} to {{.LessThan}}startpoint{{.GreaterThan}}, even if {{.LessThan}}branchname{{.GreaterThan}} exists already. Without {{.EmphasisLeft}}-f{{.EmphasisRight}}, {{.EmphasisLeft}}dolt branch{{.EmphasisRight}} refuses to change an existing branch. In combination with {{.EmphasisLeft}}-d{{.EmphasisRight}} (or {{.EmphasisLeft}}--delete{{.EmphasisRight}}), allow deleting the branch irrespective of its merged status. In combination with -m (or {{.EmphasisLeft}}--move{{.EmphasisRight}}), allow renaming the branch even if the new branch name already exists, the same applies for {{.EmphasisLeft}}-c{{.EmphasisRight}} (or {{.EmphasisLeft}}--copy{{.EmphasisRight}})."
+
+var branchDocs = cli.CommandDocumentationContent{
+	ShortDesc: `List, create, or delete branches`,
+	LongDesc: `If {{.EmphasisLeft}}--list{{.EmphasisRight}} is given, or if there are no non-option arguments, existing branches are listed; the current branch will be highlighted with an asterisk.
 
 The command's second form creates a new branch head named {{.LessThan}}branchname{{.GreaterThan}} which points to the current {{.EmphasisLeft}}HEAD{{.EmphasisRight}}, or {{.LessThan}}start-point{{.GreaterThan}} if given.
 
@@ -45,24 +49,14 @@ With a {{.EmphasisLeft}}-m{{.EmphasisRight}}, {{.LessThan}}oldbranch{{.GreaterTh
 
 The {{.EmphasisLeft}}-c{{.EmphasisRight}} options have the exact same semantics as {{.EmphasisLeft}}-m{{.EmphasisRight}}, except instead of the branch being renamed it will be copied to a new name.
 
-With a {{.EmphasisLeft}}-d{{.EmphasisRight}}, {{.LessThan}}branchname{{.GreaterThan}} will be deleted. You may specify more than one branch for deletion.`
-
-var branchShortDesc = `List, create, or delete branches`
-
-var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.LessThan}} to {{.LessThan}}startpoint{{.LessThan}}, even if {{.LessThan}}branchname{{.LessThan}} exists already. Without {{.EmphasisLeft}}-f{{.EmphasisRight}}, {{.EmphasisLeft}}dolt branch{{.EmphasisRight}} refuses to change an existing branch. In combination with {{.EmphasisLeft}}-d{{.EmphasisRight}} (or {{.EmphasisLeft}}--delete{{.EmphasisRight}}), allow deleting the branch irrespective of its merged status. In combination with -m (or {{.EmphasisLeft}}--move{{.EmphasisRight}}), allow renaming the branch even if the new branch name already exists, the same applies for {{.EmphasisLeft}}-c{{.EmphasisRight}} (or {{.EmphasisLeft}}--copy{{.EmphasisRight}})."
-
-var branchSynopsis = []string{
-	`[--list] [-v] [-a]`,
-	`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
-	`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
-	`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
-	`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,
-}
-
-var BranchDocumentation = cli.CommandDocumentation{
-	ShortDesc: branchShortDesc,
-	LongDesc:  branchLongDesc,
-	Synopsis:  branchSynopsis,
+With a {{.EmphasisLeft}}-d{{.EmphasisRight}}, {{.LessThan}}branchname{{.GreaterThan}} will be deleted. You may specify more than one branch for deletion.`,
+	Synopsis: []string{
+		`[--list] [-v] [-a]`,
+		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
+		`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
+		`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
+		`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,
+	},
 }
 
 const (
@@ -91,7 +85,7 @@ func (cmd BranchCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd BranchCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, BranchDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, branchDocs, ap))
 }
 
 func (cmd BranchCmd) createArgParser() *argparser.ArgParser {
@@ -116,7 +110,7 @@ func (cmd BranchCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, BranchDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, branchDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	switch {

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -52,7 +52,7 @@ var branchForceFlagDesc = "Reset {{.LessThan}}branchname{{.LessThan}} to {{.Less
 
 var branchSynopsis = []string{
 		`[--list] [-v] [-a]`,
-		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point>{{.GreaterThan}}]`,
+		`[-f] {{.LessThan}}branchname{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
 		`-m [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
 		`-c [-f] [{{.LessThan}}oldbranch{{.GreaterThan}}] {{.LessThan}}newbranch{{.GreaterThan}}`,
 		`-d [-f] {{.LessThan}}branchname{{.GreaterThan}}...`,

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -28,8 +28,9 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var coShortDesc = `Switch branches or restore working tree tables`
-var coLongDesc = `
+var checkoutDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Switch branches or restore working tree tables`,
+	LongDesc: `
 Updates tables in the working set to match the staged versions. If no paths are given, dolt checkout will also update HEAD to set the specified branch as the current branch.
 
 dolt checkout {{.LessThan}}}branch{{.GreaterThan}}
@@ -40,18 +41,12 @@ dolt checkout -b {{.LessThan}}}new_branch{{.GreaterThan}} [{{.LessThan}}}start_p
    Specifying -b causes a new branch to be created as if dolt branch were called and then checked out.
 
 dolt checkout {{.LessThan}}}table{{.GreaterThan}}...
-  To update table(s) with their values in HEAD `
-
-var coSynopsis = []string{
-	`<branch>`,
-	`<table>...`,
-	`-b <new-branch> [<start-point>]`,
-}
-
-var coDocumentation = cli.CommandDocumentation{
-	ShortDesc: coShortDesc,
-	LongDesc:  coLongDesc,
-	Synopsis:  coSynopsis,
+  To update table(s) with their values in HEAD `,
+	Synopsis: []string{
+		`{{.LessThan}}branch{{.GreaterThan}}`,
+		`{{.LessThan}}table{{.GreaterThan}}...`,
+		`-b {{.LessThan}}new-branch{{.GreaterThan}} [{{.LessThan}}start-point{{.GreaterThan}}]`,
+	},
 }
 
 const coBranchArg = "b"
@@ -71,7 +66,7 @@ func (cmd CheckoutCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CheckoutCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, coDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, checkoutDocs, ap))
 }
 
 func (cmd CheckoutCmd) createArgParser() *argparser.ArgParser {
@@ -88,7 +83,7 @@ func (cmd CheckoutCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPrt, usagePrt := cli.HelpAndUsagePrinters(commandStr, coDocumentation, ap)
+	helpPrt, usagePrt := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, checkoutDocs, ap))
 	apr := cli.ParseArgs(ap, args, helpPrt)
 
 	if (apr.Contains(coBranchArg) && apr.NArg() > 1) || (!apr.Contains(coBranchArg) && apr.NArg() == 0) {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -42,17 +42,16 @@ dolt checkout -b {{.LessThan}}}new_branch{{.GreaterThan}} [{{.LessThan}}}start_p
 dolt checkout {{.LessThan}}}table{{.GreaterThan}}...
   To update table(s) with their values in HEAD `
 
-
-var coSynopsis = []string {
-		`<branch>`,
-		`<table>...`,
-		`-b <new-branch> [<start-point>]`,
-	}
+var coSynopsis = []string{
+	`<branch>`,
+	`<table>...`,
+	`-b <new-branch> [<start-point>]`,
+}
 
 var coDocumentation = cli.CommandDocumentation{
 	ShortDesc: coShortDesc,
-	LongDesc: coLongDesc,
-	Synopsis: coSynopsis,
+	LongDesc:  coLongDesc,
+	Synopsis:  coSynopsis,
 }
 
 const coBranchArg = "b"

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -29,22 +29,30 @@ import (
 )
 
 var coShortDesc = `Switch branches or restore working tree tables`
-var coLongDesc = `Updates tables in the working set to match the staged versions. If no paths are given, dolt checkout will also update HEAD to set the specified branch as the current branch.
+var coLongDesc = `
+Updates tables in the working set to match the staged versions. If no paths are given, dolt checkout will also update HEAD to set the specified branch as the current branch.
 
-dolt checkout <branch>
-   To prepare for working on <branch>, switch to it by updating the index and the tables in the working tree, and by pointing HEAD at the branch. Local modifications to the tables in the working
-   tree are kept, so that they can be committed to the <branch>.
+dolt checkout {{.LessThan}}}branch{{.GreaterThan}}
+   To prepare for working on {{.LessThan}}}branch{{.GreaterThan}}, switch to it by updating the index and the tables in the working tree, and by pointing HEAD at the branch. Local modifications to the tables in the working
+   tree are kept, so that they can be committed to the {{.LessThan}}}branch{{.GreaterThan}}.
 
-dolt checkout -b <new_branch> [<start_point>]
+dolt checkout -b {{.LessThan}}}new_branch{{.GreaterThan}} [{{.LessThan}}}start_point{{.GreaterThan}}]
    Specifying -b causes a new branch to be created as if dolt branch were called and then checked out.
 
-dolt checkout <table>...
+dolt checkout {{.LessThan}}}table{{.GreaterThan}}...
   To update table(s) with their values in HEAD `
 
-var coSynopsis = []string{
-	`<branch>`,
-	`<table>...`,
-	`-b <new-branch> [<start-point>]`,
+
+var coSynopsis = []string {
+		`<branch>`,
+		`<table>...`,
+		`-b <new-branch> [<start-point>]`,
+	}
+
+var coDocumentation = cli.CommandDocumentation{
+	ShortDesc: coShortDesc,
+	LongDesc: coLongDesc,
+	Synopsis: coSynopsis,
 }
 
 const coBranchArg = "b"
@@ -64,7 +72,7 @@ func (cmd CheckoutCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CheckoutCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, coShortDesc, coLongDesc, coSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, coDocumentation, ap)
 }
 
 func (cmd CheckoutCmd) createArgParser() *argparser.ArgParser {
@@ -81,7 +89,7 @@ func (cmd CheckoutCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPrt, usagePrt := cli.HelpAndUsagePrinters(commandStr, coShortDesc, coLongDesc, coSynopsis, ap)
+	helpPrt, usagePrt := cli.HelpAndUsagePrinters(commandStr, coDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, helpPrt)
 
 	if (apr.Contains(coBranchArg) && apr.NArg() > 1) || (!apr.Contains(coBranchArg) && apr.NArg() == 0) {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -77,7 +77,7 @@ func (cmd CheckoutCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr strin
 
 func (cmd CheckoutCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsString(coBranchArg, "", "branch", "Create a new branch named <new_branch> and start it at <start_point>.")
+	ap.SupportsString(coBranchArg, "", "branch", "Create a new branch named {{.LessThan}}new_branch{{.GreaterThan}} and start it at {{.LessThan}}start_point{{.GreaterThan}}.")
 	return ap
 }
 

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -17,6 +17,11 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -33,10 +38,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/strhelp"
 	"github.com/liquidata-inc/dolt/go/store/datas"
 	"github.com/liquidata-inc/dolt/go/store/types"
-	"os"
-	"path"
-	"path/filepath"
-	"sync"
 )
 
 const (
@@ -53,13 +54,13 @@ This default configuration is achieved by creating references to the remote bran
 `
 
 var cloneSynopsis = []string{
-		"[-remote {{.LessThan}}remote{{.GreaterThan}}] [-branch {{.LessThan}}branch{{.GreaterThan}}]  [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}remote-url{{.GreaterThan}} <new-dir{{.GreaterThan}}",
-	}
+	"[-remote {{.LessThan}}remote{{.GreaterThan}}] [-branch {{.LessThan}}branch{{.GreaterThan}}]  [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}remote-url{{.GreaterThan}} <new-dir{{.GreaterThan}}",
+}
 
 var cloneDocumentation = cli.CommandDocumentation{
 	ShortDesc: cloneShortDesc,
-	LongDesc: cloneLongDesc,
-	Synopsis: cloneSynopsis,
+	LongDesc:  cloneLongDesc,
+	Synopsis:  cloneSynopsis,
 }
 
 type CloneCmd struct{}

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -17,11 +17,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"os"
-	"path"
-	"path/filepath"
-	"sync"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -38,6 +33,10 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/strhelp"
 	"github.com/liquidata-inc/dolt/go/store/datas"
 	"github.com/liquidata-inc/dolt/go/store/types"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
 )
 
 const (
@@ -46,17 +45,21 @@ const (
 )
 
 var cloneShortDesc = "Clone a data repository into a new directory"
-var cloneLongDesc = "Clones a repository into a newly created directory, creates remote-tracking branches for each " +
-	"branch in the cloned repository (visible using dolt branch -a), and creates and checks out an initial branch that " +
-	"is forked from the cloned repository's currently active branch.\n" +
-	"\n" +
-	"After the clone, a plain <b>dolt fetch</b> without arguments will update all the remote-tracking branches, and a <b>dolt " +
-	"pull</b> without arguments will in addition merge the remote branch into the current branch\n" +
-	"\n" +
-	"This default configuration is achieved by creating references to the remote branch heads under refs/remotes/origin " +
-	"and by creating a remote named 'origin'."
+var cloneLongDesc = `Clones a repository into a newly created directory, creates remote-tracking branches for each branch in the cloned repository (visible using {{.LessThan}}dolt branch -a{{.GreaterThan}}), and creates and checks out an initial branch that is forked from the cloned repository's currently active branch.
+
+After the clone, a plain {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} without arguments will update all the remote-tracking branches, and a {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} without arguments will in addition merge the remote branch into the current branch.
+
+This default configuration is achieved by creating references to the remote branch heads under {{.LessThan}}refs/remotes/origin{{.GreaterThan}}  and by creating a remote named 'origin'.
+`
+
 var cloneSynopsis = []string{
-	"[-remote <remote>] [-branch <branch>]  [--aws-region <region>] [--aws-creds-type <creds-type>] [--aws-creds-file <file>] [--aws-creds-profile <profile>] <remote-url> <new-dir>",
+		"[-remote <remote>] [-branch <branch>]  [--aws-region <region>] [--aws-creds-type <creds-type>] [--aws-creds-file <file>] [--aws-creds-profile <profile>] <remote-url> <new-dir>",
+	}
+
+var cloneDocumentation = cli.CommandDocumentation{
+	ShortDesc: cloneShortDesc,
+	LongDesc: cloneLongDesc,
+	Synopsis: cloneSynopsis,
 }
 
 type CloneCmd struct{}
@@ -80,7 +83,7 @@ func (cmd CloneCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CloneCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, cloneShortDesc, cloneLongDesc, cloneSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, cloneDocumentation, ap)
 }
 
 func (cmd CloneCmd) createArgParser() *argparser.ArgParser {
@@ -102,7 +105,7 @@ func (cmd CloneCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, cloneShortDesc, cloneLongDesc, cloneSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, cloneDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	remoteName := apr.GetValueOrDefault(remoteParam, "origin")

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -45,22 +45,17 @@ const (
 	branchParam = "branch"
 )
 
-var cloneShortDesc = "Clone a data repository into a new directory"
-var cloneLongDesc = `Clones a repository into a newly created directory, creates remote-tracking branches for each branch in the cloned repository (visible using {{.LessThan}}dolt branch -a{{.GreaterThan}}), and creates and checks out an initial branch that is forked from the cloned repository's currently active branch.
+var cloneDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Clone a data repository into a new directory",
+	LongDesc: `Clones a repository into a newly created directory, creates remote-tracking branches for each branch in the cloned repository (visible using {{.LessThan}}dolt branch -a{{.GreaterThan}}), and creates and checks out an initial branch that is forked from the cloned repository's currently active branch.
 
 After the clone, a plain {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} without arguments will update all the remote-tracking branches, and a {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} without arguments will in addition merge the remote branch into the current branch.
 
 This default configuration is achieved by creating references to the remote branch heads under {{.LessThan}}refs/remotes/origin{{.GreaterThan}}  and by creating a remote named 'origin'.
-`
-
-var cloneSynopsis = []string{
-	"[-remote {{.LessThan}}remote{{.GreaterThan}}] [-branch {{.LessThan}}branch{{.GreaterThan}}]  [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}remote-url{{.GreaterThan}} <new-dir{{.GreaterThan}}",
-}
-
-var cloneDocumentation = cli.CommandDocumentation{
-	ShortDesc: cloneShortDesc,
-	LongDesc:  cloneLongDesc,
-	Synopsis:  cloneSynopsis,
+`,
+	Synopsis: []string{
+		"[-remote {{.LessThan}}remote{{.GreaterThan}}] [-branch {{.LessThan}}branch{{.GreaterThan}}]  [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}remote-url{{.GreaterThan}} {{.LessThan}}new-dir{{.GreaterThan}}",
+	},
 }
 
 type CloneCmd struct{}
@@ -84,7 +79,7 @@ func (cmd CloneCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CloneCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, cloneDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, cloneDocs, ap))
 }
 
 func (cmd CloneCmd) createArgParser() *argparser.ArgParser {
@@ -106,7 +101,7 @@ func (cmd CloneCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, cloneDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cloneDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remoteName := apr.GetValueOrDefault(remoteParam, "origin")

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -53,7 +53,7 @@ This default configuration is achieved by creating references to the remote bran
 `
 
 var cloneSynopsis = []string{
-		"[-remote <remote>] [-branch <branch>]  [--aws-region <region>] [--aws-creds-type <creds-type>] [--aws-creds-file <file>] [--aws-creds-profile <profile>] <remote-url> <new-dir>",
+		"[-remote {{.LessThan}}remote{{.GreaterThan}}] [-branch {{.LessThan}}branch{{.GreaterThan}}]  [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}remote-url{{.GreaterThan}} <new-dir{{.GreaterThan}}",
 	}
 
 var cloneDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -37,10 +37,9 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
 
-
 var catDocs = cli.CommandDocumentationContent{
 	ShortDesc: "print conflicts",
-	LongDesc: `The dolt conflicts cat command reads table conflicts and writes them to the standard output.`,
+	LongDesc:  `The dolt conflicts cat command reads table conflicts and writes them to the standard output.`,
 	Synopsis: []string{
 		"[{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}}...",
 	},

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -37,16 +37,13 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
 
-var catShortDesc = "print conflicts"
-var catLongDesc = `The dolt conflicts cat command reads table conflicts and writes them to the standard output.`
-var catSynopsis = []string{
-	"[{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}}...",
-}
 
-var catDocumentation = cli.CommandDocumentation{
-	ShortDesc: catShortDesc,
-	LongDesc:  catLongDesc,
-	Synopsis:  catSynopsis,
+var catDocs = cli.CommandDocumentationContent{
+	ShortDesc: "print conflicts",
+	LongDesc: `The dolt conflicts cat command reads table conflicts and writes them to the standard output.`,
+	Synopsis: []string{
+		"[{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}}...",
+	},
 }
 
 type CatCmd struct{}
@@ -64,7 +61,7 @@ func (cmd CatCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CatCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, catDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, catDocs, ap))
 }
 
 // EventType returns the type of the event to log
@@ -82,7 +79,7 @@ func (cmd CatCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, catDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, catDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -40,7 +40,7 @@ import (
 var catShortDesc = "print conflicts"
 var catLongDesc = `The dolt conflicts cat command reads table conflicts and writes them to the standard output.`
 var catSynopsis = []string{
-	"[<commit>] <table>...",
+	"[{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}}...",
 }
 
 var catDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -43,6 +43,12 @@ var catSynopsis = []string{
 	"[<commit>] <table>...",
 }
 
+var catDocumentation = cli.CommandDocumentation{
+	ShortDesc: catShortDesc,
+	LongDesc: catLongDesc,
+	Synopsis: catSynopsis,
+}
+
 type CatCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -58,7 +64,7 @@ func (cmd CatCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CatCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, catShortDesc, catLongDesc, catSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, catDocumentation, ap)
 }
 
 // EventType returns the type of the event to log
@@ -76,7 +82,7 @@ func (cmd CatCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, catShortDesc, catLongDesc, catSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, catDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -45,8 +45,8 @@ var catSynopsis = []string{
 
 var catDocumentation = cli.CommandDocumentation{
 	ShortDesc: catShortDesc,
-	LongDesc: catLongDesc,
-	Synopsis: catSynopsis,
+	LongDesc:  catLongDesc,
+	Synopsis:  catSynopsis,
 }
 
 type CatCmd struct{}

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -30,25 +30,21 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-var resShortDesc = "Removes rows from list of conflicts"
 
-var resLongDesc = `
+
+var resDocumentation = cli.CommandDocumentationContent{
+	ShortDesc: "Removes rows from list of conflicts",
+	LongDesc: `
 When a merge operation finds conflicting changes, the rows with the conflicts are added to list of conflicts that must be resolved.  Once the value for the row is resolved in the working set of tables, then the conflict should be resolved.
 		
 In it's first form {{.EmphasisLeft}}dolt conflicts resolve <table> <key>...{{.EmphasisRight}}, resolve runs in manual merge mode resolving the conflicts whose keys are provided.
 
 In it's second form {{.EmphasisLeft}}dolt conflicts resolve --ours|--theirs <table>...{{.EmphasisRight}}, resolve runs in auto resolve mode. Where conflicts are resolved using a rule to determine which version of a row should be used.
-`
-
-var resSynopsis = []string{
-	`{{.LessThan}}table{{.GreaterThan}} [{{.LessThan}}key_definition{{.GreaterThan}}] {{.LessThan}}key{{.GreaterThan}}...`,
-	`--ours|--theirs {{.LessThan}}table{{.GreaterThan}}...`,
-}
-
-var resDocumentation = cli.CommandDocumentation{
-	ShortDesc: resShortDesc,
-	LongDesc:  resLongDesc,
-	Synopsis:  resSynopsis,
+`,
+	Synopsis: []string{
+		`{{.LessThan}}table{{.GreaterThan}} [{{.LessThan}}key_definition{{.GreaterThan}}] {{.LessThan}}key{{.GreaterThan}}...`,
+		`--ours|--theirs {{.LessThan}}table{{.GreaterThan}}...`,
+	},
 }
 
 const (
@@ -85,7 +81,7 @@ func (cmd ResolveCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ResolveCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, resDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, resDocumentation, ap))
 }
 
 // EventType returns the type of the event to log
@@ -106,7 +102,7 @@ func (cmd ResolveCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, resDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, resDocumentation, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -31,18 +31,24 @@ import (
 )
 
 var resShortDesc = "Removes rows from list of conflicts"
-var resLongDesc = "When a merge operation finds conflicting changes, the rows with the conflicts are added to list " +
-	"of conflicts that must be resolved.  Once the value for the row is resolved in the working set of tables, then " +
-	"the conflict should be resolved.\n" +
-	"\n" +
-	"In it's first form <b>dolt conflicts resolve <table> <key>...</b>, resolve runs in manual merge mode resolving " +
-	"the conflicts whose keys are provided.\n" +
-	"\n" +
-	"In it's second form <b>dolt conflicts resolve --ours|--theirs <table>...</b>, resolve runs in auto resolve mode. " +
-	"where conflicts are resolved using a rule to determine which version of a row should be used."
+
+var resLongDesc = `
+When a merge operation finds conflicting changes, the rows with the conflicts are added to list of conflicts that must be resolved.  Once the value for the row is resolved in the working set of tables, then the conflict should be resolved.
+		
+In it's first form <b>dolt conflicts resolve <table> <key>...</b>, resolve runs in manual merge mode resolving the conflicts whose keys are provided.\n +
+
+In it's second form <b>dolt conflicts resolve --ours|--theirs <table>...</b>, resolve runs in auto resolve mode. Where conflicts are resolved using a rule to determine which version of a row should be used.
+`
+
 var resSynopsis = []string{
-	"<table> [<key_definition>] <key>...",
-	"--ours|--theirs <table>...",
+		`<table> [<key_definition>] <key>...`,
+		`--ours|--theirs <table>...`,
+	}
+
+var resDocumentation = cli.CommandDocumentation{
+	ShortDesc: resShortDesc,
+	LongDesc: resLongDesc,
+	Synopsis: resSynopsis,
 }
 
 const (
@@ -79,7 +85,7 @@ func (cmd ResolveCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ResolveCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, resShortDesc, resLongDesc, resSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, resDocumentation, ap)
 }
 
 // EventType returns the type of the event to log
@@ -100,7 +106,7 @@ func (cmd ResolveCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, resShortDesc, resLongDesc, resSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, resDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -35,14 +35,14 @@ var resShortDesc = "Removes rows from list of conflicts"
 var resLongDesc = `
 When a merge operation finds conflicting changes, the rows with the conflicts are added to list of conflicts that must be resolved.  Once the value for the row is resolved in the working set of tables, then the conflict should be resolved.
 		
-In it's first form <b>dolt conflicts resolve <table> <key>...</b>, resolve runs in manual merge mode resolving the conflicts whose keys are provided.\n +
+In it's first form {{.EmphasisLeft}}dolt conflicts resolve <table> <key>...{{.EmphasisRight}}, resolve runs in manual merge mode resolving the conflicts whose keys are provided.
 
-In it's second form <b>dolt conflicts resolve --ours|--theirs <table>...</b>, resolve runs in auto resolve mode. Where conflicts are resolved using a rule to determine which version of a row should be used.
+In it's second form {{.EmphasisLeft}}dolt conflicts resolve --ours|--theirs <table>...{{.EmphasisRight}}, resolve runs in auto resolve mode. Where conflicts are resolved using a rule to determine which version of a row should be used.
 `
 
 var resSynopsis = []string{
-		`<table> [<key_definition>] <key>...`,
-		`--ours|--theirs <table>...`,
+		`{{.LessThan}}table{{.GreaterThan}} [{{.LessThan}}key_definition{{.GreaterThan}}] {{.LessThan}}key{{.GreaterThan}}...`,
+		`--ours|--theirs {{.LessThan}}table{{.GreaterThan}}...`,
 	}
 
 var resDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -41,14 +41,14 @@ In it's second form {{.EmphasisLeft}}dolt conflicts resolve --ours|--theirs <tab
 `
 
 var resSynopsis = []string{
-		`{{.LessThan}}table{{.GreaterThan}} [{{.LessThan}}key_definition{{.GreaterThan}}] {{.LessThan}}key{{.GreaterThan}}...`,
-		`--ours|--theirs {{.LessThan}}table{{.GreaterThan}}...`,
-	}
+	`{{.LessThan}}table{{.GreaterThan}} [{{.LessThan}}key_definition{{.GreaterThan}}] {{.LessThan}}key{{.GreaterThan}}...`,
+	`--ours|--theirs {{.LessThan}}table{{.GreaterThan}}...`,
+}
 
 var resDocumentation = cli.CommandDocumentation{
 	ShortDesc: resShortDesc,
-	LongDesc: resLongDesc,
-	Synopsis: resSynopsis,
+	LongDesc:  resLongDesc,
+	Synopsis:  resSynopsis,
 }
 
 const (

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -30,8 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-
-
 var resDocumentation = cli.CommandDocumentationContent{
 	ShortDesc: "Removes rows from list of conflicts",
 	LongDesc: `

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -50,13 +50,13 @@ The log message can be added with the parameter {{.LessThan}}-m <msg>{{.GreaterT
 The commit timestamp can be modified using the --date parameter.  Dates can be specified in the formats {{.LessThan}}YYYY-MM-DD{{.GreaterThan}}, {{.LessThan}}YYYY-MM-DDTHH:MM:SS{{.GreaterThan}}, or {{.LessThan}}YYYY-MM-DDTHH:MM:SSZ07:00{{.GreaterThan}} (where {{.LessThan}}07:00{{.GreaterThan}} is the time zone offset)."
 `
 var commitSynopsis = []string{
-		"[options]",
-	}
+	"[options]",
+}
 
 var commitDocumentation = cli.CommandDocumentation{
 	ShortDesc: commitShortDesc,
-	LongDesc: commitLongDesc,
-	Synopsis: commitSynopsis,
+	LongDesc:  commitLongDesc,
+	Synopsis:  commitSynopsis,
 }
 
 type CommitCmd struct{}

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -39,20 +39,24 @@ const (
 	commitMessageArg = "message"
 )
 
-var commitShortDesc = `Record changes to the repository`
-var commitLongDesc = "Stores the current contents of the staged tables in a new commit along with a log message from the " +
-	"user describing the changes.\n" +
-	"\n" +
-	"The content to be added can be specified by using dolt add to incrementally \"add\" changes to the staged tables " +
-	"before using the commit command (Note: even modified files must be \"added\");" +
-	"\n" +
-	"The log message can be added with the parameter -m <msg>.  If the -m parameter is not provided an editor will be " +
-	"opened where you can review the commit and provide a log message.\n" +
-	"\n" +
-	"The commit timestamp can be modified using the --date parameter.  Dates can be specified in the formats YYYY-MM-DD " +
-	"YYYY-MM-DDTHH:MM:SS, or YYYY-MM-DDTHH:MM:SSZ07:00 (where 07:00 is the time zone offset)."
+var commitShortDesc = "Record changes to the repository"
+var commitLongDesc = `
+Stores the current contents of the staged tables in a new commit along with a log message from the user describing the changes.
+
+The content to be added can be specified by using dolt add to incrementally \"add\" changes to the staged tables before using the commit command (Note: even modified files must be \"added\").
+
+The log message can be added with the parameter {{.LessThan}}-m <msg>{{.GreaterThan}}.  If the {{.LessThan}}-m{{.GreaterThan}} parameter is not provided an editor will be opened where you can review the commit and provide a log message.
+
+The commit timestamp can be modified using the --date parameter.  Dates can be specified in the formats {{.LessThan}}YYYY-MM-DD{{.GreaterThan}}, {{.LessThan}}YYYY-MM-DDTHH:MM:SS{{.GreaterThan}}, or {{.LessThan}}YYYY-MM-DDTHH:MM:SSZ07:00{{.GreaterThan}} (where {{.LessThan}}07:00{{.GreaterThan}} is the time zone offset)."
+`
 var commitSynopsis = []string{
-	"[options]",
+		"[options]",
+	}
+
+var commitDocumentation = cli.CommandDocumentation{
+	ShortDesc: commitShortDesc,
+	LongDesc: commitLongDesc,
+	Synopsis: commitSynopsis,
 }
 
 type CommitCmd struct{}
@@ -70,7 +74,7 @@ func (cmd CommitCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CommitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, commitShortDesc, commitLongDesc, commitSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, commitDocumentation, ap)
 }
 
 func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
@@ -84,7 +88,7 @@ func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, commitShortDesc, commitLongDesc, commitSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, commitDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	msg, msgOk := apr.GetValue(commitMessageArg)

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -79,7 +79,7 @@ func (cmd CommitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string)
 
 func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsString(commitMessageArg, "m", "msg", "Use the given <msg> as the commit message.")
+	ap.SupportsString(commitMessageArg, "m", "msg", "Use the given {{.LessThan}}msg{{.GreaterThan}} as the commit message.")
 	ap.SupportsFlag(allowEmptyFlag, "", "Allow recording a commit that has the exact same data as its sole parent. This is usually a mistake, so it is disabled by default. This option bypasses that safety.")
 	ap.SupportsString(dateParam, "", "date", "Specify the date used in the commit. If not specified the current system time is used.")
 	return ap

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -39,24 +39,20 @@ const (
 	commitMessageArg = "message"
 )
 
-var commitShortDesc = "Record changes to the repository"
-var commitLongDesc = `
-Stores the current contents of the staged tables in a new commit along with a log message from the user describing the changes.
-
-The content to be added can be specified by using dolt add to incrementally \"add\" changes to the staged tables before using the commit command (Note: even modified files must be \"added\").
-
-The log message can be added with the parameter {{.LessThan}}-m <msg>{{.GreaterThan}}.  If the {{.LessThan}}-m{{.GreaterThan}} parameter is not provided an editor will be opened where you can review the commit and provide a log message.
-
-The commit timestamp can be modified using the --date parameter.  Dates can be specified in the formats {{.LessThan}}YYYY-MM-DD{{.GreaterThan}}, {{.LessThan}}YYYY-MM-DDTHH:MM:SS{{.GreaterThan}}, or {{.LessThan}}YYYY-MM-DDTHH:MM:SSZ07:00{{.GreaterThan}} (where {{.LessThan}}07:00{{.GreaterThan}} is the time zone offset)."
-`
-var commitSynopsis = []string{
-	"[options]",
-}
-
-var commitDocumentation = cli.CommandDocumentation{
-	ShortDesc: commitShortDesc,
-	LongDesc:  commitLongDesc,
-	Synopsis:  commitSynopsis,
+var commitDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Record changes to the repository",
+	LongDesc: `
+	Stores the current contents of the staged tables in a new commit along with a log message from the user describing the changes.
+	
+	The content to be added can be specified by using dolt add to incrementally \"add\" changes to the staged tables before using the commit command (Note: even modified files must be \"added\").
+	
+	The log message can be added with the parameter {{.EmphasisLeft}}-m <msg>{{.EmphasisRight}}.  If the {{.LessThan}}-m{{.GreaterThan}} parameter is not provided an editor will be opened where you can review the commit and provide a log message.
+	
+	The commit timestamp can be modified using the --date parameter.  Dates can be specified in the formats {{.LessThan}}YYYY-MM-DD{{.GreaterThan}}, {{.LessThan}}YYYY-MM-DDTHH:MM:SS{{.GreaterThan}}, or {{.LessThan}}YYYY-MM-DDTHH:MM:SSZ07:00{{.GreaterThan}} (where {{.LessThan}}07:00{{.GreaterThan}} is the time zone offset)."
+	`,
+	Synopsis: []string{
+		"[options]",
+	},
 }
 
 type CommitCmd struct{}
@@ -74,7 +70,7 @@ func (cmd CommitCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CommitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, commitDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, commitDocs, ap))
 }
 
 func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
@@ -88,7 +84,7 @@ func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, commitDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, commitDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	msg, msgOk := apr.GetValue(commitMessageArg)

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -38,25 +38,21 @@ const (
 	unsetOperationStr = "unset"
 )
 
-var cfgShortDesc = `Get and set repository or global options`
-var cfgLongDesc = `You can query/set/replace/unset options with this command.
+var cfgDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Get and set repository or global options`,
+	LongDesc: `You can query/set/replace/unset options with this command.
+		
+	When reading, the values are read from the global and repository local configuration files, and options {{.LessThan}}--global{{.GreaterThan}}, and {{.LessThan}}--local{{.GreaterThan}} can be used to tell the command to read from only that location.
 	
-When reading, the values are read from the global and repository local configuration files, and options {{.LessThan}}--global{{.GreaterThan}}, and {{.LessThan}}--local{{.GreaterThan}} can be used to tell the command to read from only that location.
+	When writing, the new value is written to the repository local configuration file by default, and options {{.LessThan}}--global{{.GreaterThan}}, can be used to tell the command to write to that location (you can say {{.LessThan}}--local{{.GreaterThan}} but that is the default).
+`,
 
-When writing, the new value is written to the repository local configuration file by default, and options {{.LessThan}}--global{{.GreaterThan}}, can be used to tell the command to write to that location (you can say {{.LessThan}}--local{{.GreaterThan}} but that is the default).
-	`
-
-var cfgSynopsis = []string{
-	`[--global|--local] --list`,
-	`[--global|--local] --add {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}value{{.GreaterThan}}`,
-	`[--global|--local] --get {{.LessThan}}name{{.GreaterThan}}`,
-	`[--global|--local] --unset {{.LessThan}}name{{.GreaterThan}}...`,
-}
-
-var cfgDocumentation = cli.CommandDocumentation{
-	ShortDesc: cfgShortDesc,
-	LongDesc:  cfgLongDesc,
-	Synopsis:  cfgSynopsis,
+	Synopsis: []string{
+		`[--global|--local] --list`,
+		`[--global|--local] --add {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}value{{.GreaterThan}}`,
+		`[--global|--local] --get {{.LessThan}}name{{.GreaterThan}}`,
+		`[--global|--local] --unset {{.LessThan}}name{{.GreaterThan}}...`,
+	},
 }
 
 type ConfigCmd struct{}
@@ -80,7 +76,7 @@ func (cmd ConfigCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ConfigCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, cfgDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, cfgDocs, ap))
 }
 
 func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
@@ -98,7 +94,7 @@ func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ConfigCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, cfgDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cfgDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	cfgTypes := apr.FlagsEqualTo([]string{globalParamName, localParamName}, true)

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -39,7 +39,7 @@ const (
 )
 
 var cfgShortDesc = `Get and set repository or global options`
-var cfgLongDesc= `You can query/set/replace/unset options with this command.
+var cfgLongDesc = `You can query/set/replace/unset options with this command.
 	
 When reading, the values are read from the global and repository local configuration files, and options {{.LessThan}}--global{{.GreaterThan}}, and {{.LessThan}}--local{{.GreaterThan}} can be used to tell the command to read from only that location.
 
@@ -47,18 +47,17 @@ When writing, the new value is written to the repository local configuration fil
 	`
 
 var cfgSynopsis = []string{
-		`[--global|--local] --list`,
-		`[--global|--local] --add {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}value{{.GreaterThan}}`,
-		`[--global|--local] --get {{.LessThan}}name{{.GreaterThan}}`,
-		`[--global|--local] --unset {{.LessThan}}name{{.GreaterThan}}...`,
-	}
+	`[--global|--local] --list`,
+	`[--global|--local] --add {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}value{{.GreaterThan}}`,
+	`[--global|--local] --get {{.LessThan}}name{{.GreaterThan}}`,
+	`[--global|--local] --unset {{.LessThan}}name{{.GreaterThan}}...`,
+}
 
 var cfgDocumentation = cli.CommandDocumentation{
 	ShortDesc: cfgShortDesc,
-	LongDesc: cfgLongDesc,
-	Synopsis: cfgSynopsis,
+	LongDesc:  cfgLongDesc,
+	Synopsis:  cfgSynopsis,
 }
-
 
 type ConfigCmd struct{}
 

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -39,17 +39,26 @@ const (
 )
 
 var cfgShortDesc = `Get and set repository or global options`
-var cfgLongDesc = `You can query/set/replace/unset options with this command.
+var cfgLongDesc= `You can query/set/replace/unset options with this command.
+	
+When reading, the values are read from the global and repository local configuration files, and options {{.LessThan}}--global{{.GreaterThan}}, and {{.LessThan}}--local{{.GreaterThan}} can be used to tell the command to read from only that location.
 
-When reading, the values are read from the global and repository local configuration files, and options --global, and --local can be used to tell the command to read from only that location.
+When writing, the new value is written to the repository local configuration file by default, and options {{.LessThan}}--global{{.GreaterThan}}, can be used to tell the command to write to that location (you can say {{.LessThan}}--local{{.GreaterThan}} but that is the default).
+	`
 
-When writing, the new value is written to the repository local configuration file by default, and options --global, can be used to tell the command to write to that location (you can say --local but that is the default).`
 var cfgSynopsis = []string{
-	"[--global|--local] --list",
-	"[--global|--local] --add <name> <value>",
-	"[--global|--local] --get <name>",
-	"[--global|--local] --unset <name>...",
+		`[--global|--local] --list`,
+		`[--global|--local] --add {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}value{{.GreaterThan}}`,
+		`[--global|--local] --get {{.LessThan}}name{{.GreaterThan}}`,
+		`[--global|--local] --unset {{.LessThan}}name{{.GreaterThan}}...`,
+	}
+
+var cfgDocumentation = cli.CommandDocumentation{
+	ShortDesc: cfgShortDesc,
+	LongDesc: cfgLongDesc,
+	Synopsis: cfgSynopsis,
 }
+
 
 type ConfigCmd struct{}
 
@@ -72,7 +81,7 @@ func (cmd ConfigCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ConfigCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, cfgShortDesc, cfgLongDesc, cfgSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, cfgDocumentation, ap)
 }
 
 func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
@@ -90,7 +99,7 @@ func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ConfigCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, cfgShortDesc, cfgLongDesc, cfgSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, cfgDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	cfgTypes := apr.FlagsEqualTo([]string{globalParamName, localParamName}, true)

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -34,6 +34,12 @@ var checkShortDesc = "Check authenticating with a credential keypair against a d
 var checkLongDesc = `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`
 var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds <eak95022q3vskvumn2fcrpibdnheq1dtr8t...>]"}
 
+var checkDocumentation = cli.CommandDocumentation{
+	ShortDesc: checkShortDesc,
+	LongDesc: checkLongDesc,
+	Synopsis: checkSynopsis,
+}
+
 type CheckCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -49,7 +55,7 @@ func (cmd CheckCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CheckCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, checkShortDesc, checkLongDesc, checkSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, checkDocumentation, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -73,7 +79,7 @@ func (cmd CheckCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CheckCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, lsShortDesc, lsLongDesc, lsSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, checkDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	endpoint := loadEndpoint(dEnv, apr)

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -32,7 +32,7 @@ import (
 
 var checkShortDesc = "Check authenticating with a credential keypair against a doltremoteapi."
 var checkLongDesc = `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`
-var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds <eak95022q3vskvumn2fcrpibdnheq1dtr8t...>]"}
+var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds {{.LessThan}}eak95022q3vskvumn2fcrpibdnheq1dtr8t...{{.GreaterThan}}]"}
 
 var checkDocumentation = cli.CommandDocumentation{
 	ShortDesc: checkShortDesc,

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -36,8 +36,8 @@ var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--cred
 
 var checkDocumentation = cli.CommandDocumentation{
 	ShortDesc: checkShortDesc,
-	LongDesc: checkLongDesc,
-	Synopsis: checkSynopsis,
+	LongDesc:  checkLongDesc,
+	Synopsis:  checkSynopsis,
 }
 
 type CheckCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -36,9 +36,8 @@ var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--cred
 
 var checkDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Check authenticating with a credential keypair against a doltremoteapi.",
-	LongDesc: `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`,
-	Synopsis: []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds {{.LessThan}}eak95022q3vskvumn2fcrpibdnheq1dtr8t...{{.GreaterThan}}]"},
-
+	LongDesc:  `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`,
+	Synopsis:  []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds {{.LessThan}}eak95022q3vskvumn2fcrpibdnheq1dtr8t...{{.GreaterThan}}]"},
 }
 
 type CheckCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -34,10 +34,11 @@ var checkShortDesc = "Check authenticating with a credential keypair against a d
 var checkLongDesc = `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`
 var checkSynopsis = []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds {{.LessThan}}eak95022q3vskvumn2fcrpibdnheq1dtr8t...{{.GreaterThan}}]"}
 
-var checkDocumentation = cli.CommandDocumentation{
-	ShortDesc: checkShortDesc,
-	LongDesc:  checkLongDesc,
-	Synopsis:  checkSynopsis,
+var checkDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Check authenticating with a credential keypair against a doltremoteapi.",
+	LongDesc: `Tests calling a doltremoteapi with dolt credentials and reports the authentication result.`,
+	Synopsis: []string{"[--endpoint doltremoteapi.dolthub.com:443] [--creds {{.LessThan}}eak95022q3vskvumn2fcrpibdnheq1dtr8t...{{.GreaterThan}}]"},
+
 }
 
 type CheckCmd struct{}
@@ -55,7 +56,7 @@ func (cmd CheckCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CheckCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, checkDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, checkDocs, ap))
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -79,7 +80,7 @@ func (cmd CheckCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CheckCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, checkDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, checkDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	endpoint := loadEndpoint(dEnv, apr)

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -33,7 +33,7 @@ import (
 var lsShortDesc = "List keypairs available for authenticating with doltremoteapi."
 var lsLongDesc = `Lists known public keys from keypairs for authenticating with doltremoteapi.
 
-The currently selected keypair appears with a '*' next to it.`
+The currently selected keypair appears with a {{.EmphasisLeft}}*{{.EmphasisRight}} next to it.`
 var lsSynopsis = []string{"[-v | --verbose]"}
 
 var lsDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -30,8 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
-
 var lsDocs = cli.CommandDocumentationContent{
 	ShortDesc: "List keypairs available for authenticating with doltremoteapi.",
 	LongDesc: `Lists known public keys from keypairs for authenticating with doltremoteapi.

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -38,8 +38,8 @@ var lsSynopsis = []string{"[-v | --verbose]"}
 
 var lsDocumentation = cli.CommandDocumentation{
 	ShortDesc: lsShortDesc,
-	LongDesc: lsLongDesc,
-	Synopsis: lsSynopsis,
+	LongDesc:  lsLongDesc,
+	Synopsis:  lsSynopsis,
 }
 
 var lsVerbose = false

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -30,16 +30,14 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var lsShortDesc = "List keypairs available for authenticating with doltremoteapi."
-var lsLongDesc = `Lists known public keys from keypairs for authenticating with doltremoteapi.
 
-The currently selected keypair appears with a {{.EmphasisLeft}}*{{.EmphasisRight}} next to it.`
-var lsSynopsis = []string{"[-v | --verbose]"}
 
-var lsDocumentation = cli.CommandDocumentation{
-	ShortDesc: lsShortDesc,
-	LongDesc:  lsLongDesc,
-	Synopsis:  lsSynopsis,
+var lsDocs = cli.CommandDocumentationContent{
+	ShortDesc: "List keypairs available for authenticating with doltremoteapi.",
+	LongDesc: `Lists known public keys from keypairs for authenticating with doltremoteapi.
+
+The currently selected keypair appears with a {{.EmphasisLeft}}*{{.EmphasisRight}} next to it.`,
+	Synopsis: []string{"[-v | --verbose]"},
 }
 
 var lsVerbose = false
@@ -53,13 +51,13 @@ func (cmd LsCmd) Name() string {
 
 // Description returns a description of the command
 func (cmd LsCmd) Description() string {
-	return lsShortDesc
+	return lsDocs.ShortDesc
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, lsDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, lsDocs, ap))
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -82,7 +80,7 @@ func (cmd LsCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, lsDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, lsDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.Contains("verbose") {

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -36,6 +36,12 @@ var lsLongDesc = `Lists known public keys from keypairs for authenticating with 
 The currently selected keypair appears with a '*' next to it.`
 var lsSynopsis = []string{"[-v | --verbose]"}
 
+var lsDocumentation = cli.CommandDocumentation{
+	ShortDesc: lsShortDesc,
+	LongDesc: lsLongDesc,
+	Synopsis: lsSynopsis,
+}
+
 var lsVerbose = false
 
 type LsCmd struct{}
@@ -53,7 +59,7 @@ func (cmd LsCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, lsShortDesc, lsLongDesc, lsSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, lsDocumentation, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -76,7 +82,7 @@ func (cmd LsCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, lsShortDesc, lsLongDesc, lsSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, lsDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.Contains("verbose") {

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -29,8 +29,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
-
 var newDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Create a new public/private keypair for authenticating with doltremoteapi.",
 	LongDesc: `Creates a new keypair for authenticating with doltremoteapi.

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -37,8 +37,8 @@ var newSynopsis = []string{}
 
 var newDocumentation = cli.CommandDocumentation{
 	ShortDesc: newShortDesc,
-	LongDesc: newLongDesc,
-	Synopsis: newSynopsis,
+	LongDesc:  newLongDesc,
+	Synopsis:  newSynopsis,
 }
 
 type NewCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -32,8 +32,7 @@ import (
 var newShortDesc = "Create a new public/private keypair for authenticating with doltremoteapi."
 var newLongDesc = `Creates a new keypair for authenticating with doltremoteapi.
 
-Prints the public portion of the keypair, which can entered into the credentials
-settings page of dolthub.`
+Prints the public portion of the keypair, which can entered into the credentials settings page of dolthub.`
 var newSynopsis = []string{}
 
 var newDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -29,16 +29,14 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var newShortDesc = "Create a new public/private keypair for authenticating with doltremoteapi."
-var newLongDesc = `Creates a new keypair for authenticating with doltremoteapi.
 
-Prints the public portion of the keypair, which can entered into the credentials settings page of dolthub.`
-var newSynopsis = []string{}
 
-var newDocumentation = cli.CommandDocumentation{
-	ShortDesc: newShortDesc,
-	LongDesc:  newLongDesc,
-	Synopsis:  newSynopsis,
+var newDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Create a new public/private keypair for authenticating with doltremoteapi.",
+	LongDesc: `Creates a new keypair for authenticating with doltremoteapi.
+
+Prints the public portion of the keypair, which can entered into the credentials settings page of dolthub.`,
+	Synopsis: []string{},
 }
 
 type NewCmd struct{}
@@ -50,13 +48,13 @@ func (cmd NewCmd) Name() string {
 
 // Description returns a description of the command
 func (cmd NewCmd) Description() string {
-	return newShortDesc
+	return newDocs.ShortDesc
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd NewCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, newDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, newDocs, ap))
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -78,7 +76,7 @@ func (cmd NewCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd NewCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, newDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, newDocs, ap))
 	cli.ParseArgs(ap, args, help)
 
 	_, newCreds, verr := actions.NewCredsFile(dEnv)

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -36,6 +36,12 @@ Prints the public portion of the keypair, which can entered into the credentials
 settings page of dolthub.`
 var newSynopsis = []string{}
 
+var newDocumentation = cli.CommandDocumentation{
+	ShortDesc: newShortDesc,
+	LongDesc: newLongDesc,
+	Synopsis: newSynopsis,
+}
+
 type NewCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -51,7 +57,7 @@ func (cmd NewCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd NewCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, newShortDesc, newLongDesc, newSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, newDocumentation, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -73,7 +79,7 @@ func (cmd NewCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd NewCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, newShortDesc, newLongDesc, newSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, newDocumentation, ap)
 	cli.ParseArgs(ap, args, help)
 
 	_, newCreds, verr := actions.NewCredsFile(dEnv)

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -30,8 +30,8 @@ import (
 
 var rmDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Remove a stored public/private keypair.",
-	LongDesc: `Removes an existing keypair from dolt's credential storage.`,
-	Synopsis: []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterThan}}"},
+	LongDesc:  `Removes an existing keypair from dolt's credential storage.`,
+	Synopsis:  []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterThan}}"},
 }
 
 type RmCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -34,8 +34,8 @@ var rmSynopsis = []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterTha
 
 var rmDocumentation = cli.CommandDocumentation{
 	ShortDesc: rmShortDesc,
-	LongDesc: rmLongDesc,
-	Synopsis: rmSynopsis,
+	LongDesc:  rmLongDesc,
+	Synopsis:  rmSynopsis,
 }
 
 type RmCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -32,6 +32,12 @@ var rmShortDesc = "Remove a stored public/private keypair."
 var rmLongDesc = `Removes an existing keypair from dolt's credential storage.`
 var rmSynopsis = []string{"<public_key_as_appears_in_ls>"}
 
+var rmDocumentation = cli.CommandDocumentation{
+	ShortDesc: rmShortDesc,
+	LongDesc: rmLongDesc,
+	Synopsis: rmSynopsis,
+}
+
 type RmCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -47,7 +53,7 @@ func (cmd RmCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, rmShortDesc, rmLongDesc, rmSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, rmDocumentation, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -69,7 +75,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, rmShortDesc, rmLongDesc, rmSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, rmDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -30,7 +30,7 @@ import (
 
 var rmShortDesc = "Remove a stored public/private keypair."
 var rmLongDesc = `Removes an existing keypair from dolt's credential storage.`
-var rmSynopsis = []string{"<public_key_as_appears_in_ls>"}
+var rmSynopsis = []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterThan}}"}
 
 var rmDocumentation = cli.CommandDocumentation{
 	ShortDesc: rmShortDesc,

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -28,14 +28,10 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var rmShortDesc = "Remove a stored public/private keypair."
-var rmLongDesc = `Removes an existing keypair from dolt's credential storage.`
-var rmSynopsis = []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterThan}}"}
-
-var rmDocumentation = cli.CommandDocumentation{
-	ShortDesc: rmShortDesc,
-	LongDesc:  rmLongDesc,
-	Synopsis:  rmSynopsis,
+var rmDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Remove a stored public/private keypair.",
+	LongDesc: `Removes an existing keypair from dolt's credential storage.`,
+	Synopsis: []string{"{{.LessThan}}public_key_as_appears_in_ls{{.GreaterThan}}"},
 }
 
 type RmCmd struct{}
@@ -47,13 +43,13 @@ func (cmd RmCmd) Name() string {
 
 // Description returns a description of the command
 func (cmd RmCmd) Description() string {
-	return rmShortDesc
+	return rmDocs.ShortDesc
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, rmDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, rmDocs, ap))
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -75,7 +71,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, rmDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, rmDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -28,20 +28,17 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var useShortDesc = "Select an existing dolt credential for authenticating with doltremoteapi."
-var useLongDesc = `Selects an existing dolt credential for authenticating with doltremoteapi.
+
+var useDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Select an existing dolt credential for authenticating with doltremoteapi.",
+	LongDesc: `Selects an existing dolt credential for authenticating with doltremoteapi.
 
 Can be given a credential's public key or key id and will update global dolt
 config to use the credential when interacting with doltremoteapi.
 
-You can see your available credentials with 'dolt creds ls'.`
+You can see your available credentials with 'dolt creds ls'.`,
 
-var useSynopsis = []string{"<public_key_as_appears_in_ls | public_key_id_as_appears_in_ls"}
-
-var useDocumentation = cli.CommandDocumentation{
-	ShortDesc: useShortDesc,
-	LongDesc:  useLongDesc,
-	Synopsis:  useSynopsis,
+	Synopsis: []string{"{{.LessThan}}public_key_as_appears_in_ls | public_key_id_as_appears_in_ls{{.GreaterThan}}"},
 }
 
 type UseCmd struct{}
@@ -53,13 +50,13 @@ func (cmd UseCmd) Name() string {
 
 // Description returns a description of the command
 func (cmd UseCmd) Description() string {
-	return useShortDesc
+	return useDocs.ShortDesc
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd UseCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, useDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, useDocs, ap))
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -81,7 +78,7 @@ func (cmd UseCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd UseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, useDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, useDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 	if len(args) != 1 {

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -40,8 +40,8 @@ var useSynopsis = []string{"<public_key_as_appears_in_ls | public_key_id_as_appe
 
 var useDocumentation = cli.CommandDocumentation{
 	ShortDesc: useShortDesc,
-	LongDesc: useLongDesc,
-	Synopsis: useSynopsis,
+	LongDesc:  useLongDesc,
+	Synopsis:  useSynopsis,
 }
 
 type UseCmd struct{}

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -38,6 +38,12 @@ You can see your available credentials with 'dolt creds ls'.`
 
 var useSynopsis = []string{"<public_key_as_appears_in_ls | public_key_id_as_appears_in_ls"}
 
+var useDocumentation = cli.CommandDocumentation{
+	ShortDesc: useShortDesc,
+	LongDesc: useLongDesc,
+	Synopsis: useSynopsis,
+}
+
 type UseCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -53,7 +59,7 @@ func (cmd UseCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd UseCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, useShortDesc, useLongDesc, useSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, useDocumentation, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -75,7 +81,7 @@ func (cmd UseCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd UseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, useShortDesc, useLongDesc, useSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, useDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 	if len(args) != 1 {

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -28,7 +28,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
 var useDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Select an existing dolt credential for authenticating with doltremoteapi.",
 	LongDesc: `Selects an existing dolt credential for authenticating with doltremoteapi.

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -77,8 +77,9 @@ type DiffSink interface {
 	Close() error
 }
 
-var diffShortDesc = "Show changes between commits, commit and working tree, etc"
-var diffLongDesc = `
+var diffDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Show changes between commits, commit and working tree, etc",
+	LongDesc: `
 Show changes between the working and staged tables, changes between the working tables and the tables within a commit, or changes between tables at two commits.
 
 {{.EmphasisLeft}}dolt diff [--options] [<tables>...]{{.EmphasisRight}}
@@ -93,17 +94,11 @@ Show changes between the working and staged tables, changes between the working 
 The diffs displayed can be limited to show the first N by providing the parameter {{.EmphasisLeft}}--limit N{{.EmphasisRight}} where {{.EmphasisLeft}}N{{.EmphasisRight}} is the number of diffs to display.
 
 In order to filter which diffs are displayed {{.EmphasisLeft}}--where key=value{{.EmphasisRight}} can be used.  The key in this case would be either {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} or {{.EmphasisLeft}}from_COLUMN_NAME{{.EmphasisRight}}. where {{.EmphasisLeft}}from_COLUMN_NAME=value{{.EmphasisRight}} would filter based on the original value and {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} would select based on its updated value.
-`
-
-var diffSynopsis = []string{
-	`[options] [{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}tables{{.GreaterThan}}...]`,
-	`[options] {{.LessThan}}commit{{.GreaterThan}} {{.LessThan}}commit{{.GreaterThan}} [{{.LessThan}}tables{{.GreaterThan}}...]`,
-}
-
-var diffDocumnetation = cli.CommandDocumentation{
-	ShortDesc: diffShortDesc,
-	LongDesc:  diffLongDesc,
-	Synopsis:  diffSynopsis,
+`,
+	Synopsis: []string{
+		`[options] [{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}tables{{.GreaterThan}}...]`,
+		`[options] {{.LessThan}}commit{{.GreaterThan}} {{.LessThan}}commit{{.GreaterThan}} [{{.LessThan}}tables{{.GreaterThan}}...]`,
+	},
 }
 
 type diffArgs struct {
@@ -133,7 +128,7 @@ func (cmd DiffCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd DiffCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, diffDocumnetation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, diffDocs, ap))
 }
 
 func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
@@ -150,7 +145,7 @@ func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(commandStr, diffDocumnetation, ap)
+	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, diffDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	diffParts := SchemaAndDataDiff

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -95,15 +95,15 @@ The diffs displayed can be limited to show the first N by providing the paramete
 In order to filter which diffs are displayed {{.EmphasisLeft}}--where key=value{{.EmphasisRight}} can be used.  The key in this case would be either {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} or {{.EmphasisLeft}}from_COLUMN_NAME{{.EmphasisRight}}. where {{.EmphasisLeft}}from_COLUMN_NAME=value{{.EmphasisRight}} would filter based on the original value and {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} would select based on its updated value.
 `
 
-var diffSynopsis= []string{
-		`[options] [{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}tables{{.GreaterThan}}...]`,
-		`[options] {{.LessThan}}commit{{.GreaterThan}} {{.LessThan}}commit{{.GreaterThan}} [{{.LessThan}}tables{{.GreaterThan}}...]`,
-	}
+var diffSynopsis = []string{
+	`[options] [{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}tables{{.GreaterThan}}...]`,
+	`[options] {{.LessThan}}commit{{.GreaterThan}} {{.LessThan}}commit{{.GreaterThan}} [{{.LessThan}}tables{{.GreaterThan}}...]`,
+}
 
 var diffDocumnetation = cli.CommandDocumentation{
 	ShortDesc: diffShortDesc,
-	LongDesc: diffLongDesc,
-	Synopsis: diffSynopsis,
+	LongDesc:  diffLongDesc,
+	Synopsis:  diffSynopsis,
 }
 
 type diffArgs struct {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -141,8 +141,8 @@ func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
 	ap.SupportsFlag(DataFlag, "d", "Show only the data changes, do not show the schema changes (Both shown by default).")
 	ap.SupportsFlag(SchemaFlag, "s", "Show only the schema changes, do not show the data changes (Both shown by default).")
 	ap.SupportsFlag(SummaryFlag, "", "Show summary of data changes")
-	ap.SupportsFlag(SQLFlag, "q", "Output diff as a SQL patch file of INSERT / UPDATE / DELETE statements")
-	ap.SupportsString(whereParam, "", "column", "filters columns based on values in the diff.  See dolt diff --help for details.")
+	ap.SupportsFlag(SQLFlag, "q", "Output diff as a SQL patch file of {{.EmphasisLeft}}INSERT{{.EmphasisRight}} / {{.EmphasisLeft}}UPDATE{{.EmphasisRight}} / {{.EmphasisLeft}}DELETE{{.EmphasisRight}} statements")
+	ap.SupportsString(whereParam, "", "column", "filters columns based on values in the diff.  See {{.EmphasisLeft}}dolt diff --help{{.EmphasisRight}} for details.")
 	ap.SupportsInt(limitParam, "", "record_count", "limits to the first N diffs.")
 	return ap
 }

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -78,25 +78,32 @@ type DiffSink interface {
 }
 
 var diffShortDesc = "Show changes between commits, commit and working tree, etc"
-var diffLongDesc = `Show changes between the working and staged tables, changes between the working tables and the tables within a commit, or changes between tables at two commits.
+var diffLongDesc = `
+Show changes between the working and staged tables, changes between the working tables and the tables within a commit, or changes between tables at two commits.
 
-dolt diff [--options] [<tables>...]
+{{.EmphasisLeft}}dolt diff [--options] [<tables>...]{{.EmphasisRight}}
    This form is to view the changes you made relative to the staging area for the next commit. In other words, the differences are what you could tell Dolt to further add but you still haven't. You can stage these changes by using dolt add.
 
-dolt diff [--options] <commit> [<tables>...]
-   This form is to view the changes you have in your working tables relative to the named <commit>. You can use HEAD to compare it with the latest commit, or a branch name to compare with the tip of a different branch.
+{{.EmphasisLeft}}dolt diff [--options] <commit> [<tables>...]{{.EmphasisRight}}
+   This form is to view the changes you have in your working tables relative to the named {{.LessThan}}commit{{.GreaterThan}}. You can use HEAD to compare it with the latest commit, or a branch name to compare with the tip of a different branch.
 
-dolt diff [--options] <commit> <commit> [<tables>...]
-   This is to view the changes between two arbitrary <commit>.
+{{.EmphasisLeft}}dolt diff [--options] <commit> <commit> [<tables>...]{{.EmphasisRight}}
+   This is to view the changes between two arbitrary {{.EmphasisLeft}}commit{{.EmphasisRight}}.
 
-The diffs displayed can be limited to show the first N by providing the parameter <b>--limit N</b> where N is the number of diffs to display.
+The diffs displayed can be limited to show the first N by providing the parameter {{.EmphasisLeft}}--limit N{{.EmphasisRight}} where {{.EmphasisLeft}}N{{.EmphasisRight}} is the number of diffs to display.
 
-In order to filter which diffs are displayed <b>--where key=value</b> can be used.  The key in this case would be either to_COLUMN_NAME or from_COLUMN_NAME. where from_COLUMN_NAME=value would filter based on the original value and to_COLUMN_NAME would select based on its updated value.
+In order to filter which diffs are displayed {{.EmphasisLeft}}--where key=value{{.EmphasisRight}} can be used.  The key in this case would be either {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} or {{.EmphasisLeft}}from_COLUMN_NAME{{.EmphasisRight}}. where {{.EmphasisLeft}}from_COLUMN_NAME=value{{.EmphasisRight}} would filter based on the original value and {{.EmphasisLeft}}to_COLUMN_NAME{{.EmphasisRight}} would select based on its updated value.
 `
 
-var diffSynopsis = []string{
-	"[options] [<commit>] [<tables>...]",
-	"[options] <commit> <commit> [<tables>...]",
+var diffSynopsis= []string{
+		`[options] [{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}tables{{.GreaterThan}}...]`,
+		`[options] {{.LessThan}}commit{{.GreaterThan}} {{.LessThan}}commit{{.GreaterThan}} [{{.LessThan}}tables{{.GreaterThan}}...]`,
+	}
+
+var diffDocumnetation = cli.CommandDocumentation{
+	ShortDesc: diffShortDesc,
+	LongDesc: diffLongDesc,
+	Synopsis: diffSynopsis,
 }
 
 type diffArgs struct {
@@ -126,7 +133,7 @@ func (cmd DiffCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd DiffCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, diffShortDesc, diffLongDesc, diffSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, diffDocumnetation, ap)
 }
 
 func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
@@ -143,7 +150,7 @@ func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(commandStr, diffShortDesc, diffLongDesc, diffSynopsis, ap)
+	help, _ := cli.HelpAndUsagePrinters(commandStr, diffDocumnetation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	diffParts := SchemaAndDataDiff

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -15,11 +15,13 @@
 package commands
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
@@ -67,7 +69,7 @@ func (cmd *DumpDocsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr stri
 func (cmd *DumpDocsCmd) Exec(_ context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := argparser.NewArgParser()
 	ap.SupportsString(dirParamName, "", "dir", "The directory where the md files should be dumped")
-	help, usage := cli.HelpAndUsagePrinters(commandStr, initShortDesc, initLongDesc, initSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, initDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	dirStr := apr.GetValueOrDefault(dirParamName, ".")
@@ -152,3 +154,165 @@ func (cmd *DumpDocsCmd) dumpDocs(idxWr io.Writer, dEnv *env.DoltEnv, dirStr, cmd
 
 	return nil
 }
+
+
+func CreateMarkdown(fs filesys.Filesys, path, commandStr string, cmdDoc cli.CommandDocumentation, parser *argparser.ArgParser) error {
+	longDesc, longDescErr := cmdDoc.GetLongDesc(cli.MarkdownFormat)
+	if longDescErr != nil {
+		return longDescErr
+	}
+	synopsis, synopsisErr := cmdDoc.GetSynopsis(cli.MarkdownFormat)
+	if synopsisErr != nil {
+		return synopsisErr
+	}
+
+	wr, err := fs.OpenForWrite(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer wr.Close()
+
+	// Insert the header that is used by Gatsby
+	err = iohelp.WriteIfNoErr(wr, []byte(getHeader(commandStr)), nil)
+
+	formattedShortDesc := fmt.Sprintf("`%s` - %s\n\n", commandStr, cmdDoc.GetShortDesc())
+	err = iohelp.WriteIfNoErr(wr, titleHelper("Command"), err)
+	err = iohelp.WriteIfNoErr(wr, []byte(formattedShortDesc), err)
+
+	if len(synopsis) > 0 {
+		err = iohelp.WriteIfNoErr(wr, titleHelper("Synopsis"), err)
+		err = iohelp.WriteIfNoErr(wr, []byte(getSynopsis(commandStr, synopsis)), err)
+	}
+
+	err = iohelp.WriteIfNoErr(wr, titleHelper("Description"), err)
+	err = iohelp.WriteIfNoErr(wr, []byte(fmt.Sprintf("%s\n\n", longDesc)), err)
+
+	if len(parser.Supported) > 0 || len(parser.ArgListHelp) > 0 {
+		err = iohelp.WriteIfNoErr(wr, titleHelper("Options"), err)
+
+		// Iterate across arguments and template them
+		for _, kvTuple := range parser.ArgListHelp {
+			arg, desc := kvTuple[0], kvTuple[1]
+			argStruct := Agument{arg, desc}
+			outputStr, err := TemplateArgument(argStruct)
+			err = iohelp.WriteIfNoErr(wr, []byte(outputStr), err)
+		}
+
+		// Iterate accross supported options, templating each one of them
+		for _, supOpt := range parser.Supported {
+			argStruct := Supported{supOpt.Abbrev, supOpt.Name, supOpt.ValDesc}
+			outputStr, err := TemplateSupported(argStruct)
+			err = iohelp.WriteIfNoErr(wr, []byte(outputStr), err)
+		}
+	}
+
+	return err
+}
+
+func getHeader(commandStr string) string {
+	header := `---
+title: %s
+---
+
+`
+	return fmt.Sprintf(header, commandStr)
+}
+
+// Apply appropriate markdown to title and add a few newlines
+func titleHelper(title string) []byte {
+	return []byte(fmt.Sprintf("## %s\n\n", title))
+}
+
+// Create a synopsis properly contained within HTML tags required for markdown generation
+// TODO we could probably enhance this using html/template
+func getSynopsis(commandStr string, synopsis [] string) string {
+	synopsisStr := fmt.Sprintf("%s %s<br />\n", commandStr, synopsis[0])
+	if len(synopsis) > 1 {
+		temp := make([]string, len(synopsis)-1)
+		for i, el := range(synopsis[1:]) {
+			temp[i] = fmt.Sprintf("\t\t\t%s %s<br />\n", commandStr, el)
+		}
+		synopsisStr += strings.Join(temp, "")
+	}
+
+	html := `
+<div class="gatsby-highlight" data-language="text">
+	<pre class="language-text">
+		<code class="language-text">
+			%s
+  		</code>
+	</pre>
+</div>
+
+`
+
+	return fmt.Sprintf(html, synopsisStr)
+}
+
+type Agument struct {
+	Name string
+	Description string
+}
+
+
+func TemplateArgument(supportedArg Agument) (string, error) {
+	var formatString string
+	if supportedArg.Description == "" {
+		formatString = "`<{{.Name}}>`\n\n"
+	} else {
+		formatString = "`<{{.Name}}>`:\n\n{{.Description}}\n\n"
+	}
+
+	templ, err := template.New("argString").Parse(formatString)
+	if err != nil {
+		cli.Println(err)
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, supportedArg); err != nil {
+		cli.Println(err)
+		return "", err
+	}
+	ret := templBuffer.String()
+	cli.Printf("%s", ret)
+	return ret, nil
+}
+
+type Supported struct {
+	Abbreviation string
+	Name string
+	Description string
+}
+
+func TemplateSupported(supported Supported) (string, error) {
+	var formatString string
+	if supported.Abbreviation == "" && supported.Description == "" {
+		formatString = "`--{{.Name}}`\n\n"
+	} else if supported.Abbreviation == "" && supported.Description != ""  {
+		formatString = "`--{{.Name}}`:\n\n\t{{.Description}}\n\n"
+
+	} else if supported.Abbreviation != "" && supported.Description == "" {
+		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`\n\n"
+	} else {
+		formatString = "`-{{.Abbreviation}}`, `--{{.Name}}`:\n\n\t{{.Description}}\n\n"
+	}
+
+	templ, err := template.New("argString").Parse(formatString)
+	if err != nil {
+		cli.Println(err)
+		return "", err
+	}
+	var templBuffer bytes.Buffer
+	if err := templ.Execute(&templBuffer, supported); err != nil {
+		cli.Println(err)
+		return "", err
+	}
+	ret := templBuffer.String()
+	cli.Printf("%s", ret)
+	return ret, nil
+}
+
+
+

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -66,7 +66,7 @@ func (cmd *DumpDocsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr stri
 func (cmd *DumpDocsCmd) Exec(_ context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := argparser.NewArgParser()
 	ap.SupportsString(dirParamName, "", "dir", "The directory where the md files should be dumped")
-	help, usage := cli.HelpAndUsagePrinters(commandStr, initDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cli.CommandDocumentationContent{}, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	dirStr := apr.GetValueOrDefault(dirParamName, ".")
@@ -127,8 +127,8 @@ func (cmd *DumpDocsCmd) dumpDocs(dEnv *env.DoltEnv, dirStr, cmdStr string, subCo
 	return nil
 }
 
-func CreateMarkdown(fs filesys.Filesys, path, commandStr string, cmdDoc cli.CommandDocumentation, parser *argparser.ArgParser) error {
-	markdownDoc, err := cmdDoc.CmdDocToMd(commandStr, parser)
+func CreateMarkdown(fs filesys.Filesys, path string, cmdDoc cli.CommandDocumentation) error {
+	markdownDoc, err := cmdDoc.CmdDocToMd()
 	if err != nil {
 		return err
 	}

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -17,14 +17,15 @@ package commands
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
-	"path/filepath"
-	"strings"
 )
 
 const (

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -39,13 +39,13 @@ When no refspec(s) are specified on the command line, the fetch_specs for the de
 `
 
 var fetchSynopsis = []string{
-		"[{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}} ...]",
-	}
+	"[{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}} ...]",
+}
 
 var fetchDocumentation = cli.CommandDocumentation{
 	ShortDesc: fetchShortDesc,
-	LongDesc: fetchLongDesc,
-	Synopsis: fetchSynopsis,
+	LongDesc:  fetchLongDesc,
+	Synopsis:  fetchSynopsis,
 }
 
 type FetchCmd struct{}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -30,8 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
-
 var fetchDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Download objects and refs from another repository",
 	LongDesc: `Fetch refs, along with the objects necessary to complete their histories and update remote-tracking branches.

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -30,22 +30,20 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var fetchShortDesc = "Download objects and refs from another repository"
-var fetchLongDesc = `Fetch refs, along with the objects necessary to complete their histories and update remote-tracking branches.
+
+
+var fetchDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Download objects and refs from another repository",
+	LongDesc: `Fetch refs, along with the objects necessary to complete their histories and update remote-tracking branches.
 
 By default dolt will attempt to fetch from a remote named {{.EmphasisLeft}}origin{{.EmphasisRight}}.  The {{.LessThan}}remote{{.GreaterThan}} parameter allows you to specify the name of a different remote you wish to pull from by the remote's name.
 
 When no refspec(s) are specified on the command line, the fetch_specs for the default remote are used.
-`
+`,
 
-var fetchSynopsis = []string{
-	"[{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}} ...]",
-}
-
-var fetchDocumentation = cli.CommandDocumentation{
-	ShortDesc: fetchShortDesc,
-	LongDesc:  fetchLongDesc,
-	Synopsis:  fetchSynopsis,
+	Synopsis: []string{
+		"[{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}} ...]",
+	},
 }
 
 type FetchCmd struct{}
@@ -68,7 +66,7 @@ func (cmd FetchCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd FetchCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, fetchDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, fetchDocs, ap))
 }
 
 func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
@@ -79,7 +77,7 @@ func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := argparser.NewArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, fetchDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, _ := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -31,15 +31,21 @@ import (
 )
 
 var fetchShortDesc = "Download objects and refs from another repository"
-var fetchLongDesc = "Fetch refs, along with the objects necessary to complete their histories and update " +
-	"remote-tracking branches." +
-	"\n" +
-	"\n By default dolt will attempt to fetch from a remote named 'origin'.  The <remote> parameter allows you to " +
-	"specify the name of a different remote you wish to pull from by the remote's name." +
-	"\n" +
-	"\nWhen no refspec(s) are specified on the command line, the fetch_specs for the default remote are used."
+var fetchLongDesc = `Fetch refs, along with the objects necessary to complete their histories and update remote-tracking branches.
+
+By default dolt will attempt to fetch from a remote named {{.EmphasisLeft}}origin{{.EmphasisRight}}.  The {{.LessThan}}remote{{.GreaterThan}} parameter allows you to specify the name of a different remote you wish to pull from by the remote's name.
+
+When no refspec(s) are specified on the command line, the fetch_specs for the default remote are used.
+`
+
 var fetchSynopsis = []string{
-	"[<remote>] [<refspec> ...]",
+		"[{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}} ...]",
+	}
+
+var fetchDocumentation = cli.CommandDocumentation{
+	ShortDesc: fetchShortDesc,
+	LongDesc: fetchLongDesc,
+	Synopsis: fetchSynopsis,
 }
 
 type FetchCmd struct{}
@@ -62,7 +68,7 @@ func (cmd FetchCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd FetchCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, fetchShortDesc, fetchLongDesc, fetchSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, fetchDocumentation, ap)
 }
 
 func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
@@ -73,7 +79,7 @@ func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := argparser.NewArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, fetchShortDesc, fetchLongDesc, fetchSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, fetchDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, _ := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -41,12 +41,12 @@ This command creates an empty Dolt data repository in the current directory.
 Running dolt init in an already initialized directory will fail.
 `
 
-var initSynopsis = []string{`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`,}
+var initSynopsis = []string{`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`}
 
 var initDocumentation = cli.CommandDocumentation{
 	ShortDesc: initShortDesc,
-	LongDesc: initLongDesc,
-	Synopsis: initSynopsis,
+	LongDesc:  initLongDesc,
+	Synopsis:  initSynopsis,
 }
 
 type InitCmd struct{}
@@ -66,7 +66,6 @@ func (cmd InitCmd) Description() string {
 func (cmd InitCmd) RequiresRepo() bool {
 	return false
 }
-
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd InitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -34,11 +34,18 @@ const (
 )
 
 var initShortDesc = "Create an empty Dolt data repository"
-var initLongDesc = `This command creates an empty Dolt data repository in the current directory.
+var initLongDesc = `
+This command creates an empty Dolt data repository in the current directory.
 
-Running dolt init in an already initialized directory will fail.`
-var initSynopsis = []string{
-	"[<options>] [<path>]",
+Running dolt init in an already initialized directory will fail.
+`
+
+var initSynopsis = []string{`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`,}
+
+var initDocumentation = cli.CommandDocumentation{
+	ShortDesc: initShortDesc,
+	LongDesc: initLongDesc,
+	Synopsis: initSynopsis,
 }
 
 type InitCmd struct{}
@@ -59,11 +66,11 @@ func (cmd InitCmd) RequiresRepo() bool {
 	return false
 }
 
+
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd InitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-
-	return cli.CreateMarkdown(fs, path, commandStr, initShortDesc, initLongDesc, initSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, initDocumentation, ap)
 }
 
 func (cmd InitCmd) createArgParser() *argparser.ArgParser {
@@ -78,7 +85,7 @@ func (cmd InitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, initShortDesc, initLongDesc, initSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, initDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if dEnv.HasDoltDir() {

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -34,19 +34,16 @@ const (
 	usernameParamName = "name"
 )
 
-var initShortDesc = "Create an empty Dolt data repository"
-var initLongDesc = `
-This command creates an empty Dolt data repository in the current directory.
+var initDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Create an empty Dolt data repository",
+	LongDesc: `This command creates an empty Dolt data repository in the current directory.
 
 Running dolt init in an already initialized directory will fail.
-`
+`,
 
-var initSynopsis = []string{`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`}
-
-var initDocumentation = cli.CommandDocumentation{
-	ShortDesc: initShortDesc,
-	LongDesc:  initLongDesc,
-	Synopsis:  initSynopsis,
+	Synopsis: []string{
+	//`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`,
+	},
 }
 
 type InitCmd struct{}
@@ -70,13 +67,13 @@ func (cmd InitCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd InitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, initDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, initDocs, ap))
 }
 
 func (cmd InitCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsString(usernameParamName, "", "name", fmt.Sprint("The name used in commits to this repo. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserNameKey))
-	ap.SupportsString(emailParamName, "", "email", fmt.Sprint("The email address used. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserEmailKey))
+	ap.SupportsString(usernameParamName, "", "name", fmt.Sprintf("The name used in commits to this repo. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserNameKey))
+	ap.SupportsString(emailParamName, "", "email", fmt.Sprintf("The email address used. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserEmailKey))
 	ap.SupportsString(dateParam, "", "date", "Specify the date used in the initial commit. If not specified the current system time is used.")
 
 	return ap
@@ -85,7 +82,7 @@ func (cmd InitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, initDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, initDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if dEnv.HasDoltDir() {

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -42,7 +42,7 @@ Running dolt init in an already initialized directory will fail.
 `,
 
 	Synopsis: []string{
-	//`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`,
+		//`[{{.LessThan}}options{{.GreaterThan}}] [{{.LessThan}}path{{.GreaterThan}}]`,
 	},
 }
 

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fatih/color"
@@ -75,8 +76,8 @@ func (cmd InitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) e
 
 func (cmd InitCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsString(usernameParamName, "", "name", "The name used in commits to this repo. If not provided will be taken from \""+env.UserNameKey+"\" in the global config.")
-	ap.SupportsString(emailParamName, "", "email", "The email address used. If not provided will be taken from \""+env.UserEmailKey+"\" in the global config.")
+	ap.SupportsString(usernameParamName, "", "name", fmt.Sprint("The name used in commits to this repo. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserNameKey))
+	ap.SupportsString(emailParamName, "", "email", fmt.Sprint("The email address used. If not provided will be taken from {{.EmphasisLeft}}%s{{.EmphasisRight}} in the global config.", env.UserEmailKey))
 	ap.SupportsString(dateParam, "", "date", "Specify the date used in the initial commit. If not specified the current system time is used.")
 
 	return ap

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -36,12 +36,20 @@ const (
 )
 
 var logShortDesc = `Show commit logs`
-var logLongDesc = "Shows the commit logs.\n" +
-	"\n" +
-	"The command takes options to control what is shown and how."
+
+var logLongDesc = `Shows the commit logs
+
+The command takes options to control what is shown and how.`
+
 
 var logSynopsis = []string{
-	"[-n <num_commits>] [<commit>]",
+		`[-n {{.LessThan}}num_commits{{.GreaterThan}}] [{{.LessThan}}commit{{.GreaterThan}}]`,
+	}
+
+var logDocumentation = cli.CommandDocumentation{
+	ShortDesc: loginShortDesc,
+	LongDesc: logLongDesc,
+	Synopsis: logSynopsis,
 }
 
 type commitLoggerFunc func(*doltdb.CommitMeta, []hash.Hash, hash.Hash)
@@ -100,7 +108,7 @@ func (cmd LogCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LogCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := createLogArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, logShortDesc, logLongDesc, logSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, logDocumentation, ap)
 }
 
 func createLogArgParser() *argparser.ArgParser {
@@ -116,7 +124,7 @@ func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 
 func logWithLoggerFunc(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, loggerFunc commitLoggerFunc) int {
 	ap := createLogArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, logShortDesc, logLongDesc, logSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, logDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -41,15 +41,14 @@ var logLongDesc = `Shows the commit logs
 
 The command takes options to control what is shown and how.`
 
-
 var logSynopsis = []string{
-		`[-n {{.LessThan}}num_commits{{.GreaterThan}}] [{{.LessThan}}commit{{.GreaterThan}}]`,
-	}
+	`[-n {{.LessThan}}num_commits{{.GreaterThan}}] [{{.LessThan}}commit{{.GreaterThan}}]`,
+}
 
 var logDocumentation = cli.CommandDocumentation{
 	ShortDesc: loginShortDesc,
-	LongDesc: logLongDesc,
-	Synopsis: logSynopsis,
+	LongDesc:  logLongDesc,
+	Synopsis:  logSynopsis,
 }
 
 type commitLoggerFunc func(*doltdb.CommitMeta, []hash.Hash, hash.Hash)

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -35,21 +35,16 @@ const (
 	numLinesParam = "number"
 )
 
-var logShortDesc = `Show commit logs`
+var logDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Show commit logs`,
+	LongDesc: `Shows the commit logs
 
-var logLongDesc = `Shows the commit logs
-
-The command takes options to control what is shown and how.`
-
-var logSynopsis = []string{
-	`[-n {{.LessThan}}num_commits{{.GreaterThan}}] [{{.LessThan}}commit{{.GreaterThan}}]`,
+The command takes options to control what is shown and how.`,
+	Synopsis: []string{
+		`[-n {{.LessThan}}num_commits{{.GreaterThan}}] [{{.LessThan}}commit{{.GreaterThan}}]`,
+	},
 }
 
-var logDocumentation = cli.CommandDocumentation{
-	ShortDesc: loginShortDesc,
-	LongDesc:  logLongDesc,
-	Synopsis:  logSynopsis,
-}
 
 type commitLoggerFunc func(*doltdb.CommitMeta, []hash.Hash, hash.Hash)
 
@@ -107,7 +102,7 @@ func (cmd LogCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LogCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := createLogArgParser()
-	return CreateMarkdown(fs, path, commandStr, logDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, logDocs, ap))
 }
 
 func createLogArgParser() *argparser.ArgParser {
@@ -123,7 +118,7 @@ func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 
 func logWithLoggerFunc(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, loggerFunc commitLoggerFunc) int {
 	ap := createLogArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, logDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, logDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -45,7 +45,6 @@ The command takes options to control what is shown and how.`,
 	},
 }
 
-
 type commitLoggerFunc func(*doltdb.CommitMeta, []hash.Hash, hash.Hash)
 
 func logToStdOutFunc(cm *doltdb.CommitMeta, parentHashes []hash.Hash, ch hash.Hash) {

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -17,6 +17,10 @@ package commands
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"github.com/skratchdot/open-golang/open"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -26,8 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-	"github.com/skratchdot/open-golang/open"
-	"time"
 )
 
 const (
@@ -42,8 +44,8 @@ var loginSynopsis = []string{"[<creds>]"}
 
 var loginDocumentation = cli.CommandDocumentation{
 	ShortDesc: loginShortDesc,
-	LongDesc: loginLongDesc,
-	Synopsis: loginSynopsis,
+	LongDesc:  loginLongDesc,
+	Synopsis:  loginSynopsis,
 }
 
 type LoginCmd struct{}

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -36,16 +36,11 @@ const (
 	loginRetryInterval = 5
 )
 
-var loginShortDesc = ""
-var loginLongDesc = `Login into DoltHub using the email in your config so you can pull from private repos and push to those you have permission to.
-`
-
-var loginSynopsis = []string{"[<creds>]"}
-
-var loginDocumentation = cli.CommandDocumentation{
-	ShortDesc: loginShortDesc,
-	LongDesc:  loginLongDesc,
-	Synopsis:  loginSynopsis,
+var loginDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Login to DoltHub",
+	LongDesc: `Login into DoltHub using the email in your config so you can pull from private repos and push to those you have permission to.
+`,
+	Synopsis: []string{"[{{.LessThan}}creds{{.GreaterThan}}]"},
 }
 
 type LoginCmd struct{}
@@ -69,7 +64,7 @@ func (cmd LoginCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LoginCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, loginDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, loginDocs, ap))
 }
 
 func (cmd LoginCmd) createArgParser() *argparser.ArgParser {
@@ -86,7 +81,7 @@ func (cmd LoginCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LoginCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, loginDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, loginDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -17,10 +17,6 @@ package commands
 import (
 	"context"
 	"fmt"
-	"time"
-
-	"github.com/skratchdot/open-golang/open"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -30,6 +26,8 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
+	"github.com/skratchdot/open-golang/open"
+	"time"
 )
 
 const (
@@ -37,9 +35,15 @@ const (
 )
 
 var loginShortDesc = ""
-var loginLongDesc = ""
-var loginSynopsis = []string{
-	"[<creds>]",
+var loginLongDesc = `Login into DoltHub using the email in your config so you can pull from private repos and push to those you have permission to.
+`
+
+var loginSynopsis = []string{"[<creds>]"}
+
+var loginDocumentation = cli.CommandDocumentation{
+	ShortDesc: loginShortDesc,
+	LongDesc: loginLongDesc,
+	Synopsis: loginSynopsis,
 }
 
 type LoginCmd struct{}
@@ -63,7 +67,7 @@ func (cmd LoginCmd) RequiresRepo() bool {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LoginCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, loginShortDesc, loginLongDesc, loginSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, loginDocumentation, ap)
 }
 
 func (cmd LoginCmd) createArgParser() *argparser.ArgParser {
@@ -80,7 +84,7 @@ func (cmd LoginCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LoginCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, loginShortDesc, loginLongDesc, loginSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, loginDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -36,11 +36,11 @@ const (
 )
 
 var lsShortDesc = "List tables"
-var lsLongDesc = `With no arguments lists the tables in the current working set but if a commit is specified it will list the tables in that commit.  If the --verbose flag is provided a row count and a hash of the table will also be displayed.
+var lsLongDesc = `With no arguments lists the tables in the current working set but if a commit is specified it will list the tables in that commit.  If the {{.EmphasisLeft}}--verbose{{.EmphasisRight}} flag is provided a row count and a hash of the table will also be displayed.
 
-If the --system flag is supplied this will show the dolt system tables which are queryable with SQL.  Some system tables can be queried even if they are not in the working set by specifying appropriate parameters in the SQL queries.  To see these tables too you may pass the --verbose flag.
+If the {{.EmphasisLeft}}--system{{.EmphasisRight}} flag is supplied this will show the dolt system tables which are queryable with SQL.  Some system tables can be queried even if they are not in the working set by specifying appropriate parameters in the SQL queries. To see these tables too you may pass the {{.EmphasisLeft}}--verbose{{.EmphasisRight}} flag.
 
-If the --all flag is supplied both user and system tables will be printed.
+If the {{.EmphasisLeft}}--all{{.EmphasisRight}} flag is supplied both user and system tables will be printed.
 `
 
 var lsSynopsis = []string{

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -36,22 +36,18 @@ const (
 	systemFlag = "system"
 )
 
-var lsShortDesc = "List tables"
-var lsLongDesc = `With no arguments lists the tables in the current working set but if a commit is specified it will list the tables in that commit.  If the {{.EmphasisLeft}}--verbose{{.EmphasisRight}} flag is provided a row count and a hash of the table will also be displayed.
+var lsDocs = cli.CommandDocumentationContent{
+	ShortDesc: "List tables",
+	LongDesc: `With no arguments lists the tables in the current working set but if a commit is specified it will list the tables in that commit.  If the {{.EmphasisLeft}}--verbose{{.EmphasisRight}} flag is provided a row count and a hash of the table will also be displayed.
 
 If the {{.EmphasisLeft}}--system{{.EmphasisRight}} flag is supplied this will show the dolt system tables which are queryable with SQL.  Some system tables can be queried even if they are not in the working set by specifying appropriate parameters in the SQL queries. To see these tables too you may pass the {{.EmphasisLeft}}--verbose{{.EmphasisRight}} flag.
 
 If the {{.EmphasisLeft}}--all{{.EmphasisRight}} flag is supplied both user and system tables will be printed.
-`
+`,
 
-var lsSynopsis = []string{
-	"[--options] [{{.LessThan}}commit{{.GreaterThan}}]",
-}
-
-var lsDocumentation = cli.CommandDocumentation{
-	ShortDesc: lsShortDesc,
-	LongDesc:  lsLongDesc,
-	Synopsis:  lsSynopsis,
+	Synopsis: []string{
+		"[--options] [{{.LessThan}}commit{{.GreaterThan}}]",
+	},
 }
 
 type LsCmd struct{}
@@ -69,7 +65,7 @@ func (cmd LsCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, lsDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, lsDocs, ap))
 }
 
 func (cmd LsCmd) createArgParser() *argparser.ArgParser {
@@ -88,7 +84,7 @@ func (cmd LsCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, lsDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, lsDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -16,10 +16,6 @@ package commands
 
 import (
 	"context"
-	"io"
-	"sort"
-	"strings"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -30,6 +26,9 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/funcitr"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
+	"io"
+	"sort"
+	"strings"
 )
 
 const (
@@ -37,17 +36,21 @@ const (
 )
 
 var lsShortDesc = "List tables"
-var lsLongDesc = "With no arguments lists the tables in the current working set but if a commit is specified it will list " +
-	"the tables in that commit.  If the --verbose flag is provided a row count and a hash of the table will also be " +
-	"displayed.\n" +
-	"\n" +
-	"If the --system flag is supplied this will show the dolt system tables which are queryable with SQL.  Some system " +
-	"tables can be queried even if they are not in the working set by specifying appropriate parameters in the SQL " +
-	"queries.  To see these tables too you may pass the --verbose flag.\n" +
-	"\n" +
-	"If the --all flag is supplied both user and system tables will be printed."
+var lsLongDesc = `With no arguments lists the tables in the current working set but if a commit is specified it will list the tables in that commit.  If the --verbose flag is provided a row count and a hash of the table will also be displayed.
+
+If the --system flag is supplied this will show the dolt system tables which are queryable with SQL.  Some system tables can be queried even if they are not in the working set by specifying appropriate parameters in the SQL queries.  To see these tables too you may pass the --verbose flag.
+
+If the --all flag is supplied both user and system tables will be printed.
+`
+
 var lsSynopsis = []string{
-	"[--options] [<commit>]",
+	"[--options] [{{.LessThan}}commit{{.GreaterThan}}]",
+}
+
+var lsDocumentation = cli.CommandDocumentation{
+	ShortDesc: lsShortDesc,
+	LongDesc: lsLongDesc,
+	Synopsis: lsSynopsis,
 }
 
 type LsCmd struct{}
@@ -65,7 +68,7 @@ func (cmd LsCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, lsShortDesc, lsLongDesc, lsSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, lsDocumentation, ap)
 }
 
 func (cmd LsCmd) createArgParser() *argparser.ArgParser {
@@ -84,7 +87,7 @@ func (cmd LsCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, lsShortDesc, lsLongDesc, lsSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, lsDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -16,6 +16,10 @@ package commands
 
 import (
 	"context"
+	"io"
+	"sort"
+	"strings"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -26,9 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/funcitr"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
-	"io"
-	"sort"
-	"strings"
 )
 
 const (
@@ -49,8 +50,8 @@ var lsSynopsis = []string{
 
 var lsDocumentation = cli.CommandDocumentation{
 	ShortDesc: lsShortDesc,
-	LongDesc: lsLongDesc,
-	Synopsis: lsSynopsis,
+	LongDesc:  lsLongDesc,
+	Synopsis:  lsSynopsis,
 }
 
 type LsCmd struct{}

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -57,11 +57,10 @@ var mergeDocumentation  = cli.CommandDocumentation{
 	Synopsis: mergeSynopsis,
 }
 
-var abortDetails = "Abort the current conflict resolution process, and try to reconstruct the pre-merge state.\n" +
-	"\n" +
-	"If there were uncommitted working set changes present when the merge started, dolt merge --abort will be " +
-	"unable to reconstruct these changes. It is therefore recommended to always commit or stash your changes before " +
-	"running git merge."
+var abortDetails = `Abort the current conflict resolution process, and try to reconstruct the pre-merge state.
+
+If there were uncommitted working set changes present when the merge started, {{.EmphasisLeft}}dolt merge --abort{{.EmphasisRight}} will be unable to reconstruct these changes. It is therefore recommended to always commit or stash your changes before running git merge.
+`
 
 type MergeCmd struct{}
 
@@ -128,13 +127,13 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 				verr = errhand.BuildDError("error: failed to get conflicts").AddCause(err).Build()
 			} else if has {
 				cli.Println("error: Merging is not possible because you have unmerged files.")
-				cli.Println("hint: Fix them up in the work tree, and then use 'dolt add <table>'")
+				cli.Println("hint: Fix them up in the work tree, and then use {{.EmphasisLeft}}dolt add <table>{{.EmphasisRight}}")
 				cli.Println("hint: as appropriate to mark resolution and make a commit.")
 				cli.Println("fatal: Exiting because of an unresolved conflict.")
 				return 1
 			} else if dEnv.IsMergeActive() {
 				cli.Println("error: Merging is not possible because you have not committed an active merge.")
-				cli.Println("hint: add affected tables using 'dolt add <table>' and commit using 'dolt commit -m <msg>'")
+				cli.Println("hint: add affected tables using {{.EmphasisLeft}}dolt add <table>{{.EmphasisRight}} and commit using {{.EmphasisLeft}}dolt commit -m <msg>{{.EmphasisRight}}")
 				cli.Println("fatal: Exiting because of active merge")
 				return 1
 			}

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -41,9 +41,9 @@ const (
 var mergeShortDesc = "Join two or more development histories together"
 var mergeLongDesc = `Incorporates changes from the named commits (since the time their histories diverged from the current branch) into the current branch.
 
-The second syntax (\<b>dolt merge --abort</b>\) can only be run after the merge has resulted in conflicts. git merge --abort will abort the merge process and try to reconstruct the pre-merge state. However, if there were uncommitted changes when the merge started (and especially if those changes were further modified after the merge was started), dolt merge --abort will in some cases be unable to reconstruct the original (pre-merge) changes. Therefore: \n +
+The second syntax ({{.LessThan}}dolt merge --abort{{.GreaterThan}}) can only be run after the merge has resulted in conflicts. git merge {{.EmphasisLeft}}--abort{{.EmphasisRight}} will abort the merge process and try to reconstruct the pre-merge state. However, if there were uncommitted changes when the merge started (and especially if those changes were further modified after the merge was started), dolt merge {{.EmphasisLeft}}--abort{{.EmphasisRight}} will in some cases be unable to reconstruct the original (pre-merge) changes. Therefore: 
 
-<b>Warning</b>: Running dolt merge with non-trivial uncommitted changes is discouraged: while possible, it may leave you in a state that is hard to back out of in the case of a conflict.
+{{.LessThan}}Warning{{.GreaterThan}}: Running dolt merge with non-trivial uncommitted changes is discouraged: while possible, it may leave you in a state that is hard to back out of in the case of a conflict.
 `
 
 var mergeSynopsis = []string{

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -38,23 +38,19 @@ const (
 	abortParam = "abort"
 )
 
-var mergeShortDesc = "Join two or more development histories together"
-var mergeLongDesc = `Incorporates changes from the named commits (since the time their histories diverged from the current branch) into the current branch.
+var mergeDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Join two or more development histories together",
+	LongDesc: `Incorporates changes from the named commits (since the time their histories diverged from the current branch) into the current branch.
 
 The second syntax ({{.LessThan}}dolt merge --abort{{.GreaterThan}}) can only be run after the merge has resulted in conflicts. git merge {{.EmphasisLeft}}--abort{{.EmphasisRight}} will abort the merge process and try to reconstruct the pre-merge state. However, if there were uncommitted changes when the merge started (and especially if those changes were further modified after the merge was started), dolt merge {{.EmphasisLeft}}--abort{{.EmphasisRight}} will in some cases be unable to reconstruct the original (pre-merge) changes. Therefore: 
 
 {{.LessThan}}Warning{{.GreaterThan}}: Running dolt merge with non-trivial uncommitted changes is discouraged: while possible, it may leave you in a state that is hard to back out of in the case of a conflict.
-`
+`,
 
-var mergeSynopsis = []string{
-	"{{.LessThan}}branch{{.GreaterThan}}",
-	"--abort",
-}
-
-var mergeDocumentation = cli.CommandDocumentation{
-	ShortDesc: mergeShortDesc,
-	LongDesc:  mergeLongDesc,
-	Synopsis:  mergeSynopsis,
+	Synopsis: []string{
+		"{{.LessThan}}branch{{.GreaterThan}}",
+		"--abort",
+	},
 }
 
 var abortDetails = `Abort the current conflict resolution process, and try to reconstruct the pre-merge state.
@@ -77,7 +73,7 @@ func (cmd MergeCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd MergeCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, mergeDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, mergeDocs, ap))
 }
 
 func (cmd MergeCmd) createArgParser() *argparser.ArgParser {
@@ -94,7 +90,7 @@ func (cmd MergeCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, mergeDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, mergeDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -51,10 +51,10 @@ var mergeSynopsis = []string{
 	"--abort",
 }
 
-var mergeDocumentation  = cli.CommandDocumentation{
+var mergeDocumentation = cli.CommandDocumentation{
 	ShortDesc: mergeShortDesc,
-	LongDesc: mergeLongDesc,
-	Synopsis: mergeSynopsis,
+	LongDesc:  mergeLongDesc,
+	Synopsis:  mergeSynopsis,
 }
 
 var abortDetails = `Abort the current conflict resolution process, and try to reconstruct the pre-merge state.

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -39,20 +39,22 @@ const (
 )
 
 var mergeShortDesc = "Join two or more development histories together"
-var mergeLongDesc = "Incorporates changes from the named commits (since the time their histories diverged from the " +
-	"current branch) into the current branch.\n" +
-	"\n" +
-	"The second syntax (\"<b>dolt merge --abort</b>\") can only be run after the merge has resulted in conflicts. " +
-	"git merge --abort will abort the merge process and try to reconstruct the pre-merge state. However, if there were " +
-	"uncommitted changes when the merge started (and especially if those changes were further modified after the merge " +
-	"was started), dolt merge --abort will in some cases be unable to reconstruct the original (pre-merge) changes. " +
-	"Therefore: \n" +
-	"\n" +
-	"<b>Warning</b>: Running dolt merge with non-trivial uncommitted changes is discouraged: while possible, it may " +
-	"leave you in a state that is hard to back out of in the case of a conflict."
+var mergeLongDesc = `Incorporates changes from the named commits (since the time their histories diverged from the current branch) into the current branch.
+
+The second syntax (\<b>dolt merge --abort</b>\) can only be run after the merge has resulted in conflicts. git merge --abort will abort the merge process and try to reconstruct the pre-merge state. However, if there were uncommitted changes when the merge started (and especially if those changes were further modified after the merge was started), dolt merge --abort will in some cases be unable to reconstruct the original (pre-merge) changes. Therefore: \n +
+
+<b>Warning</b>: Running dolt merge with non-trivial uncommitted changes is discouraged: while possible, it may leave you in a state that is hard to back out of in the case of a conflict.
+`
+
 var mergeSynopsis = []string{
-	"<branch>",
+	"{{.LessThan}}branch{{.GreaterThan}}",
 	"--abort",
+}
+
+var mergeDocumentation  = cli.CommandDocumentation{
+	ShortDesc: mergeShortDesc,
+	LongDesc: mergeLongDesc,
+	Synopsis: mergeSynopsis,
 }
 
 var abortDetails = "Abort the current conflict resolution process, and try to reconstruct the pre-merge state.\n" +
@@ -76,7 +78,7 @@ func (cmd MergeCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd MergeCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, mergeShortDesc, mergeLongDesc, mergeSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, mergeDocumentation, ap)
 }
 
 func (cmd MergeCmd) createArgParser() *argparser.ArgParser {
@@ -93,7 +95,7 @@ func (cmd MergeCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, mergeShortDesc, mergeLongDesc, mergeSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, mergeDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -16,25 +16,29 @@ package commands
 
 import (
 	"context"
-
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
+	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var pullShortDesc = "Fetch from and integrate with another repository or a local branch"
-var pullLongDesc = "Incorporates changes from a remote repository into the current branch. In its default mode, " +
-	"<b>dolt pull</b> is shorthand for <b>dolt fetch</b> followed by <b>dolt merge <remote>/<branch></b>." +
-	"\n" +
-	"\nMore precisely, dolt pull runs dolt fetch with the given parameters and calls dolt merge to merge the retrieved " +
-	"branch heads into the current branch."
+var pullLongDesc = `Incorporates changes from a remote repository into the current branch. In its default mode, <b>dolt pull</b> is shorthand for <b>dolt fetch</b> followed by <b>dolt merge <remote>/<branch></b>.
+
+More precisely, dolt pull runs dolt fetch with the given parameters and calls dolt merge to merge the retrieved branch heads into the current branch.
+`
+
 var pullSynopsis = []string{
 	"<remote>",
+}
+
+var pullDocumentation = cli.CommandDocumentation{
+	ShortDesc: pullShortDesc,
+	LongDesc: pullLongDesc,
+	Synopsis: pullSynopsis,
 }
 
 type PullCmd struct{}
@@ -52,7 +56,7 @@ func (cmd PullCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd PullCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, pullShortDesc, pullLongDesc, pullSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, pullDocumentation, ap)
 }
 
 func (cmd PullCmd) createArgParser() *argparser.ArgParser {
@@ -68,7 +72,7 @@ func (cmd PullCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, pullShortDesc, pullLongDesc, pullSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, pullDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 	branch := dEnv.RepoState.CWBHeadRef()
 

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -26,20 +26,15 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var pullShortDesc = "Fetch from and integrate with another repository or a local branch"
-var pullLongDesc = `Incorporates changes from a remote repository into the current branch. In its default mode, {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} is shorthand for {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt merge <remote>/<branch>{{.EmphasisRight}}.
+var pullDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Fetch from and integrate with another repository or a local branch",
+	LongDesc: `Incorporates changes from a remote repository into the current branch. In its default mode, {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} is shorthand for {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt merge <remote>/<branch>{{.EmphasisRight}}.
 
 More precisely, dolt pull runs dolt fetch with the given parameters and calls dolt merge to merge the retrieved branch heads into the current branch.
-`
-
-var pullSynopsis = []string{
-	"{{.LessThan}}remote{{.GreaterThan}}",
-}
-
-var pullDocumentation = cli.CommandDocumentation{
-	ShortDesc: pullShortDesc,
-	LongDesc:  pullLongDesc,
-	Synopsis:  pullSynopsis,
+`,
+	Synopsis: []string{
+		"{{.LessThan}}remote{{.GreaterThan}}",
+	},
 }
 
 type PullCmd struct{}
@@ -57,7 +52,7 @@ func (cmd PullCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd PullCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, pullDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, pullDocs, ap))
 }
 
 func (cmd PullCmd) createArgParser() *argparser.ArgParser {
@@ -73,7 +68,7 @@ func (cmd PullCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, pullDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, pullDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	branch := dEnv.RepoState.CWBHeadRef()
 

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"context"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -37,8 +38,8 @@ var pullSynopsis = []string{
 
 var pullDocumentation = cli.CommandDocumentation{
 	ShortDesc: pullShortDesc,
-	LongDesc: pullLongDesc,
-	Synopsis: pullSynopsis,
+	LongDesc:  pullLongDesc,
+	Synopsis:  pullSynopsis,
 }
 
 type PullCmd struct{}

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -30,7 +30,7 @@ var pullDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Fetch from and integrate with another repository or a local branch",
 	LongDesc: `Incorporates changes from a remote repository into the current branch. In its default mode, {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} is shorthand for {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt merge <remote>/<branch>{{.EmphasisRight}}.
 
-More precisely, dolt pull runs dolt fetch with the given parameters and calls dolt merge to merge the retrieved branch heads into the current branch.
+More precisely, dolt pull runs {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} with the given parameters and calls {{.EmphasisLeft}}dolt merge{{.EmphasisRight}} to merge the retrieved branch {{.EmphasisLeft}}HEAD{{.EmphasisRight}} into the current branch.
 `,
 	Synopsis: []string{
 		"{{.LessThan}}remote{{.GreaterThan}}",

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -26,13 +26,13 @@ import (
 )
 
 var pullShortDesc = "Fetch from and integrate with another repository or a local branch"
-var pullLongDesc = `Incorporates changes from a remote repository into the current branch. In its default mode, <b>dolt pull</b> is shorthand for <b>dolt fetch</b> followed by <b>dolt merge <remote>/<branch></b>.
+var pullLongDesc = `Incorporates changes from a remote repository into the current branch. In its default mode, {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} is shorthand for {{.EmphasisLeft}}dolt fetch{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt merge <remote>/<branch>{{.EmphasisRight}}.
 
 More precisely, dolt pull runs dolt fetch with the given parameters and calls dolt merge to merge the retrieved branch heads into the current branch.
 `
 
 var pullSynopsis = []string{
-	"<remote>",
+	"{{.LessThan}}remote{{.GreaterThan}}",
 }
 
 var pullDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -17,7 +17,11 @@ package commands
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/dustin/go-humanize"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -31,8 +35,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/earl"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/datas"
-	"sync"
-	"time"
 )
 
 const (
@@ -56,8 +58,8 @@ var pushSynopsis = []string{
 
 var pushDocumentation = cli.CommandDocumentation{
 	ShortDesc: pushShortDesc,
-	LongDesc: pushLongDesc,
-	Synopsis: pushSynopsis,
+	LongDesc:  pushLongDesc,
+	Synopsis:  pushSynopsis,
 }
 
 type PushCmd struct{}

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -57,7 +57,6 @@ When neither the command-line does not specify what to push, the default behavio
 	},
 }
 
-
 type PushCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -80,7 +80,7 @@ func (cmd PushCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) e
 
 func (cmd PushCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsFlag(SetUpstreamFlag, "u", "For every branch that is up to date or successfully pushed, add upstream (tracking) reference, used by argument-less dolt pull and other commands.")
+	ap.SupportsFlag(SetUpstreamFlag, "u", "For every branch that is up to date or successfully pushed, add upstream (tracking) reference, used by argument-less {{.EmphasisLeft}}dolt pull{{.EmphasisRight}} and other commands.")
 	return ap
 }
 

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -17,11 +17,7 @@ package commands
 import (
 	"context"
 	"fmt"
-	"sync"
-	"time"
-
 	"github.com/dustin/go-humanize"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
@@ -35,6 +31,8 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/earl"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/datas"
+	"sync"
+	"time"
 )
 
 const (
@@ -43,21 +41,23 @@ const (
 
 var pushShortDesc = "Update remote refs along with associated objects"
 
-var pushLongDesc = "Updates remote refs using local refs, while sending objects necessary to complete the given refs." +
-	"\n" +
-	"\nWhen the command line does not specify where to push with the <remote> argument, an attempt is made to infer the " +
-	"remote.  If only one remote exists it will be used, if multiple remotes exists, a remote named 'origin' will be " +
-	"attempted.  If there is more than one remote, and none of them are named 'origin' then the command will fail and " +
-	"you will need to specify the correct remote explicitly." +
-	"\n" +
-	"\nWhen the command line does not specify what to push with <refspec>... then the current branch will be used." +
-	"\n" +
-	"\nWhen neither the command-line does not specify what to push, the default behavior is used, which corresponds to the " +
-	"current branch being pushed to the corresponding upstream branch, but as a safety measure, the push is aborted if " +
-	"the upstream branch does not have the same name as the local one."
+var pushLongDesc = `Updates remote refs using local refs, while sending objects necessary to complete the given refs. 
+
+When the command line does not specify where to push with the <remote> argument, an attempt is made to infer the remote.  If only one remote exists it will be used, if multiple remotes exists, a remote named 'origin' will be attempted.  If there is more than one remote, and none of them are named 'origin' then the command will fail and you will need to specify the correct remote explicitly.
+
+When the command line does not specify what to push with <refspec>... then the current branch will be used.
+
+When neither the command-line does not specify what to push, the default behavior is used, which corresponds to the current branch being pushed to the corresponding upstream branch, but as a safety measure, the push is aborted if the upstream branch does not have the same name as the local one.
+`
 
 var pushSynopsis = []string{
-	"[-u | --set-upstream] [<remote>] [<refspec>]",
+	"[-u | --set-upstream] [{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}}]",
+}
+
+var pushDocumentation = cli.CommandDocumentation{
+	ShortDesc: pushShortDesc,
+	LongDesc: pushLongDesc,
+	Synopsis: pushSynopsis,
 }
 
 type PushCmd struct{}
@@ -75,7 +75,7 @@ func (cmd PushCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd PushCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, pushShortDesc, pushLongDesc, pushSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, pushDocumentation, ap)
 }
 
 func (cmd PushCmd) createArgParser() *argparser.ArgParser {
@@ -92,7 +92,7 @@ func (cmd PushCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, pushShortDesc, pushLongDesc, pushSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, pushDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, err := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -43,9 +43,9 @@ var pushShortDesc = "Update remote refs along with associated objects"
 
 var pushLongDesc = `Updates remote refs using local refs, while sending objects necessary to complete the given refs. 
 
-When the command line does not specify where to push with the <remote> argument, an attempt is made to infer the remote.  If only one remote exists it will be used, if multiple remotes exists, a remote named 'origin' will be attempted.  If there is more than one remote, and none of them are named 'origin' then the command will fail and you will need to specify the correct remote explicitly.
+When the command line does not specify where to push with the {{.LessThan}}remote{{.GreaterThan}} argument, an attempt is made to infer the remote.  If only one remote exists it will be used, if multiple remotes exists, a remote named 'origin' will be attempted.  If there is more than one remote, and none of them are named 'origin' then the command will fail and you will need to specify the correct remote explicitly.
 
-When the command line does not specify what to push with <refspec>... then the current branch will be used.
+When the command line does not specify what to push with {{.LessThan}}refspec{{.GreaterThan}}... then the current branch will be used.
 
 When neither the command-line does not specify what to push, the default behavior is used, which corresponds to the current branch being pushed to the corresponding upstream branch, but as a safety measure, the push is aborted if the upstream branch does not have the same name as the local one.
 `

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -41,26 +41,22 @@ const (
 	SetUpstreamFlag = "set-upstream"
 )
 
-var pushShortDesc = "Update remote refs along with associated objects"
-
-var pushLongDesc = `Updates remote refs using local refs, while sending objects necessary to complete the given refs. 
+var pushDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Update remote refs along with associated objects",
+	LongDesc: `Updates remote refs using local refs, while sending objects necessary to complete the given refs.
 
 When the command line does not specify where to push with the {{.LessThan}}remote{{.GreaterThan}} argument, an attempt is made to infer the remote.  If only one remote exists it will be used, if multiple remotes exists, a remote named 'origin' will be attempted.  If there is more than one remote, and none of them are named 'origin' then the command will fail and you will need to specify the correct remote explicitly.
 
 When the command line does not specify what to push with {{.LessThan}}refspec{{.GreaterThan}}... then the current branch will be used.
 
 When neither the command-line does not specify what to push, the default behavior is used, which corresponds to the current branch being pushed to the corresponding upstream branch, but as a safety measure, the push is aborted if the upstream branch does not have the same name as the local one.
-`
+`,
 
-var pushSynopsis = []string{
-	"[-u | --set-upstream] [{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}}]",
+	Synopsis: []string{
+		"[-u | --set-upstream] [{{.LessThan}}remote{{.GreaterThan}}] [{{.LessThan}}refspec{{.GreaterThan}}]",
+	},
 }
 
-var pushDocumentation = cli.CommandDocumentation{
-	ShortDesc: pushShortDesc,
-	LongDesc:  pushLongDesc,
-	Synopsis:  pushSynopsis,
-}
 
 type PushCmd struct{}
 
@@ -77,7 +73,7 @@ func (cmd PushCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd PushCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, pushDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, pushDocs, ap))
 }
 
 func (cmd PushCmd) createArgParser() *argparser.ArgParser {
@@ -94,7 +90,7 @@ func (cmd PushCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, pushDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, pushDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, err := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -67,8 +67,8 @@ var remoteSynopsis = []string{
 
 var remoteDocumentation = cli.CommandDocumentation{
 	ShortDesc: pushShortDesc,
-	LongDesc: pushLongDesc,
-	Synopsis: pushSynopsis,
+	LongDesc:  pushLongDesc,
+	Synopsis:  pushSynopsis,
 }
 
 const (

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -40,12 +40,12 @@ var ErrInvalidPort = errors.New("invalid port")
 var remoteShortDesc = "Manage set of tracked repositories"
 var remoteLongDesc = `With no arguments, shows a list of existing remotes. Several subcommands are available to perform operations on the remotes.
 
-\n<b>add</b>
-Adds a remote named <name> for the repository at <url>. The command dolt fetch <name> can then be used to create and update remote-tracking branches <name>/<branch>.
+{{.EmphasisLeft}}add{{.EmphasisRight}}
+Adds a remote named {{.LessThan}}name{{.GreaterThan}} for the repository at {{.LessThan}}url{{.GreaterThan}}. The command dolt fetch {{.LessThan}}name{{.GreaterThan}} can then be used to create and update remote-tracking branches {{.EmphasisLeft}}<name>/<branch>{{.EmphasisRight}}.
 
-The <url> parameter supports url schemes of http, https, aws, gs, and file.  If a url scheme does not prefix the url then https is assumed.  If the <url> paramenter is in the format <organization>/<repository> then dolt will use the remotes.default_host from your configuration file (Which will be dolthub.com unless changed).
+The {{.LessThan}}url{{.GreaterThan}} parameter supports url schemes of http, https, aws, gs, and file.  If a url scheme does not prefix the url then https is assumed.  If the {{.LessThan}}url{{.GreaterThan}} paramenter is in the format {{.EmphasisLeft}}<organization>/<repository>{{.EmphasisRight}} then dolt will use the {{.EmphasisLeft}}remotes.default_host{{.EmphasisRight}} from your configuration file (Which will be dolthub.com unless changed).
 
-AWS cloud remote urls should be of the form aws://[dynamo-table:s3-bucket]/database.  You may configure your aws cloud remote using the optional parameters aws-region, aws-creds-type, aws-creds-file.
+AWS cloud remote urls should be of the form {{.EmphasisLeft}}aws://[dynamo-table:s3-bucket]/database{{.EmphasisRight}}.  You may configure your aws cloud remote using the optional parameters {{.EmphasisLeft}}aws-region{{.EmphasisRight}}, {{.EmphasisLeft}}aws-creds-type{{.EmphasisRight}}, {{.EmphasisLeft}}aws-creds-file{{.EmphasisRight}}.
 
 aws-creds-type specifies the means by which credentials should be retrieved in order to access the specified cloud resources (specifically the dynamo table, and the s3 bucket). Valid values are 'role', 'env', or 'file'.
 
@@ -55,11 +55,9 @@ aws-creds-type specifies the means by which credentials should be retrieved in o
 	
 GCP remote urls should be of the form gs://gcs-bucket/database and will use the credentials setup using the gcloud command line available from Google +
 
-The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_scheme for details.
-
-<b>remove, rm</b>\n +
-Remove the remote named <name>. All remote-tracking branches and configuration settings +
-for the remote are removed.`
+The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_schemethi
+{{.EmphasisLeft}}remove{{.EmphasisRight}}, {{.EmphasisLeft}}rm{{.EmphasisRight}}, 
+Remove the remote named {{.LessThan}}name{{.GreaterThan}}. All remote-tracking branches and configuration settings for the remote are removed.`
 
 var remoteSynopsis = []string{
 	"[-v | --verbose]",

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -37,8 +37,9 @@ import (
 
 var ErrInvalidPort = errors.New("invalid port")
 
-var remoteShortDesc = "Manage set of tracked repositories"
-var remoteLongDesc = `With no arguments, shows a list of existing remotes. Several subcommands are available to perform operations on the remotes.
+var remoteDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Manage set of tracked repositories",
+	LongDesc: `With no arguments, shows a list of existing remotes. Several subcommands are available to perform operations on the remotes.
 
 {{.EmphasisLeft}}add{{.EmphasisRight}}
 Adds a remote named {{.LessThan}}name{{.GreaterThan}} for the repository at {{.LessThan}}url{{.GreaterThan}}. The command dolt fetch {{.LessThan}}name{{.GreaterThan}} can then be used to create and update remote-tracking branches {{.EmphasisLeft}}<name>/<branch>{{.EmphasisRight}}.
@@ -57,18 +58,13 @@ GCP remote urls should be of the form gs://gcs-bucket/database and will use the 
 
 The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_schemethi
 {{.EmphasisLeft}}remove{{.EmphasisRight}}, {{.EmphasisLeft}}rm{{.EmphasisRight}}, 
-Remove the remote named {{.LessThan}}name{{.GreaterThan}}. All remote-tracking branches and configuration settings for the remote are removed.`
+Remove the remote named {{.LessThan}}name{{.GreaterThan}}. All remote-tracking branches and configuration settings for the remote are removed.`,
 
-var remoteSynopsis = []string{
-	"[-v | --verbose]",
-	"add [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}url{{.GreaterThan}}",
-	"remove {{.LessThan}}name{{.GreaterThan}}",
-}
-
-var remoteDocumentation = cli.CommandDocumentation{
-	ShortDesc: pushShortDesc,
-	LongDesc:  pushLongDesc,
-	Synopsis:  pushSynopsis,
+	Synopsis: []string{
+		"[-v | --verbose]",
+		"add [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}url{{.GreaterThan}}",
+		"remove {{.LessThan}}name{{.GreaterThan}}",
+	},
 }
 
 const (
@@ -94,7 +90,7 @@ func (cmd RemoteCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RemoteCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, remoteDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, remoteDocs, ap))
 }
 
 func (cmd RemoteCmd) createArgParser() *argparser.ArgParser {
@@ -118,7 +114,7 @@ func (cmd RemoteCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, remoteDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, remoteDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -38,41 +38,39 @@ import (
 var ErrInvalidPort = errors.New("invalid port")
 
 var remoteShortDesc = "Manage set of tracked repositories"
-var remoteLongDesc = "With no arguments, shows a list of existing remotes. Several subcommands are available to perform " +
-	"operations on the remotes." +
-	"\n" +
-	"\n<b>add</b>\n" +
-	"Adds a remote named <name> for the repository at <url>. The command dolt fetch <name> can " +
-	"then be used to create and update remote-tracking branches <name>/<branch>." +
-	"\n" +
-	"\nThe <url> parameter supports url schemes of http, https, aws, gs, and file.  If a url scheme does not prefix the " +
-	"url then https is assumed.  If the <url> paramenter is in the format <organization>/<repository> then dolt will use " +
-	"the remotes.default_host from your configuration file (Which will be dolthub.com unless changed).\n" +
-	"\n" +
-	"AWS cloud remote urls should be of the form aws://[dynamo-table:s3-bucket]/database.  You may configure your aws " +
-	"cloud remote using the optional parameters aws-region, aws-creds-type, aws-creds-file.\n" +
-	"\n" +
-	"aws-creds-type specifies the means by which credentials should be retrieved in order to access the specified " +
-	"cloud resources (specifically the dynamo table, and the s3 bucket). Valid values are 'role', 'env', or 'file'.\n" +
-	"\n" +
-	"\trole: Use the credentials installed for the current user\n" +
-	"\tenv: Looks for environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY\n" +
-	"\tfile: Uses the credentials file specified by the parameter aws-creds-file\n" +
-	"\n" +
-	"GCP remote urls should be of the form gs://gcs-bucket/database and will use the credentials setup using the gcloud " +
-	"command line available from Google" +
-	"\n" +
-	"The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See" +
-	"https://en.wikipedia.org/wiki/File_URI_scheme for details." +
-	"\n" +
-	"\n<b>remove, rm</b>\n" +
-	"Remove the remote named <name>. All remote-tracking branches and configuration settings" +
-	"for the remote are removed."
+var remoteLongDesc = `With no arguments, shows a list of existing remotes. Several subcommands are available to perform operations on the remotes.
+
+\n<b>add</b>
+Adds a remote named <name> for the repository at <url>. The command dolt fetch <name> can then be used to create and update remote-tracking branches <name>/<branch>.
+
+The <url> parameter supports url schemes of http, https, aws, gs, and file.  If a url scheme does not prefix the url then https is assumed.  If the <url> paramenter is in the format <organization>/<repository> then dolt will use the remotes.default_host from your configuration file (Which will be dolthub.com unless changed).
+
+AWS cloud remote urls should be of the form aws://[dynamo-table:s3-bucket]/database.  You may configure your aws cloud remote using the optional parameters aws-region, aws-creds-type, aws-creds-file.
+
+aws-creds-type specifies the means by which credentials should be retrieved in order to access the specified cloud resources (specifically the dynamo table, and the s3 bucket). Valid values are 'role', 'env', or 'file'.
+
+	\trole: Use the credentials installed for the current user
+	\tenv: Looks for environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
+	\tfile: Uses the credentials file specified by the parameter aws-creds-file
+	
+GCP remote urls should be of the form gs://gcs-bucket/database and will use the credentials setup using the gcloud command line available from Google +
+
+The local filesystem can be used as a remote by providing a repository url in the format file://absolute path. See https://en.wikipedia.org/wiki/File_URI_scheme for details.
+
+<b>remove, rm</b>\n +
+Remove the remote named <name>. All remote-tracking branches and configuration settings +
+for the remote are removed.`
 
 var remoteSynopsis = []string{
 	"[-v | --verbose]",
-	"add [--aws-region <region>] [--aws-creds-type <creds-type>] [--aws-creds-file <file>] [--aws-creds-profile <profile>] <name> <url>",
-	"remove <name>",
+	"add [--aws-region {{.LessThan}}region{{.GreaterThan}}] [--aws-creds-type {{.LessThan}}creds-type{{.GreaterThan}}] [--aws-creds-file {{.LessThan}}file{{.GreaterThan}}] [--aws-creds-profile {{.LessThan}}profile{{.GreaterThan}}] {{.LessThan}}name{{.GreaterThan}} {{.LessThan}}url{{.GreaterThan}}",
+	"remove {{.LessThan}}name{{.GreaterThan}}",
+}
+
+var remoteDocumentation = cli.CommandDocumentation{
+	ShortDesc: pushShortDesc,
+	LongDesc: pushLongDesc,
+	Synopsis: pushSynopsis,
 }
 
 const (
@@ -98,7 +96,7 @@ func (cmd RemoteCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RemoteCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, remoteShortDesc, remoteLongDesc, remoteSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, remoteDocumentation, ap)
 }
 
 func (cmd RemoteCmd) createArgParser() *argparser.ArgParser {
@@ -122,7 +120,7 @@ func (cmd RemoteCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, remoteShortDesc, remoteLongDesc, remoteSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, remoteDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -80,7 +80,7 @@ func (cmd ResetCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) 
 
 func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
-	ap.SupportsFlag(HardResetParam, "", "Resets the working tables and staged tables. Any changes to tracked tables in the working tree since <commit> are discarded.")
+	ap.SupportsFlag(HardResetParam, "", "Resets the working tables and staged tables. Any changes to tracked tables in the working tree since {{.LessThan}}commit{{.GreaterThan}} are discarded.")
 	ap.SupportsFlag(SoftResetParam, "", "Does not touch the working tables, but removes all tables staged to be committed.")
 	return ap
 }

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -56,8 +56,8 @@ var resetSynopsis = []string{
 
 var resetDocumentation = cli.CommandDocumentation{
 	ShortDesc: resetShortDesc,
-	LongDesc: resetLongDesc,
-	Synopsis: resetSynopsis,
+	LongDesc:  resetLongDesc,
+	Synopsis:  resetSynopsis,
 }
 
 type ResetCmd struct{}

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -54,6 +54,12 @@ var resetSynopsis = []string{
 	"[--hard | --soft]",
 }
 
+var resetDocumentation = cli.CommandDocumentation{
+	ShortDesc: resetShortDesc,
+	LongDesc: resetLongDesc,
+	Synopsis: resetSynopsis,
+}
+
 type ResetCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -69,7 +75,7 @@ func (cmd ResetCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ResetCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, resetShortDesc, resetLongDesc, resetSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, resetDocumentation, ap)
 }
 
 func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
@@ -82,7 +88,7 @@ func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, resetShortDesc, resetLongDesc, resetSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, resetDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -37,7 +37,7 @@ const (
 var resetShortDesc = "Resets staged tables to their HEAD state"
 var resetLongDesc = `Sets the state of a table in the staging area to be that table's value at HEAD
 
-dolt reset <tables>...
+{{.EmphasisLeft}}dolt reset <tables>...{{.EmphasisRight}}"
 	This form resets the values for all staged {{.LessThan}}tables{{.GreaterThan}} to their values at {{.EmphasisLeft}}HEAD{{.EmphasisRight}}. (It does not affect the working tree or
 	the current branch.)
 

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -34,8 +34,9 @@ const (
 	HardResetParam = "hard"
 )
 
-var resetShortDesc = "Resets staged tables to their HEAD state"
-var resetLongDesc = `Sets the state of a table in the staging area to be that table's value at HEAD
+var resetDocContent = cli.CommandDocumentationContent{
+	ShortDesc: "Resets staged tables to their HEAD state",
+	LongDesc: `Sets the state of a table in the staging area to be that table's value at HEAD
 
 {{.EmphasisLeft}}dolt reset <tables>...{{.EmphasisRight}}"
 	This form resets the values for all staged {{.LessThan}}tables{{.GreaterThan}} to their values at {{.EmphasisLeft}}HEAD{{.EmphasisRight}}. (It does not affect the working tree or
@@ -47,17 +48,12 @@ var resetLongDesc = `Sets the state of a table in the staging area to be that ta
 	contents out of the staged tables to the working tables.
 
 dolt reset .
-	This form resets {{.EmphasisLeft}}all{{.EmphasisRight}} staged tables to their values at HEAD. It is the opposite of {{.EmphasisLeft}}dolt add .{{.EmphasisRight}}`
+	This form resets {{.EmphasisLeft}}all{{.EmphasisRight}} staged tables to their values at HEAD. It is the opposite of {{.EmphasisLeft}}dolt add .{{.EmphasisRight}}`,
 
-var resetSynopsis = []string{
-	"{{.LessThan}}tables{{.GreaterThan}}...",
-	"[--hard | --soft]",
-}
-
-var resetDocumentation = cli.CommandDocumentation{
-	ShortDesc: resetShortDesc,
-	LongDesc:  resetLongDesc,
-	Synopsis:  resetSynopsis,
+	Synopsis: []string{
+		"{{.LessThan}}tables{{.GreaterThan}}...",
+		"[--hard | --soft]",
+	},
 }
 
 type ResetCmd struct{}
@@ -75,7 +71,7 @@ func (cmd ResetCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ResetCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, resetDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, resetDocContent, ap))
 }
 
 func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
@@ -88,7 +84,7 @@ func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, resetDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, resetDocContent, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -38,19 +38,19 @@ var resetShortDesc = "Resets staged tables to their HEAD state"
 var resetLongDesc = `Sets the state of a table in the staging area to be that table's value at HEAD
 
 dolt reset <tables>...
-	This form resets the values for all staged <tables> to their values at HEAD. (It does not affect the working tree or
+	This form resets the values for all staged {{.LessThan}}tables{{.GreaterThan}} to their values at {{.EmphasisLeft}}HEAD{{.EmphasisRight}}. (It does not affect the working tree or
 	the current branch.)
 
-	This means that </b>dolt reset <tables></b> is the opposite of <b>dolt add <tables></b>.
+	This means that {{.EmphasisLeft}}dolt reset <tables>{{.EmphasisRight}} is the opposite of {{.EmphasisLeft}}dolt add <tables>{{.EmphasisRight}}.
 
-	After running <b>dolt reset <tables></b> to update the staged tables, you can use <b>dolt checkout</b> to check the
+	After running {{.EmphasisLeft}}dolt reset <tables>{{.EmphasisRight}} to update the staged tables, you can use {{.EmphasisLeft}}dolt checkout{{.EmphasisRight}} to check the
 	contents out of the staged tables to the working tables.
 
 dolt reset .
-	This form resets <b>all</b> staged tables to their values at HEAD. It is the opposite of <b>dolt add .</b>`
+	This form resets {{.EmphasisLeft}}all{{.EmphasisRight}} staged tables to their values at HEAD. It is the opposite of {{.EmphasisLeft}}dolt add .{{.EmphasisRight}}`
 
 var resetSynopsis = []string{
-	"<tables>...",
+	"{{.LessThan}}tables{{.GreaterThan}}...",
 	"[--hard | --soft]",
 }
 

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -29,16 +29,13 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-var schExportShortDesc = "Exports a table's schema."
-var schExportLongDesc = ""
-var schExportSynopsis = []string{
-	"{{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
-}
 
-var schExportDocumentation = cli.CommandDocumentation{
-	ShortDesc: schExportShortDesc,
-	LongDesc:  schExportLongDesc,
-	Synopsis:  schExportSynopsis,
+var schExportDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Exports a table's schema.",
+	LongDesc: "",
+	Synopsis: []string{
+		"{{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+	},
 }
 
 const (
@@ -62,7 +59,7 @@ func (cmd ExportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, schExportDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, schExportDocs, ap))
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {
@@ -83,7 +80,7 @@ func (cmd ExportCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, schExportDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, schExportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	root, verr := commands.GetWorkingWithVErr(dEnv)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -35,6 +35,12 @@ var schExportSynopsis = []string{
 	"<table> <file>",
 }
 
+var schExportDocumentation = cli.CommandDocumentation{
+	ShortDesc: schExportShortDesc,
+	LongDesc: schExportLongDesc,
+	Synopsis: schExportSynopsis,
+}
+
 const (
 	defaultParam = "default"
 	tagParam     = "tag"
@@ -56,7 +62,7 @@ func (cmd ExportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, schExportShortDesc, schExportLongDesc, schExportSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, schExportDocumentation, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {
@@ -77,7 +83,7 @@ func (cmd ExportCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, schExportShortDesc, schExportLongDesc, schExportSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, schExportDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	root, verr := commands.GetWorkingWithVErr(dEnv)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -32,7 +32,7 @@ import (
 var schExportShortDesc = "Exports a table's schema."
 var schExportLongDesc = ""
 var schExportSynopsis = []string{
-	"<table> <file>",
+	"{{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 }
 
 var schExportDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -29,10 +29,9 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-
 var schExportDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Exports a table's schema.",
-	LongDesc: "",
+	LongDesc:  "",
 	Synopsis: []string{
 		"{{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 	},

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -37,8 +37,8 @@ var schExportSynopsis = []string{
 
 var schExportDocumentation = cli.CommandDocumentation{
 	ShortDesc: schExportShortDesc,
-	LongDesc: schExportLongDesc,
-	Synopsis: schExportSynopsis,
+	LongDesc:  schExportLongDesc,
+	Synopsis:  schExportSynopsis,
 }
 
 const (

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -55,21 +55,21 @@ const (
 )
 
 var schImportShortDesc = "Creates a new table with an inferred schema."
-var schImportLongDesc = `If <b>--create | -c</b> is given the operation will create <table> with a schema that it infers from the supplied file. One or more primary key columns must be specified using the <b>--pks</b> parameter.
+var schImportLongDesc = `If {{.EmphasisLeft}}--create | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} with a schema that it infers from the supplied file. One or more primary key columns must be specified using the {{.EmphasisLeft}}--pks{{.EmphasisRight}} parameter.
 
-If <b>--update | -u</b> is given the operation will update <table> any additional columns, or change the types of columns based on the file supplied.  If the <b>--keep-types</b> parameter is supplied then the types for existing columns will not be modified, even if they differ from what is in the supplied file.
+If {{.EmphasisLeft}}--update | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} any additional columns, or change the types of columns based on the file supplied.  If the {{.EmphasisLeft}}--keep-types{{.EmphasisRight}} parameter is supplied then the types for existing columns will not be modified, even if they differ from what is in the supplied file.
 
-If <b>--replace | -r</b> is given the operation will replace <table> with a new, empty table which has a schema inferred from the supplied file but columns tags will be maintained across schemas.  <b>--keep-types</b> can also be supplied here to guarantee that types are the same in the file and in the pre-existing table.
+If {{.EmphasisLeft}}--replace | -r{{.EmphasisRight}} is given the operation will replace {{.LessThan}}table{{.GreaterThan}} with a new, empty table which has a schema inferred from the supplied file but columns tags will be maintained across schemas.  {{.EmphasisLeft}}--keep-types{{.EmphasisRight}} can also be supplied here to guarantee that types are the same in the file and in the pre-existing table.
 
 A mapping file can be used to map fields between the file being imported and the table's schema being inferred.  This can be used when creating a new table, or updating or replacing an existing table.
 
 tblcmds.MappingFileHelp
 
-In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the <b>--file-type</b> parameter should be used to explicitly define the format of the file in one of the supported formats (Currently only csv is supported).  For files separated by a delimiter other than a ',', the --delim parameter can be used to specify a delimeter.
+In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (Currently only csv is supported).  For files separated by a delimiter other than a ',', the --delim parameter can be used to specify a delimeter.
 
-If the parameter <b>--dry-run</b> is supplied a sql statement will be generated showing what would be executed if this were run without the --dry-run flag
+If the parameter {{.EmphasisLeft}}--dry-run{{.EmphasisRight}} is supplied a sql statement will be generated showing what would be executed if this were run without the --dry-run flag
 
-<b>--float-threshold</b> is the threshold at which a string representing a floating point number should be interpreted as a float versus an int.  If FloatThreshold is 0.0 then any number with a decimal point will be interpreted as a float (such as 0.0, 1.0, etc).  If FloatThreshold is 1.0 then any number with a decimal point will be converted to an int (0.5 will be the int 0, 1.99 will be the int 1, etc.  If the FloatThreshold is 0.001 then numbers with a fractional component greater than or equal to 0.001 will be treated as a float (1.0 would be an int, 1.0009 would be an int, 1.001 would be a float, 1.1 would be a float, etc)
+{{.EmphasisLeft}}--float-threshold{{.EmphasisRight}} is the threshold at which a string representing a floating point number should be interpreted as a float versus an int.  If FloatThreshold is 0.0 then any number with a decimal point will be interpreted as a float (such as 0.0, 1.0, etc).  If FloatThreshold is 1.0 then any number with a decimal point will be converted to an int (0.5 will be the int 0, 1.99 will be the int 1, etc.  If the FloatThreshold is 0.001 then numbers with a fractional component greater than or equal to 0.001 will be treated as a float (1.0 would be an int, 1.0009 would be an int, 1.001 would be a float, 1.1 would be a float, etc)
 `
 
 var schImportSynopsis = []string{

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -55,39 +55,31 @@ const (
 )
 
 var schImportShortDesc = "Creates a new table with an inferred schema."
-var schImportLongDesc = "If <b>--create | -c</b> is given the operation will create <table> with a schema that it infers" +
-	"from the supplied file. One or more primary key columns must be specified using the <b>--pks</b> parameter.\n" +
-	"\n" +
-	"If <b>--update | -u</b> is given the operation will update <table> any additional columns, or change the types of columns" +
-	"based on the file supplied.  If the <b>--keep-types</b> parameter is supplied then the types for existing columns will" +
-	"not be modified, even if they differ from what is in the supplied file." +
-	"\n" +
-	"If <b>--replace | -r</b> is given the operation will replace <table> with a new, empty table which has a schema inferred from" +
-	"the supplied file but columns tags will be maintained across schemas.  <b>--keep-types</b> can also be supplied here" +
-	"to guarantee that types are the same in the file and in the pre-existing table.\n" +
-	"\n" +
-	"A mapping file can be used to map fields between the file being imported and the table's schema being inferred.  This can" +
-	"be used when creating a new table, or updating or replacing an existing table.\n" +
-	"\n" +
-	tblcmds.MappingFileHelp +
-	"\n" +
-	"In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not" +
-	"have the expected extension then the <b>--file-type</b> parameter should be used to explicitly define the format of" +
-	"the file in one of the supported formats (Currently only csv is supported).  For files separated by a delimiter other than a" +
-	"',', the --delim parameter can be used to specify a delimeter.\n" +
-	"\n" +
-	"If the parameter <b>--dry-run</b> is supplied a sql statement will be generated showing what would be executed if this" +
-	"were run without the --dry-run flag\n" +
-	"\n" +
-	"<b>--float-threshold</b> is the threshold at which a string representing a floating point number should be interpreted as" +
-	"a float versus an int.  If FloatThreshold is 0.0 then any number with a decimal point will be interpreted as a" +
-	"float (such as 0.0, 1.0, etc).  If FloatThreshold is 1.0 then any number with a decimal point will be converted" +
-	"to an int (0.5 will be the int 0, 1.99 will be the int 1, etc.  If the FloatThreshold is 0.001 then numbers with" +
-	"a fractional component greater than or equal to 0.001 will be treated as a float (1.0 would be an int, 1.0009 would" +
-	"be an int, 1.001 would be a float, 1.1 would be a float, etc)"
+var schImportLongDesc = `If <b>--create | -c</b> is given the operation will create <table> with a schema that it infers from the supplied file. One or more primary key columns must be specified using the <b>--pks</b> parameter.
+
+If <b>--update | -u</b> is given the operation will update <table> any additional columns, or change the types of columns based on the file supplied.  If the <b>--keep-types</b> parameter is supplied then the types for existing columns will not be modified, even if they differ from what is in the supplied file.
+
+If <b>--replace | -r</b> is given the operation will replace <table> with a new, empty table which has a schema inferred from the supplied file but columns tags will be maintained across schemas.  <b>--keep-types</b> can also be supplied here to guarantee that types are the same in the file and in the pre-existing table.
+
+A mapping file can be used to map fields between the file being imported and the table's schema being inferred.  This can be used when creating a new table, or updating or replacing an existing table.
+
+tblcmds.MappingFileHelp
+
+In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the <b>--file-type</b> parameter should be used to explicitly define the format of the file in one of the supported formats (Currently only csv is supported).  For files separated by a delimiter other than a ',', the --delim parameter can be used to specify a delimeter.
+
+If the parameter <b>--dry-run</b> is supplied a sql statement will be generated showing what would be executed if this were run without the --dry-run flag
+
+<b>--float-threshold</b> is the threshold at which a string representing a floating point number should be interpreted as a float versus an int.  If FloatThreshold is 0.0 then any number with a decimal point will be interpreted as a float (such as 0.0, 1.0, etc).  If FloatThreshold is 1.0 then any number with a decimal point will be converted to an int (0.5 will be the int 0, 1.99 will be the int 1, etc.  If the FloatThreshold is 0.001 then numbers with a fractional component greater than or equal to 0.001 will be treated as a float (1.0 would be an int, 1.0009 would be an int, 1.001 would be a float, 1.1 would be a float, etc)
+`
 
 var schImportSynopsis = []string{
-	"[--create|--replace] [--force] [--dry-run] [--lower|--upper] [--keep-types] [--file-type <type>] [--float-threshold] [--map <mapping-file>] [--delim <delimiter>]--pks <field>,... <table> <file>",
+	`[--create|--replace] [--force] [--dry-run] [--lower|--upper] [--keep-types] [--file-type {{.LessThan}}type{{.GreaterThan}}] [--float-threshold] [--map {{.LessThan}}mapping-file{{.GreaterThan}}] [--delim {{.LessThan}}delimiter{{.GreaterThan}}]--pks {{.LessThan}}field{{.GreaterThan}},... {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}`,
+}
+
+var schImportDocumentation = cli.CommandDocumentation{
+	ShortDesc: schImportShortDesc,
+	LongDesc: schImportShortDesc,
+	Synopsis: schImportSynopsis,
 }
 
 type importOp int
@@ -126,7 +118,7 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, schImportShortDesc, schImportLongDesc, schImportSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, schImportDocumentation, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
@@ -150,7 +142,7 @@ func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, schImportShortDesc, schImportLongDesc, schImportSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, schImportDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -78,8 +78,8 @@ var schImportSynopsis = []string{
 
 var schImportDocumentation = cli.CommandDocumentation{
 	ShortDesc: schImportShortDesc,
-	LongDesc: schImportShortDesc,
-	Synopsis: schImportSynopsis,
+	LongDesc:  schImportShortDesc,
+	Synopsis:  schImportSynopsis,
 }
 
 type importOp int

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -54,8 +54,9 @@ const (
 	delimParam          = "delim"
 )
 
-var schImportShortDesc = "Creates a new table with an inferred schema."
-var schImportLongDesc = `If {{.EmphasisLeft}}--create | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} with a schema that it infers from the supplied file. One or more primary key columns must be specified using the {{.EmphasisLeft}}--pks{{.EmphasisRight}} parameter.
+var schImportDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Creates a new table with an inferred schema.",
+	LongDesc: `If {{.EmphasisLeft}}--create | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} with a schema that it infers from the supplied file. One or more primary key columns must be specified using the {{.EmphasisLeft}}--pks{{.EmphasisRight}} parameter.
 
 If {{.EmphasisLeft}}--update | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} any additional columns, or change the types of columns based on the file supplied.  If the {{.EmphasisLeft}}--keep-types{{.EmphasisRight}} parameter is supplied then the types for existing columns will not be modified, even if they differ from what is in the supplied file.
 
@@ -70,16 +71,11 @@ In create, update, and replace scenarios the file's extension is used to infer t
 If the parameter {{.EmphasisLeft}}--dry-run{{.EmphasisRight}} is supplied a sql statement will be generated showing what would be executed if this were run without the --dry-run flag
 
 {{.EmphasisLeft}}--float-threshold{{.EmphasisRight}} is the threshold at which a string representing a floating point number should be interpreted as a float versus an int.  If FloatThreshold is 0.0 then any number with a decimal point will be interpreted as a float (such as 0.0, 1.0, etc).  If FloatThreshold is 1.0 then any number with a decimal point will be converted to an int (0.5 will be the int 0, 1.99 will be the int 1, etc.  If the FloatThreshold is 0.001 then numbers with a fractional component greater than or equal to 0.001 will be treated as a float (1.0 would be an int, 1.0009 would be an int, 1.001 would be a float, 1.1 would be a float, etc)
-`
+`,
 
-var schImportSynopsis = []string{
-	`[--create|--replace] [--force] [--dry-run] [--lower|--upper] [--keep-types] [--file-type {{.LessThan}}type{{.GreaterThan}}] [--float-threshold] [--map {{.LessThan}}mapping-file{{.GreaterThan}}] [--delim {{.LessThan}}delimiter{{.GreaterThan}}]--pks {{.LessThan}}field{{.GreaterThan}},... {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}`,
-}
-
-var schImportDocumentation = cli.CommandDocumentation{
-	ShortDesc: schImportShortDesc,
-	LongDesc:  schImportShortDesc,
-	Synopsis:  schImportSynopsis,
+	Synopsis: []string{
+		`[--create|--replace] [--force] [--dry-run] [--lower|--upper] [--keep-types] [--file-type {{.LessThan}}type{{.GreaterThan}}] [--float-threshold] [--map {{.LessThan}}mapping-file{{.GreaterThan}}] [--delim {{.LessThan}}delimiter{{.GreaterThan}}]--pks {{.LessThan}}field{{.GreaterThan}},... {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}`,
+	},
 }
 
 type importOp int
@@ -118,21 +114,21 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, schImportDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, schImportDocs, ap))
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
 	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{"table", "Name of the table to be created."})
 	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{"file", "The file being used to infer the schema."})
-	ap.SupportsFlag(createFlag, "c", "Create a table with the schema inferred from the <file> provided.")
-	ap.SupportsFlag(updateFlag, "u", "Update a table to match the inferred schema of the <file> provided")
-	ap.SupportsFlag(replaceFlag, "r", "Replace a table with a new schema that has the inferred schema from the <file> provided. All previous data will be lost.")
+	ap.SupportsFlag(createFlag, "c", "Create a table with the schema inferred from the {{.LessThan}}file{{.GreaterThan}} provided.")
+	ap.SupportsFlag(updateFlag, "u", "Update a table to match the inferred schema of the {{.LessThan}}file{{.GreaterThan}} provided")
+	ap.SupportsFlag(replaceFlag, "r", "Replace a table with a new schema that has the inferred schema from the {{.LessThan}}file{{.GreaterThan}} provided. All previous data will be lost.")
 	ap.SupportsFlag(dryRunFlag, "", "Print the sql statement that would be run if executed without the flag.")
-	ap.SupportsFlag(keepTypesParam, "", "When a column already exists in the table, and it's also in the <file> provided, use the type from the table.")
+	ap.SupportsFlag(keepTypesParam, "", "When a column already exists in the table, and it's also in the {{.LessThan}}file{{.GreaterThan}} provided, use the type from the table.")
 	ap.SupportsString(fileTypeParam, "", "type", "Explicitly define the type of the file if it can't be inferred from the file extension.")
 	ap.SupportsString(pksParam, "", "comma-separated-col-names", "List of columns used as the primary key cols.  Order of the columns will determine sort order.")
-	ap.SupportsString(mappingParam, "", "mapping-file", "A file that can map a column name in <file> to a new value.")
+	ap.SupportsString(mappingParam, "", "mapping-file", "A file that can map a column name in {{.LessThan}}file{{.GreaterThan}} to a new value.")
 	ap.SupportsString(floatThresholdParam, "", "float", "Minimum value at which the fractional component of a value must exceed in order to be considered a float.")
 	ap.SupportsString(delimParam, "", "delimiter", "Specify a delimiter for a csv style file with a non-comma delimiter.")
 	return ap
@@ -142,7 +138,7 @@ func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, schImportDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, schImportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -29,7 +29,7 @@ import (
 )
 
 var tblSchemaShortDesc = "Shows the schema of one or more tables."
-var tblSchemaLongDesc = `dolt table schema displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +
+var tblSchemaLongDesc = `{{.EmphasisLeft}}dolt table schema{{.EmphasisRight}} displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +
 
 A list of tables can optionally be provided.  If it is omitted all table schemas will be shown.`
 

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -30,19 +30,15 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var tblSchemaShortDesc = "Shows the schema of one or more tables."
-var tblSchemaLongDesc = `{{.EmphasisLeft}}dolt table schema{{.EmphasisRight}} displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +
 
-A list of tables can optionally be provided.  If it is omitted all table schemas will be shown.`
+var tblSchemaDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Shows the schema of one or more tables.",
+	LongDesc: `{{.EmphasisLeft}}dolt table schema{{.EmphasisRight}} displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +
 
-var tblSchemaSynopsis = []string{
-	"[{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}table{{.GreaterThan}}...]",
-}
-
-var tblSchemaDocumentation = cli.CommandDocumentation{
-	ShortDesc: tblSchemaShortDesc,
-	LongDesc:  tblSchemaLongDesc,
-	Synopsis:  tblSchemaSynopsis,
+A list of tables can optionally be provided.  If it is omitted all table schemas will be shown.`,
+	Synopsis: []string{
+		"[{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}table{{.GreaterThan}}...]",
+	},
 }
 
 var bold = color.New(color.Bold)
@@ -62,7 +58,7 @@ func (cmd ShowCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ShowCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, tblSchemaDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap))
 }
 
 func (cmd ShowCmd) createArgParser() *argparser.ArgParser {
@@ -80,7 +76,7 @@ func (cmd ShowCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblSchemaDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	verr := printSchemas(ctx, apr, dEnv)

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -30,7 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
 var tblSchemaDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Shows the schema of one or more tables.",
 	LongDesc: `{{.EmphasisLeft}}dolt table schema{{.EmphasisRight}} displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -16,9 +16,7 @@ package schcmds
 
 import (
 	"context"
-
 	"github.com/fatih/color"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
@@ -31,12 +29,18 @@ import (
 )
 
 var tblSchemaShortDesc = "Shows the schema of one or more tables."
-var tblSchemaLongDesc = "dolt table schema displays the schema of tables at a given commit.  If no commit is provided the working set will be used." +
-	"\n" +
-	"A list of tables can optionally be provided.  If it is omitted all table schemas will be shown."
+var tblSchemaLongDesc = `dolt table schema displays the schema of tables at a given commit.  If no commit is provided the working set will be used. +
+
+A list of tables can optionally be provided.  If it is omitted all table schemas will be shown.`
 
 var tblSchemaSynopsis = []string{
-	"[<commit>] [<table>...]",
+	"[{{.LessThan}}commit{{.GreaterThan}}] [{{.LessThan}}table{{.GreaterThan}}...]",
+}
+
+var tblSchemaDocumentation = cli.CommandDocumentation{
+	ShortDesc: tblSchemaShortDesc,
+	LongDesc: tblSchemaLongDesc,
+	Synopsis: tblSchemaSynopsis,
 }
 
 var bold = color.New(color.Bold)
@@ -56,7 +60,7 @@ func (cmd ShowCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ShowCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, tblSchemaShortDesc, tblSchemaLongDesc, tblSchemaSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, tblSchemaDocumentation, ap)
 }
 
 func (cmd ShowCmd) createArgParser() *argparser.ArgParser {
@@ -74,7 +78,7 @@ func (cmd ShowCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblSchemaShortDesc, tblSchemaLongDesc, tblSchemaSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, tblSchemaDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	verr := printSchemas(ctx, apr, dEnv)

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -16,7 +16,9 @@ package schcmds
 
 import (
 	"context"
+
 	"github.com/fatih/color"
+
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
@@ -39,8 +41,8 @@ var tblSchemaSynopsis = []string{
 
 var tblSchemaDocumentation = cli.CommandDocumentation{
 	ShortDesc: tblSchemaShortDesc,
-	LongDesc: tblSchemaLongDesc,
-	Synopsis: tblSchemaSynopsis,
+	LongDesc:  tblSchemaLongDesc,
+	Synopsis:  tblSchemaSynopsis,
 }
 
 var bold = color.New(color.Bold)

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -38,8 +38,6 @@ const (
 	sendMetricsShortDesc = "Send metrics to the events server or print them to stdout"
 )
 
-var sendMetricsDocumentation = cli.CommandDocumentation{ShortDesc: sendMetricsShortDesc}
-
 type SendMetricsCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -74,7 +72,7 @@ func (cmd SendMetricsCmd) Exec(ctx context.Context, commandStr string, args []st
 	ap := argparser.NewArgParser()
 	ap.SupportsFlag(outputFlag, "o", "Flush events to stdout.")
 
-	help, _ := cli.HelpAndUsagePrinters(commandStr, sendMetricsDocumentation, ap)
+	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cli.CommandDocumentationContent{ShortDesc: sendMetricsShortDesc}, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	metricsDisabled := dEnv.Config.GetStringOrDefault(env.MetricsDisabled, "false")

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -33,13 +33,12 @@ import (
 
 // SendMetricsCommand is the command used for sending metrics
 const (
-	SendMetricsCommand  = "send-metrics"
-	outputFlag          = "output"
+	SendMetricsCommand   = "send-metrics"
+	outputFlag           = "output"
 	sendMetricsShortDesc = "Send metrics to the events server or print them to stdout"
 )
 
 var sendMetricsDocumentation = cli.CommandDocumentation{ShortDesc: sendMetricsShortDesc}
-
 
 type SendMetricsCmd struct{}
 

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -35,8 +35,11 @@ import (
 const (
 	SendMetricsCommand  = "send-metrics"
 	outputFlag          = "output"
-	sendMetricsShortDec = "Send metrics to the events server or print them to stdout"
+	sendMetricsShortDesc = "Send metrics to the events server or print them to stdout"
 )
+
+var sendMetricsDocumentation = cli.CommandDocumentation{ShortDesc: sendMetricsShortDesc}
+
 
 type SendMetricsCmd struct{}
 
@@ -72,7 +75,7 @@ func (cmd SendMetricsCmd) Exec(ctx context.Context, commandStr string, args []st
 	ap := argparser.NewArgParser()
 	ap.SupportsFlag(outputFlag, "o", "Flush events to stdout.")
 
-	help, _ := cli.HelpAndUsagePrinters(commandStr, sendMetricsShortDec, "", []string{}, ap)
+	help, _ := cli.HelpAndUsagePrinters(commandStr, sendMetricsDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	metricsDisabled := dEnv.Config.GetStringOrDefault(env.MetricsDisabled, "false")

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -78,6 +78,12 @@ var sqlSynopsis = []string{
 	"-q <query> -s <name> -m <message>",
 }
 
+var sqlDocumentation = cli.CommandDocumentation{
+	ShortDesc: sqlShortDesc,
+	LongDesc: sqlLongDesc,
+	Synopsis: sqlSynopsis,
+}
+
 const (
 	queryFlag   = "query"
 	formatFlag  = "result-format"
@@ -103,7 +109,7 @@ func (cmd SqlCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd SqlCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, sqlShortDesc, sqlLongDesc, sqlSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, sqlDocumentation, ap)
 }
 
 func (cmd SqlCmd) createArgParser() *argparser.ArgParser {
@@ -123,7 +129,7 @@ func (cmd SqlCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlShortDesc, sqlLongDesc, sqlSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlDocumentation, ap)
 
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -55,8 +55,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
-
-
 var sqlDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Runs a SQL query",
 	LongDesc: `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -57,8 +57,7 @@ import (
 
 var sqlDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Runs a SQL query",
-	LongDesc: `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the
-results. With the {{.EmphasisLeft}}-q{{.EmphasisRight}} option, runs the given query and prints any results, then exits.
+	LongDesc: `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the results. With the {{.EmphasisLeft}}-q{{.EmphasisRight}} option, runs the given query and prints any results, then exits.
 
 Pipe SQL statements to dolt sql (no {{.EmphasisLeft}}-q{{.EmphasisRight}}) to execute a SQL import or update script. 
 
@@ -67,10 +66,7 @@ Known limitations:
 * No support for foreign keys
 * No support for column constraints besides NOT NULL
 * No support for default values
-* Column types aren't always preserved accurately from SQL create table statements. VARCHAR columns are unlimited 
-    length; FLOAT, INTEGER columns are 64 bit
-* Joins can only use indexes for two table joins. Three or more tables in a join query will use a non-indexed
-    join, which is very slow.
+* Joins can only use indexes for two table joins. Three or more tables in a join query will use a non-indexed join, which is very slow.
 `,
 	Synopsis: []string{
 		"",

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -55,8 +55,11 @@ import (
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
-var sqlShortDesc = "Runs a SQL query"
-var sqlLongDesc = `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the
+
+
+var sqlDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Runs a SQL query",
+	LongDesc: `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the
 results. With the {{.EmphasisLeft}}-q{{.EmphasisRight}} option, runs the given query and prints any results, then exits.
 
 Pipe SQL statements to dolt sql (no {{.EmphasisLeft}}-q{{.EmphasisRight}}) to execute a SQL import or update script. 
@@ -70,18 +73,13 @@ Known limitations:
     length; FLOAT, INTEGER columns are 64 bit
 * Joins can only use indexes for two table joins. Three or more tables in a join query will use a non-indexed
     join, which is very slow.
-`
-var sqlSynopsis = []string{
-	"",
-	"-q {{.LessThan}}query{{.GreaterThan}}",
-	"-q {{.LessThan}}query{{.GreaterThan}} -r {{.LessThan}}result format{{.GreaterThan}}",
-	"-q {{.LessThan}}query{{.GreaterThan}} -s {{.LessThan}}name{{.GreaterThan}} -m {{.LessThan}}message{{.GreaterThan}}",
-}
-
-var sqlDocumentation = cli.CommandDocumentation{
-	ShortDesc: sqlShortDesc,
-	LongDesc:  sqlLongDesc,
-	Synopsis:  sqlSynopsis,
+`,
+	Synopsis: []string{
+		"",
+		"-q {{.LessThan}}query{{.GreaterThan}}",
+		"-q {{.LessThan}}query{{.GreaterThan}} -r {{.LessThan}}result format{{.GreaterThan}}",
+		"-q {{.LessThan}}query{{.GreaterThan}} -s {{.LessThan}}name{{.GreaterThan}} -m {{.LessThan}}message{{.GreaterThan}}",
+	},
 }
 
 const (
@@ -109,7 +107,7 @@ func (cmd SqlCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd SqlCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, sqlDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, sqlDocs, ap))
 }
 
 func (cmd SqlCmd) createArgParser() *argparser.ArgParser {
@@ -129,7 +127,7 @@ func (cmd SqlCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, sqlDocs, ap))
 
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -57,9 +57,9 @@ import (
 
 var sqlShortDesc = "Runs a SQL query"
 var sqlLongDesc = `Runs a SQL query you specify. By default, begins an interactive shell to run queries and view the
-results. With the -q option, runs the given query and prints any results, then exits.
+results. With the {{.EmphasisLeft}}-q{{.EmphasisRight}} option, runs the given query and prints any results, then exits.
 
-Pipe SQL statements to dolt sql (no -q) to execute a SQL import or update script. 
+Pipe SQL statements to dolt sql (no {{.EmphasisLeft}}-q{{.EmphasisRight}}) to execute a SQL import or update script. 
 
 Known limitations:
 * No support for creating indexes
@@ -73,9 +73,9 @@ Known limitations:
 `
 var sqlSynopsis = []string{
 	"",
-	"-q <query>",
-	"-q <query> -r <result format>",
-	"-q <query> -s <name> -m <message>",
+	"-q {{.LessThan}}query{{.GreaterThan}}",
+	"-q {{.LessThan}}query{{.GreaterThan}} -r {{.LessThan}}result format{{.GreaterThan}}",
+	"-q {{.LessThan}}query{{.GreaterThan}} -s {{.LessThan}}name{{.GreaterThan}} -m {{.LessThan}}message{{.GreaterThan}}",
 }
 
 var sqlDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -80,8 +80,8 @@ var sqlSynopsis = []string{
 
 var sqlDocumentation = cli.CommandDocumentation{
 	ShortDesc: sqlShortDesc,
-	LongDesc: sqlLongDesc,
-	Synopsis: sqlSynopsis,
+	LongDesc:  sqlLongDesc,
+	Synopsis:  sqlSynopsis,
 }
 
 const (

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -40,11 +40,10 @@ const (
 var sqlServerShortDesc = "Start a MySQL-compatible server."
 var sqlServerLongDesc = `Start a MySQL-compatible server which can be connected to by MySQL clients.
 
-Currently, only SELECT statements are operational, as support for other statements is
-still being developed.
+Currently, only {{.EmphasisLeft}}SELECT{{.EmphasisRight}} statements are operational, as support for other statements is still being developed.
 `
 var sqlServerSynopsis = []string{
-	"[-H <host>] [-P <port>] [-u <user>] [-p <password>] [-t <timeout>] [-l <loglevel>] [-r]",
+	"[-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}] [-t {{.LessThan}}timeout{{.GreaterThan}}] [-l {{.LessThan}}loglevel{{.GreaterThan}}] [-r]",
 }
 
 var sqlServerDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -47,6 +47,12 @@ var sqlServerSynopsis = []string{
 	"[-H <host>] [-P <port>] [-u <user>] [-p <password>] [-t <timeout>] [-l <loglevel>] [-r]",
 }
 
+var sqlServerDocumentation = cli.CommandDocumentation{
+	ShortDesc: sqlServerShortDesc,
+	LongDesc:  sqlServerLongDesc,
+	Synopsis:  sqlServerSynopsis,
+}
+
 type SqlServerCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -62,7 +68,7 @@ func (cmd SqlServerCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd SqlServerCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := createArgParser(DefaultServerConfig())
-	return cli.CreateMarkdown(fs, path, commandStr, sqlServerShortDesc, sqlServerLongDesc, sqlServerSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, sqlServerDocumentation, ap)
 }
 
 func createArgParser(serverConfig *ServerConfig) *argparser.ArgParser {
@@ -92,7 +98,7 @@ func SqlServerImpl(ctx context.Context, commandStr string, args []string, dEnv *
 	serverConfig := DefaultServerConfig()
 
 	ap := createArgParser(serverConfig)
-	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlServerShortDesc, sqlServerLongDesc, sqlServerSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlServerDocumentation, ap)
 
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -44,8 +44,8 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 Currently, only {{.EmphasisLeft}}SELECT{{.EmphasisRight}} statements are operational, as support for other statements is still being developed.
 `,
 	Synopsis: []string{
-	"[-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}] [-t {{.LessThan}}timeout{{.GreaterThan}}] [-l {{.LessThan}}loglevel{{.GreaterThan}}] [-r]",
-},
+		"[-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}] [-t {{.LessThan}}timeout{{.GreaterThan}}] [-l {{.LessThan}}loglevel{{.GreaterThan}}] [-r]",
+	},
 }
 
 type SqlServerCmd struct{}

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -37,19 +37,15 @@ const (
 	logLevelFlag = "loglevel"
 )
 
-var sqlServerShortDesc = "Start a MySQL-compatible server."
-var sqlServerLongDesc = `Start a MySQL-compatible server which can be connected to by MySQL clients.
+var sqlServerDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Start a MySQL-compatible server.",
+	LongDesc: `Start a MySQL-compatible server which can be connected to by MySQL clients.
 
 Currently, only {{.EmphasisLeft}}SELECT{{.EmphasisRight}} statements are operational, as support for other statements is still being developed.
-`
-var sqlServerSynopsis = []string{
+`,
+	Synopsis: []string{
 	"[-H {{.LessThan}}host{{.GreaterThan}}] [-P {{.LessThan}}port{{.GreaterThan}}] [-u {{.LessThan}}user{{.GreaterThan}}] [-p {{.LessThan}}password{{.GreaterThan}}] [-t {{.LessThan}}timeout{{.GreaterThan}}] [-l {{.LessThan}}loglevel{{.GreaterThan}}] [-r]",
-}
-
-var sqlServerDocumentation = cli.CommandDocumentation{
-	ShortDesc: sqlServerShortDesc,
-	LongDesc:  sqlServerLongDesc,
-	Synopsis:  sqlServerSynopsis,
+},
 }
 
 type SqlServerCmd struct{}
@@ -67,7 +63,7 @@ func (cmd SqlServerCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd SqlServerCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := createArgParser(DefaultServerConfig())
-	return commands.CreateMarkdown(fs, path, commandStr, sqlServerDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap))
 }
 
 func createArgParser(serverConfig *ServerConfig) *argparser.ArgParser {
@@ -97,7 +93,7 @@ func SqlServerImpl(ctx context.Context, commandStr string, args []string, dEnv *
 	serverConfig := DefaultServerConfig()
 
 	ap := createArgParser(serverConfig)
-	help, usage := cli.HelpAndUsagePrinters(commandStr, sqlServerDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap))
 
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -39,8 +39,8 @@ var statusSynopsis = []string{""}
 
 var statusDocumentation = cli.CommandDocumentation{
 	ShortDesc: statusShortDesc,
-	LongDesc: statusLongDesc,
-	Synopsis: statusSynopsis,
+	LongDesc:  statusLongDesc,
+	Synopsis:  statusSynopsis,
 }
 
 type StatusCmd struct{}

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -33,12 +33,10 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
 
-
-
 var statusDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Show the working status",
-	LongDesc: `Displays working tables that differ from the current HEAD commit, tables that differ from the staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would commit by running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}; the second and third are what you could commit by running {{.EmphasisLeft}}dolt add .{{.GreaterThan}} before running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}.`,
-	Synopsis: []string{""},
+	LongDesc:  `Displays working tables that differ from the current HEAD commit, tables that differ from the staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would commit by running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}; the second and third are what you could commit by running {{.EmphasisLeft}}dolt add .{{.GreaterThan}} before running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}.`,
+	Synopsis:  []string{""},
 }
 
 type StatusCmd struct{}

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -33,14 +33,12 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
 
-var statusShortDesc = "Show the working status"
-var statusLongDesc = `Displays working tables that differ from the current HEAD commit, tables that differ from the staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would commit by running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}; the second and third are what you could commit by running {{.EmphasisLeft}}dolt add .{{.GreaterThan}} before running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}.`
-var statusSynopsis = []string{""}
 
-var statusDocumentation = cli.CommandDocumentation{
-	ShortDesc: statusShortDesc,
-	LongDesc:  statusLongDesc,
-	Synopsis:  statusSynopsis,
+
+var statusDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Show the working status",
+	LongDesc: `Displays working tables that differ from the current HEAD commit, tables that differ from the staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would commit by running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}; the second and third are what you could commit by running {{.EmphasisLeft}}dolt add .{{.GreaterThan}} before running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}.`,
+	Synopsis: []string{""},
 }
 
 type StatusCmd struct{}
@@ -58,7 +56,7 @@ func (cmd StatusCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd StatusCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, commandStr, statusDocumentation, ap)
+	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, statusDocs, ap))
 }
 
 func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
@@ -69,7 +67,7 @@ func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(commandStr, statusDocumentation, ap)
+	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, statusDocs, ap))
 	cli.ParseArgs(ap, args, help)
 
 	stagedTblDiffs, notStagedTblDiffs, err := actions.GetTableDiffs(ctx, dEnv)

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -41,6 +41,12 @@ before running <b>dolt commit</b>.`
 
 var statusSynopsis = []string{""}
 
+var statusDocumentation = cli.CommandDocumentation{
+	ShortDesc: statusShortDesc,
+	LongDesc: statusLongDesc,
+	Synopsis: statusSynopsis,
+}
+
 type StatusCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -56,7 +62,7 @@ func (cmd StatusCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd StatusCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, statusShortDesc, statusLongDesc, statusSynopsis, ap)
+	return CreateMarkdown(fs, path, commandStr, statusDocumentation, ap)
 }
 
 func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
@@ -67,7 +73,7 @@ func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(commandStr, statusShortDesc, statusLongDesc, statusSynopsis, ap)
+	help, _ := cli.HelpAndUsagePrinters(commandStr, statusDocumentation, ap)
 	cli.ParseArgs(ap, args, help)
 
 	stagedTblDiffs, notStagedTblDiffs, err := actions.GetTableDiffs(ctx, dEnv)

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -34,11 +34,7 @@ import (
 )
 
 var statusShortDesc = "Show the working status"
-var statusLongDesc = `Displays working tables that differ from the current HEAD commit, tables that differ from the 
-staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would 
-commit by running <b>dolt commit</b>; the second and third are what you could commit by running <b>dolt add .</b> 
-before running <b>dolt commit</b>.`
-
+var statusLongDesc = `Displays working tables that differ from the current HEAD commit, tables that differ from the staged tables, and tables that are in the working tree that are not tracked by dolt. The first are what you would commit by running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}; the second and third are what you could commit by running {{.EmphasisLeft}}dolt add .{{.GreaterThan}} before running {{.EmphasisLeft}}dolt commit{{.GreaterThan}}.`
 var statusSynopsis = []string{""}
 
 var statusDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -42,6 +42,12 @@ var tblCpSynopsis = []string{
 	"[-f] [<commit>] <oldtable> <newtable>",
 }
 
+var tblCpDocumentation = cli.CommandDocumentation{
+	ShortDesc: tblCpShortDesc,
+	LongDesc: tblCpLongDesc,
+	Synopsis: tblCpSynopsis,
+}
+
 type CpCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -57,7 +63,7 @@ func (cmd CpCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CpCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, tblCpShortDesc, tblCpLongDesc, tblCpSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, tblCpDocumentation, ap)
 }
 
 func (cmd CpCmd) createArgParser() *argparser.ArgParser {
@@ -77,7 +83,7 @@ func (cmd CpCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblCpShortDesc, tblCpLongDesc, tblCpSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, tblCpDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() < 2 || apr.NArg() > 3 {

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -42,8 +42,8 @@ var tblCpSynopsis = []string{
 
 var tblCpDocumentation = cli.CommandDocumentation{
 	ShortDesc: tblCpShortDesc,
-	LongDesc: tblCpLongDesc,
-	Synopsis: tblCpSynopsis,
+	LongDesc:  tblCpLongDesc,
+	Synopsis:  tblCpSynopsis,
 }
 
 type CpCmd struct{}

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -28,22 +28,17 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-var tblCpShortDesc = "Makes a copy of a table"
-var tblCpLongDesc = `The dolt table cp command makes a copy of a table at a given commit. If a commit is not specified the copy is made of the table from the current working set.
+var tblCpDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Makes a copy of a table",
+	LongDesc: `The dolt table cp command makes a copy of a table at a given commit. If a commit is not specified the copy is made of the table from the current working set.
 
 If a table exists at the target location this command will fail unless the {{.EmphasisLeft}}--force|-f{{.EmphasisRight}} flag is provided.  In this case the table at the target location will be overwritten with the copied table.
 
 All changes will be applied to the working tables and will need to be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.
-`
-
-var tblCpSynopsis = []string{
-	"[-f] [{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}oldtable{{.GreaterThan}} {{.LessThan}}newtable{{.GreaterThan}}",
-}
-
-var tblCpDocumentation = cli.CommandDocumentation{
-	ShortDesc: tblCpShortDesc,
-	LongDesc:  tblCpLongDesc,
-	Synopsis:  tblCpSynopsis,
+`,
+	Synopsis: []string{
+		"[-f] [{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}oldtable{{.GreaterThan}} {{.LessThan}}newtable{{.GreaterThan}}",
+	},
 }
 
 type CpCmd struct{}
@@ -61,7 +56,7 @@ func (cmd CpCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd CpCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, tblCpDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblCpDocs, ap))
 }
 
 func (cmd CpCmd) createArgParser() *argparser.ArgParser {
@@ -81,7 +76,7 @@ func (cmd CpCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblCpDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblCpDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() < 2 || apr.NArg() > 3 {

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -29,17 +29,15 @@ import (
 )
 
 var tblCpShortDesc = "Makes a copy of a table"
-var tblCpLongDesc = `The dolt table cp command makes a copy of a table at a given commit.  If a commit is not specified the copy is made of
-the table from the current working set.
+var tblCpLongDesc = `The dolt table cp command makes a copy of a table at a given commit. If a commit is not specified the copy is made of the table from the current working set.
 
-If a table exists at the target location this command will fail unless the <b>--force|-f</b> flag is provided.  In this
-case the table at the target location will be overwritten with the copied table.
+If a table exists at the target location this command will fail unless the {{.EmphasisLeft}}--force|-f{{.EmphasisRight}} flag is provided.  In this case the table at the target location will be overwritten with the copied table.
 
-All changes will be applied to the working tables and will need to be staged using <b>dolt add</b> and committed
-using <b>dolt commit</b>.`
+All changes will be applied to the working tables and will need to be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.
+`
 
 var tblCpSynopsis = []string{
-	"[-f] [<commit>] <oldtable> <newtable>",
+	"[-f] [{{.LessThan}}commit{{.GreaterThan}}] {{.LessThan}}oldtable{{.GreaterThan}} {{.LessThan}}newtable{{.GreaterThan}}",
 }
 
 var tblCpDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -16,6 +16,7 @@ package tblcmds
 
 import (
 	"context"
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"os"
 
 	"github.com/fatih/color"
@@ -36,6 +37,12 @@ var exportLongDesc = `dolt table export will export the contents of <table> to <
 See the help for <b>dolt table import</b> as the options are the same.`
 var exportSynopsis = []string{
 	"[-f] [-pk <field>] [-schema <file>] [-map <file>] [-continue] [-file-type <type>] <table> <file>",
+}
+
+var exportDocumentation = cli.CommandDocumentation{
+	ShortDesc: exportShortDesc,
+	LongDesc: exportLongDesc,
+	Synopsis: exportSynopsis,
 }
 
 // validateExportArgs validates the input from the arg parser, and returns the tuple:
@@ -87,7 +94,7 @@ func validateExportArgs(apr *argparser.ArgParseResults, usage cli.UsagePrinter) 
 }
 
 func parseExportArgs(ap *argparser.ArgParser, commandStr string, args []string) (bool, *mvdata.MoveOptions) {
-	help, usage := cli.HelpAndUsagePrinters(commandStr, exportShortDesc, exportLongDesc, exportSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, exportDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 	tableName, tableLoc, fileLoc := validateExportArgs(apr, usage)
 
@@ -126,7 +133,7 @@ func (cmd ExportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, exportShortDesc, exportLongDesc, exportSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, exportDocumentation, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -32,11 +32,11 @@ import (
 )
 
 var exportShortDesc = `Export the contents of a table to a file.`
-var exportLongDesc = `dolt table export will export the contents of <table> to <file>
+var exportLongDesc = `dolt table export will export the contents of {{.LessThan}table{{.GreaterThan}} to {{.LessThan}file{{.GreaterThan}}
 
-See the help for <b>dolt table import</b> as the options are the same.`
+See the help for {{.EmphasisLeft}dolt table import{{.EmphasisRight}} as the options are the same.`
 var exportSynopsis = []string{
-	"[-f] [-pk <field>] [-schema <file>] [-map <file>] [-continue] [-file-type <type>] <table> <file>",
+	"[-f] [-pk {{.LessThan}}field{{.GreaterThan}}] [-schema {{.LessThan}}file{{.GreaterThan}}] [-map {{.LessThan}}file{{.GreaterThan}}] [-continue] [-file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 }
 
 var exportDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -32,9 +32,11 @@ import (
 )
 
 var exportShortDesc = `Export the contents of a table to a file.`
-var exportLongDesc = `dolt table export will export the contents of {{.LessThan}table{{.GreaterThan}} to {{.LessThan}file{{.GreaterThan}}
+var exportLongDesc = `{{.EmphasisLeft}}dolt table export{{.EmphasisRight}} will export the contents of {{.LessThan}}table{{.GreaterThan}} to {{.LessThan}}|file{{.GreaterThan}}
 
-See the help for {{.EmphasisLeft}dolt table import{{.EmphasisRight}} as the options are the same.`
+See the help for {{.EmphasisLeft}}dolt table import{{.EmphasisRight}} as the options are the same.
+`
+
 var exportSynopsis = []string{
 	"[-f] [-pk {{.LessThan}}field{{.GreaterThan}}] [-schema {{.LessThan}}file{{.GreaterThan}}] [-map {{.LessThan}}file{{.GreaterThan}}] [-continue] [-file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 }

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -32,20 +32,15 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
 
-var exportShortDesc = `Export the contents of a table to a file.`
-var exportLongDesc = `{{.EmphasisLeft}}dolt table export{{.EmphasisRight}} will export the contents of {{.LessThan}}table{{.GreaterThan}} to {{.LessThan}}|file{{.GreaterThan}}
+var exportDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Export the contents of a table to a file.`,
+	LongDesc: `{{.EmphasisLeft}}dolt table export{{.EmphasisRight}} will export the contents of {{.LessThan}}table{{.GreaterThan}} to {{.LessThan}}|file{{.GreaterThan}}
 
 See the help for {{.EmphasisLeft}}dolt table import{{.EmphasisRight}} as the options are the same.
-`
-
-var exportSynopsis = []string{
-	"[-f] [-pk {{.LessThan}}field{{.GreaterThan}}] [-schema {{.LessThan}}file{{.GreaterThan}}] [-map {{.LessThan}}file{{.GreaterThan}}] [-continue] [-file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
-}
-
-var exportDocumentation = cli.CommandDocumentation{
-	ShortDesc: exportShortDesc,
-	LongDesc:  exportLongDesc,
-	Synopsis:  exportSynopsis,
+`,
+	Synopsis: []string{
+		"[-f] [-pk {{.LessThan}}field{{.GreaterThan}}] [-schema {{.LessThan}}file{{.GreaterThan}}] [-map {{.LessThan}}file{{.GreaterThan}}] [-continue] [-file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+	},
 }
 
 // validateExportArgs validates the input from the arg parser, and returns the tuple:
@@ -97,7 +92,7 @@ func validateExportArgs(apr *argparser.ArgParseResults, usage cli.UsagePrinter) 
 }
 
 func parseExportArgs(ap *argparser.ArgParser, commandStr string, args []string) (bool, *mvdata.MoveOptions) {
-	help, usage := cli.HelpAndUsagePrinters(commandStr, exportDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, exportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	tableName, tableLoc, fileLoc := validateExportArgs(apr, usage)
 
@@ -136,7 +131,7 @@ func (cmd ExportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, exportDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, exportDocs, ap))
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"os"
 
-	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
-
 	"github.com/fatih/color"
 
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -16,8 +16,9 @@ package tblcmds
 
 import (
 	"context"
-	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"os"
+
+	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 
 	"github.com/fatih/color"
 
@@ -43,8 +44,8 @@ var exportSynopsis = []string{
 
 var exportDocumentation = cli.CommandDocumentation{
 	ShortDesc: exportShortDesc,
-	LongDesc: exportLongDesc,
-	Synopsis: exportSynopsis,
+	LongDesc:  exportLongDesc,
+	Synopsis:  exportSynopsis,
 }
 
 // validateExportArgs validates the input from the arg parser, and returns the tuple:

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -63,7 +63,7 @@ var SchemaFileHelp = "Schema definition files are json files in the format:" + `
 		]
 	}
 
-where "fields" is the array of columns in each row of the table "constraints" is a list of table constraints.  (Only primary_key constraint types are supported currently) FIELD_NAME is the name of a column in a row and can be any valid string KIND must be a supported noms kind (bool, string, uuid, uint, int, float) INTEGER_FIELD_INDEX must be the 0 based index of the primary key in the "fields" array
+where "fields" is the array of columns in each row of the table "constraints" is a list of table constraints. Only primary_key constraint types are supported currently. FIELD_NAME is the name of a column in a row and can be any valid string KIND must be a supported noms kind (bool, string, uuid, uint, int, float) INTEGER_FIELD_INDEX must be the 0 based index of the primary key in the "fields" array
 `
 
 var MappingFileHelp = "A mapping file is json in the format:" + `
@@ -77,40 +77,26 @@ where source_field_name is the name of a field in the file being imported and de
 `
 
 var importShortDesc = `Imports data into a dolt table`
-var importLongDesc = `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create <table> and import the contents of file into it.  If a
-table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The
-force flag forces the existing table to be overwritten.
+var importLongDesc = `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} and import the contents of file into it.  If a table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The force flag forces the existing table to be overwritten.
 
-The schema for the new table can be specified explicitly by providing a schema definition file, or will be inferred 
-from the imported file.  All schemas, inferred or explicitly defined must define a primary key.  If the file format 
-being imported does not support defining a primary key, then the {{.EmphasisLeft}}--pk{{.EmphasisRight}} parameter must supply the name of the 
-field that should be used as the primary key.
+The schema for the new table can be specified explicitly by providing a schema definition file, or will be inferred from the imported file.  All schemas, inferred or explicitly defined must define a primary key.  If the file format being imported does not support defining a primary key, then the {{.EmphasisLeft}}--pk{{.EmphasisRight}} parameter must supply the name of the field that should be used as the primary key.
 
 ` + SchemaFileHelp +
 	`
-If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update <table> with the contents of file. The table's existing 
-schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
+If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} with the contents of file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
-During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}}
-flag to continue importing when an error is encountered.
+During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered.
 
-If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace <table> with the contents of the file. The table's
-existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is
-specified.
+If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace <table> with the contents of the file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
-If the schema for the existing table does not match the schema for the new file, the import will be aborted by default. To
-overwrite both the table and the schema, use {{.EmphasisLeft}}-c -f{{.EmphasisRight}}.
+If the schema for the existing table does not match the schema for the new file, the import will be aborted by default. To overwrite both the table and the schema, use {{.EmphasisLeft}}-c -f{{.EmphasisRight}}.
 
-A mapping file can be used to map fields between the file being imported and the table being written to.  This can 
-be used when creating a new table, or updating or replacing an existing table.
+A mapping file can be used to map fields between the file being imported and the table being written to. This can be used when creating a new table, or updating or replacing an existing table.
 
 ` + MappingFileHelp +
 
 	`
-In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not 
-have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of 
-the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a 
-',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`
+In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`
 
 var importSynopsis = []string{
 	"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -63,11 +63,7 @@ var SchemaFileHelp = "Schema definition files are json files in the format:" + `
 		]
 	}
 
-where "fields" is the array of columns in each row of the table
-"constraints" is a list of table constraints.  (Only primary_key constraint types are supported currently)
-FIELD_NAME is the name of a column in a row and can be any valid string
-KIND must be a supported noms kind (bool, string, uuid, uint, int, float)
-INTEGER_FIELD_INDEX must be the 0 based index of the primary key in the "fields" array
+where "fields" is the array of columns in each row of the table "constraints" is a list of table constraints.  (Only primary_key constraint types are supported currently) FIELD_NAME is the name of a column in a row and can be any valid string KIND must be a supported noms kind (bool, string, uuid, uint, int, float) INTEGER_FIELD_INDEX must be the 0 based index of the primary key in the "fields" array
 `
 
 var MappingFileHelp = "A mapping file is json in the format:" + `
@@ -81,29 +77,29 @@ where source_field_name is the name of a field in the file being imported and de
 `
 
 var importShortDesc = `Imports data into a dolt table`
-var importLongDesc = `If <b>--create-table | -c</b> is given the operation will create <table> and import the contents of file into it.  If a
-table already exists at this location then the operation will fail, unless the <b>--force | -f</b> flag is provided. The
+var importLongDesc = `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create <table> and import the contents of file into it.  If a
+table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The
 force flag forces the existing table to be overwritten.
 
 The schema for the new table can be specified explicitly by providing a schema definition file, or will be inferred 
 from the imported file.  All schemas, inferred or explicitly defined must define a primary key.  If the file format 
-being imported does not support defining a primary key, then the <b>--pk</b> parameter must supply the name of the 
+being imported does not support defining a primary key, then the {{.EmphasisLeft}}--pk{{.EmphasisRight}} parameter must supply the name of the 
 field that should be used as the primary key.
 
 ` + SchemaFileHelp +
 	`
-If <b>--update-table | -u</b> is given the operation will update <table> with the contents of file. The table's existing 
+If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update <table> with the contents of file. The table's existing 
 schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
-During import, if there is an error importing any row, the import will be aborted by default.  Use the <b>--continue</b>
+During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}}
 flag to continue importing when an error is encountered.
 
-If <b>--replace-table | -r</b> is given the operation will replace <table> with the contents of the file. The table's
+If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace <table> with the contents of the file. The table's
 existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is
 specified.
 
 If the schema for the existing table does not match the schema for the new file, the import will be aborted by default. To
-overwrite both the table and the schema, use <b>-c -f</b>.
+overwrite both the table and the schema, use {{.EmphasisLeft}}-c -f{{.EmphasisRight}}.
 
 A mapping file can be used to map fields between the file being imported and the table being written to.  This can 
 be used when creating a new table, or updating or replacing an existing table.
@@ -112,14 +108,14 @@ be used when creating a new table, or updating or replacing an existing table.
 
 	`
 In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not 
-have the expected extension then the <b>--file-type</b> parameter should be used to explicitly define the format of 
+have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of 
 the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a 
 ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`
 
 var importSynopsis = []string{
-	"-c [-f] [--pk <field>] [--schema <file>] [--map <file>] [--continue] [--file-type <type>] <table> <file>",
-	"-u [--map <file>] [--continue] [--file-type <type>] <table> <file>",
-	"-r [--map <file>] [--file-type <type>] <table> <file>",
+	"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+	"-u [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+	"-r [--map {{.LessThan}}file{{.GreaterThan}}] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
 }
 
 var importDocumenation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -290,7 +290,7 @@ func createArgParser() *argparser.ArgParser {
 	ap := argparser.NewArgParser()
 	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{tableParam, "The new or existing table being imported to."})
 	ap.ArgListHelp = append(ap.ArgListHelp, [2]string{fileParam, "The file being imported. Supported file types are csv, psv, and nbf."})
-	ap.SupportsFlag(createParam, "c", "Create a new table, or overwrite an existing table (with the -f flag) from the imported data.")
+	ap.SupportsFlag(createParam, "c", "Create a new table, or overwrite an existing table (with the {{.EmphasisLeft}}-f{{.EmphasisRight}} flag) from the imported data.")
 	ap.SupportsFlag(updateParam, "u", "Update an existing table with the imported data.")
 	ap.SupportsFlag(forceParam, "f", "If a create operation is being executed, data already exists in the destination, the Force flag will allow the target to be overwritten.")
 	ap.SupportsFlag(replaceParam, "r", "Replace existing table with imported data while preserving the original schema.")

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -76,8 +76,6 @@ var MappingFileHelp = "A mapping file is json in the format:" + `
 where source_field_name is the name of a field in the file being imported and dest_field_name is the name of a field in the table being imported to.
 `
 
-
-
 var importDocs = cli.CommandDocumentationContent{
 	ShortDesc: `Imports data into a dolt table`,
 	LongDesc: `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} and import the contents of file into it.  If a table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The force flag forces the existing table to be overwritten.
@@ -85,7 +83,7 @@ var importDocs = cli.CommandDocumentationContent{
 The schema for the new table can be specified explicitly by providing a schema definition file, or will be inferred from the imported file.  All schemas, inferred or explicitly defined must define a primary key.  If the file format being imported does not support defining a primary key, then the {{.EmphasisLeft}}--pk{{.EmphasisRight}} parameter must supply the name of the field that should be used as the primary key.
 
 ` + SchemaFileHelp +
-`
+		`
 If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} with the contents of file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered.
@@ -98,7 +96,7 @@ A mapping file can be used to map fields between the file being imported and the
 
 ` + MappingFileHelp +
 
-`
+		`
 In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`,
 
 	Synopsis: []string{

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -106,8 +106,8 @@ var importSynopsis = []string{
 
 var importDocumenation = cli.CommandDocumentation{
 	ShortDesc: importShortDesc,
-	LongDesc: importLongDesc,
-	Synopsis: importSynopsis,
+	LongDesc:  importLongDesc,
+	Synopsis:  importSynopsis,
 }
 
 func getMoveParameters(apr *argparser.ArgParseResults) (mvdata.MoveOperation, mvdata.TableDataLocation, mvdata.DataLocation, interface{}) {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -122,6 +122,12 @@ var importSynopsis = []string{
 	"-r [--map <file>] [--file-type <type>] <table> <file>",
 }
 
+var importDocumenation = cli.CommandDocumentation{
+	ShortDesc: importShortDesc,
+	LongDesc: importLongDesc,
+	Synopsis: importSynopsis,
+}
+
 func getMoveParameters(apr *argparser.ArgParseResults) (mvdata.MoveOperation, mvdata.TableDataLocation, mvdata.DataLocation, interface{}) {
 	var mvOp mvdata.MoveOperation
 	if apr.Contains(createParam) {
@@ -246,7 +252,7 @@ func (cmd ImportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, importShortDesc, importLongDesc, importSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, importDocumenation, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
@@ -263,7 +269,7 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
 
-	help, usage := cli.HelpAndUsagePrinters(commandStr, importShortDesc, importLongDesc, importSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, importDocumenation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	err := validateImportArgs(apr)

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -87,7 +87,7 @@ If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation
 
 During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered.
 
-If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace <table> with the contents of the file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
+If {{.EmphasisLeft}}--replace-table | -r{{.EmphasisRight}} is given the operation will replace {{.LessThan}}table{{.GreaterThan}} with the contents of the file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 If the schema for the existing table does not match the schema for the new file, the import will be aborted by default. To overwrite both the table and the schema, use {{.EmphasisLeft}}-c -f{{.EmphasisRight}}.
 

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -76,13 +76,16 @@ var MappingFileHelp = "A mapping file is json in the format:" + `
 where source_field_name is the name of a field in the file being imported and dest_field_name is the name of a field in the table being imported to.
 `
 
-var importShortDesc = `Imports data into a dolt table`
-var importLongDesc = `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} and import the contents of file into it.  If a table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The force flag forces the existing table to be overwritten.
+
+
+var importDocs = cli.CommandDocumentationContent{
+	ShortDesc: `Imports data into a dolt table`,
+	LongDesc: `If {{.EmphasisLeft}}--create-table | -c{{.EmphasisRight}} is given the operation will create {{.LessThan}}table{{.GreaterThan}} and import the contents of file into it.  If a table already exists at this location then the operation will fail, unless the {{.EmphasisLeft}}--force | -f{{.EmphasisRight}} flag is provided. The force flag forces the existing table to be overwritten.
 
 The schema for the new table can be specified explicitly by providing a schema definition file, or will be inferred from the imported file.  All schemas, inferred or explicitly defined must define a primary key.  If the file format being imported does not support defining a primary key, then the {{.EmphasisLeft}}--pk{{.EmphasisRight}} parameter must supply the name of the field that should be used as the primary key.
 
 ` + SchemaFileHelp +
-	`
+`
 If {{.EmphasisLeft}}--update-table | -u{{.EmphasisRight}} is given the operation will update {{.LessThan}}table{{.GreaterThan}} with the contents of file. The table's existing schema will be used, and field names will be used to match file fields with table fields unless a mapping file is specified.
 
 During import, if there is an error importing any row, the import will be aborted by default.  Use the {{.EmphasisLeft}}--continue{{.EmphasisRight}} flag to continue importing when an error is encountered.
@@ -95,19 +98,14 @@ A mapping file can be used to map fields between the file being imported and the
 
 ` + MappingFileHelp +
 
-	`
-In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`
+`
+In create, update, and replace scenarios the file's extension is used to infer the type of the file.  If a file does not have the expected extension then the {{.EmphasisLeft}}--file-type{{.EmphasisRight}} parameter should be used to explicitly define the format of the file in one of the supported formats (csv, psv, json, xlsx).  For files separated by a delimiter other than a ',' (type csv) or a '|' (type psv), the --delim parameter can be used to specify a delimeter`,
 
-var importSynopsis = []string{
-	"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
-	"-u [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
-	"-r [--map {{.LessThan}}file{{.GreaterThan}}] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
-}
-
-var importDocumenation = cli.CommandDocumentation{
-	ShortDesc: importShortDesc,
-	LongDesc:  importLongDesc,
-	Synopsis:  importSynopsis,
+	Synopsis: []string{
+		"-c [-f] [--pk {{.LessThan}}field{{.GreaterThan}}] [--schema {{.LessThan}}file{{.GreaterThan}}] [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+		"-u [--map {{.LessThan}}file{{.GreaterThan}}] [--continue] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+		"-r [--map {{.LessThan}}file{{.GreaterThan}}] [--file-type {{.LessThan}}type{{.GreaterThan}}] {{.LessThan}}table{{.GreaterThan}} {{.LessThan}}file{{.GreaterThan}}",
+	},
 }
 
 func getMoveParameters(apr *argparser.ArgParseResults) (mvdata.MoveOperation, mvdata.TableDataLocation, mvdata.DataLocation, interface{}) {
@@ -234,7 +232,7 @@ func (cmd ImportCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, importDocumenation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, importDocs, ap))
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
@@ -251,7 +249,7 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
 
-	help, usage := cli.HelpAndUsagePrinters(commandStr, importDocumenation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, importDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	err := validateImportArgs(apr)

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -27,24 +27,22 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-var tblMvShortDesc = "Renames a table"
-var tblMvLongDesc = `
+
+
+var tblMvDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Renames a table",
+	LongDesc: `
 The dolt table mv command will rename a table. If a table exists with the target name this command will 
 fail unless the {{.EmphasisLeft}}--force|-f{{.EmphasisRight}} flag is provided.  In that case the table at the target location will be overwritten 
 by the table being renamed.
 
 The result is equivalent of running {{.EmphasisLeft}}dolt table cp <old> <new>{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt table rm <old>{{.EmphasisRight}}, resulting 
 in a new table and a deleted table in the working set. These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed
-using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.`
+using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.`,
 
-var tblMvSynopsis = []string{
+	Synopsis: []string{
 	"[-f] {{.LessThan}}oldtable{{.EmphasisRight}} {{.LessThan}}newtable{{.EmphasisRight}}",
-}
-
-var tblMvDocumentation = cli.CommandDocumentation{
-	ShortDesc: tblMvShortDesc,
-	LongDesc:  tblMvLongDesc,
-	Synopsis:  tblMvSynopsis,
+},
 }
 
 type MvCmd struct{}
@@ -62,7 +60,7 @@ func (cmd MvCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd MvCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, tblMvDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblMvDocs, ap))
 }
 
 func (cmd MvCmd) createArgParser() *argparser.ArgParser {
@@ -81,7 +79,7 @@ func (cmd MvCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MvCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblMvDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblMvDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -30,15 +30,15 @@ import (
 var tblMvShortDesc = "Renames a table"
 var tblMvLongDesc = `
 The dolt table mv command will rename a table. If a table exists with the target name this command will 
-fail unless the <b>--force|-f</b> flag is provided.  In that case the table at the target location will be overwritten 
+fail unless the {{.EmphasisLeft}}--force|-f{{.EmphasisRight}} flag is provided.  In that case the table at the target location will be overwritten 
 by the table being renamed.
 
-The result is equivalent of running <b>dolt table cp <old> <new></b> followed by <b>dolt table rm <old></b>, resulting 
-in a new table and a deleted table in the working set. These changes can be staged using <b>dolt add</b> and committed
-using <b>dolt commit</b>.`
+The result is equivalent of running {{.EmphasisLeft}}dolt table cp <old> <new>{{.EmphasisRight}} followed by {{.EmphasisLeft}}dolt table rm <old>{{.EmphasisRight}}, resulting 
+in a new table and a deleted table in the working set. These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed
+using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.`
 
 var tblMvSynopsis = []string{
-	"[-f] <oldtable> <newtable>",
+	"[-f] {{.LessThan}}oldtable{{.EmphasisRight}} {{.LessThan}}newtable{{.EmphasisRight}}",
 }
 
 var tblMvDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -27,8 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
-
-
 var tblMvDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Renames a table",
 	LongDesc: `
@@ -41,8 +39,8 @@ in a new table and a deleted table in the working set. These changes can be stag
 using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}.`,
 
 	Synopsis: []string{
-	"[-f] {{.LessThan}}oldtable{{.EmphasisRight}} {{.LessThan}}newtable{{.EmphasisRight}}",
-},
+		"[-f] {{.LessThan}}oldtable{{.EmphasisRight}} {{.LessThan}}newtable{{.EmphasisRight}}",
+	},
 }
 
 type MvCmd struct{}

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -41,6 +41,12 @@ var tblMvSynopsis = []string{
 	"[-f] <oldtable> <newtable>",
 }
 
+var tblMvDocumentation = cli.CommandDocumentation{
+	ShortDesc: tblMvShortDesc,
+	LongDesc:  tblMvLongDesc,
+	Synopsis:  tblMvSynopsis,
+}
+
 type MvCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -56,7 +62,7 @@ func (cmd MvCmd) Description() string {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd MvCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, tblMvShortDesc, tblMvLongDesc, tblMvSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, tblMvDocumentation, ap)
 }
 
 func (cmd MvCmd) createArgParser() *argparser.ArgParser {
@@ -75,7 +81,7 @@ func (cmd MvCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MvCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblMvShortDesc, tblMvLongDesc, tblMvSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, tblMvDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -29,10 +29,9 @@ import (
 )
 
 var tblRmShortDesc = "Removes table(s) from the working set of tables."
-var tblRmLongDesc = "dolt table rm removes table(s) from the working set.  These changes can be staged using " +
-	"<b>dolt add</b> and committed using <b>dolt commit</b>"
+var tblRmLongDesc = "dolt table rm removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{EmphasisRight}}"
 var tblRmSynopsis = []string{
-	"<table>...",
+	"{{.LessThan}}table{{.GreaterThan}}...",
 }
 
 var tblRmDocumentation = cli.CommandDocumentation{

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -29,7 +29,7 @@ import (
 )
 
 var tblRmShortDesc = "Removes table(s) from the working set of tables."
-var tblRmLongDesc = "dolt table rm removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{EmphasisRight}}"
+var tblRmLongDesc = "{{.EmphasisLeft}}dolt table rm{{.EmphasisRight}} removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}"
 var tblRmSynopsis = []string{
 	"{{.LessThan}}table{{.GreaterThan}}...",
 }

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -36,8 +36,8 @@ var tblRmSynopsis = []string{
 
 var tblRmDocumentation = cli.CommandDocumentation{
 	ShortDesc: tblRmShortDesc,
-	LongDesc: tblRmLongDesc,
-	Synopsis: tblRmSynopsis,
+	LongDesc:  tblRmLongDesc,
+	Synopsis:  tblRmSynopsis,
 }
 
 type RmCmd struct{}

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -28,16 +28,12 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
-var tblRmShortDesc = "Removes table(s) from the working set of tables."
-var tblRmLongDesc = "{{.EmphasisLeft}}dolt table rm{{.EmphasisRight}} removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}"
-var tblRmSynopsis = []string{
-	"{{.LessThan}}table{{.GreaterThan}}...",
-}
-
-var tblRmDocumentation = cli.CommandDocumentation{
-	ShortDesc: tblRmShortDesc,
-	LongDesc:  tblRmLongDesc,
-	Synopsis:  tblRmSynopsis,
+var tblRmDocs = cli.CommandDocumentationContent{
+	ShortDesc: "Removes table(s) from the working set of tables.",
+	LongDesc: "{{.EmphasisLeft}}dolt table rm{{.EmphasisRight}} removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}",
+	Synopsis: []string{
+		"{{.LessThan}}table{{.GreaterThan}}...",
+	},
 }
 
 type RmCmd struct{}
@@ -60,7 +56,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, commandStr, tblRmDocumentation, ap)
+	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblRmDocs, ap))
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -72,7 +68,7 @@ func (cmd RmCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblRmDocumentation, ap)
+	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblRmDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 {

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -30,7 +30,7 @@ import (
 
 var tblRmDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Removes table(s) from the working set of tables.",
-	LongDesc: "{{.EmphasisLeft}}dolt table rm{{.EmphasisRight}} removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}",
+	LongDesc:  "{{.EmphasisLeft}}dolt table rm{{.EmphasisRight}} removes table(s) from the working set.  These changes can be staged using {{.EmphasisLeft}}dolt add{{.EmphasisRight}} and committed using {{.EmphasisLeft}}dolt commit{{.EmphasisRight}}",
 	Synopsis: []string{
 		"{{.LessThan}}table{{.GreaterThan}}...",
 	},

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -35,6 +35,12 @@ var tblRmSynopsis = []string{
 	"<table>...",
 }
 
+var tblRmDocumentation = cli.CommandDocumentation{
+	ShortDesc: tblRmShortDesc,
+	LongDesc: tblRmLongDesc,
+	Synopsis: tblRmSynopsis,
+}
+
 type RmCmd struct{}
 
 // Name is returns the name of the Dolt cli command. This is what is used on the command line to invoke the command
@@ -55,7 +61,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
 func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
 	ap := cmd.createArgParser()
-	return cli.CreateMarkdown(fs, path, commandStr, tblRmShortDesc, tblRmLongDesc, tblRmSynopsis, ap)
+	return commands.CreateMarkdown(fs, path, commandStr, tblRmDocumentation, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -67,7 +73,7 @@ func (cmd RmCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(commandStr, tblRmShortDesc, tblRmLongDesc, tblRmSynopsis, ap)
+	help, usage := cli.HelpAndUsagePrinters(commandStr, tblRmDocumentation, ap)
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 {

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	Version = "0.15.0-oscar"
+	Version = "0.15.0"
 )
 
 var dumpDocsCommand = &commands.DumpDocsCmd{}

--- a/go/cmd/dolt/dolt.go
+++ b/go/cmd/dolt/dolt.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	Version = "0.15.0"
+	Version = "0.15.0-oscar"
 )
 
 var dumpDocsCommand = &commands.DumpDocsCmd{}


### PR DESCRIPTION
Our CLI has help text, we also use that text to generate docs for our documentation site at (DoltHub docs)[dolthub.com/docs].

Generating docs and command line output from the same content entails three separate concerns:
1. the raw content
2. modifying the content so the rendering is correct (in this case shell output and Gatsby build of `.mdx` files, JSX version of `.md`)
3. IO for writing to console (CLI help text) and files (`.md` files for building docs)

The goal of this PR is to move us towards a clean separation of these three concerns using Go templates. Specifically
- [x] implement helper types and methods for modifying content to render correctly in CLI output or `.mdx`
- [x] modify the raw content to the new data structures and text format that can be templated
- [x] update markdown generation code to simply request a template, rather than building document manually

Future work will be to use templates for the CLI output.