### PR TITLE
Zachmu/batch bug

### DIFF
--- a/bats/sql.bats
+++ b/bats/sql.bats
@@ -467,6 +467,15 @@ teardown() {
     [[ ! "$output" =~ "panic: " ]] || false
 }
 
+@test "sql delete all rows in table" {
+    run dolt sql <<SQL
+DELETE FROM one_pk;
+SELECT count(*) FROM one_pk;
+SQL
+    [ $status -eq 0 ]
+    [[ "$output" =~ "0" ]] || false
+}
+
 @test "sql shell works after failing query" {
     skiponwindows "Need to install expect and make this script work on windows."
     $BATS_TEST_DIRNAME/sql-works-after-failing-query.expect

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -170,7 +170,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 			defer rowIter.Close()
 			err = se.prettyPrintResults(ctx, se.ddb.ValueReadWriter().Format(), sqlSch, rowIter)
 			if err != nil {
-				cli.Println(color.RedString(err.Error()))
+				return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 			}
 		}
 

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -161,7 +161,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 	// run a single command and exit
 	if query, ok := apr.GetValue(queryFlag); !forceBatchMode && ok {
 
-		sqlSch, rowIter, err := processQuery(ctx, query, se);
+		sqlSch, rowIter, err := processQuery(ctx, query, se)
 		if err != nil {
 			return HandleVErrAndExitCode(errhand.VerboseErrorFromError(err), usage)
 		}

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -60,8 +60,8 @@ func TestSqlBatchMode(t *testing.T) {
 	}{
 		{
 			"create table test (a int primary key);" +
-					"insert into test values (1),(2),(3);" +
-					"select * from test;",
+				"insert into test values (1),(2),(3);" +
+				"select * from test;",
 			0,
 		},
 	}

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -53,6 +53,32 @@ func TestSqlConsole(t *testing.T) {
 
 }
 
+func TestSqlBatchMode(t *testing.T) {
+	tests := []struct {
+		query       string
+		expectedRes int
+	}{
+		{
+			"create table test (a int primary key);" +
+					"insert into test values (1),(2),(3);" +
+					"select * from test;",
+			0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.query, func(t *testing.T) {
+			dEnv := createEnvWithSeedData(t)
+
+			args := []string{"-b", "-q", test.query}
+
+			commandStr := "dolt sql"
+			result := SqlCmd{}.Exec(context.TODO(), commandStr, args, dEnv)
+			assert.Equal(t, test.expectedRes, result)
+		})
+	}
+}
+
 // Smoke tests, values are printed to console
 func TestSqlSelect(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This fixes https://github.com/liquidata-inc/dolt/issues/467.

The SQL script in question deleted and recreated a subset of the table, and should have resulted in no diff. Before this change, it resulted in some subset of rows being deleted. The issue was that DoltDatabase in batch mode was using mapEditor.Remove and mapEditor.Add for the same keys, which doesn't work in all (most) cases. The solution is to flush the cache before *and* after any non-insert statement when running in batch mode.

This change also makes the output for batch mode more sensible.

Brian to review, Andy and Aaron FYI.