### PR TITLE
execute saved query

### DIFF
--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -110,6 +110,16 @@ func (tt TaggedValues) Get(tag uint64) (types.Value, bool) {
 	return val, ok
 }
 
+func (tt TaggedValues) GetWithDefault(tag uint64, def types.Value) types.Value {
+	val, ok := tt[tag]
+
+	if !ok {
+		return def
+	}
+
+	return val
+}
+
 func (tt TaggedValues) Set(tag uint64, val types.Value) TaggedValues {
 	updated := tt.copy()
 	// Setting a nil value removes the mapping for that tag entirely, rather than setting a nil value. The methods to

--- a/go/libraries/doltcore/sqle/query_catalog_table.go
+++ b/go/libraries/doltcore/sqle/query_catalog_table.go
@@ -126,8 +126,10 @@ func NewQueryCatalogEntryWithRandID(ctx context.Context, root *doltdb.RootValue,
 		return SavedQuery{}, nil, err
 	}
 
-	// Use the last 24 hex digits of the uuid for the ID.
-	id := uid.String()[24:]
+	// Use the last 12 hex digits of the uuid for the ID.
+	uidStr := uid.String()
+	id := uidStr[len(uidStr)-12:]
+
 	return newQueryCatalogEntry(ctx, root, id, name, query, description)
 }
 

--- a/go/libraries/doltcore/sqle/query_catalog_table_test.go
+++ b/go/libraries/doltcore/sqle/query_catalog_table_test.go
@@ -38,8 +38,17 @@ func TestInsertIntoQueryCatalogTable(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, ok)
 
-	root, err = NewQueryCatalogEntry(ctx, root, "name", "select 1 from dual", "description")
+	queryStr := "select 1 from dual"
+	sq, root, err := NewQueryCatalogEntryWithRandID(ctx, root, "name", queryStr, "description")
 	require.NoError(t, err)
+	require.True(t, sq.ID != "")
+	assert.Equal(t, queryStr, sq.Query)
+	assert.Equal(t, "name", sq.Name)
+	assert.Equal(t, "description", sq.Description)
+
+	retrieved, err := RetrieveFromQueryCatalog(ctx, root, sq.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sq, retrieved)
 
 	_, ok, err = root.GetTable(ctx, doltdb.DoltQueryCatalogTableName)
 	require.NoError(t, err)
@@ -53,8 +62,17 @@ func TestInsertIntoQueryCatalogTable(t *testing.T) {
 
 	assert.Equal(t, expectedRows, rows)
 
-	root, err = NewQueryCatalogEntry(ctx, root, "name2", "select 2 from dual", "description2")
+	queryStr2 := "select 2 from dual"
+	sq2, root, err := NewQueryCatalogEntryWithNameAsID(ctx, root, "name2", queryStr2, "description2")
 	require.NoError(t, err)
+	assert.Equal(t, "name2", sq2.ID)
+	assert.Equal(t, "name2", sq2.Name)
+	assert.Equal(t, queryStr2, sq2.Query)
+	assert.Equal(t, "description2", sq2.Description)
+
+	retrieved2, err := RetrieveFromQueryCatalog(ctx, root, sq2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sq2, retrieved2)
 
 	rows, err = ExecuteSelect(root, "select display_order, query, name, description from "+doltdb.DoltQueryCatalogTableName+" order by display_order")
 	require.NoError(t, err)
@@ -71,4 +89,13 @@ func TestInsertIntoQueryCatalogTable(t *testing.T) {
 		assert.NotEmpty(t, r)
 		assert.NotEmpty(t, r[0])
 	}
+
+	queryStr3 := "select 3 from dual"
+	sq3, root, err := NewQueryCatalogEntryWithNameAsID(ctx, root, "name2", queryStr3, "description3")
+	require.NoError(t, err)
+	assert.Equal(t, "name2", sq3.ID)
+	assert.Equal(t, "name2", sq3.Name)
+	assert.Equal(t, queryStr3, sq3.Query)
+	assert.Equal(t, "description3", sq3.Description)
+	assert.Equal(t, sq2.Order, sq3.Order)
 }


### PR DESCRIPTION
Implements:
```
dolt sql -x <saved_query_name>
dolt sql --list-saved
```
Changes
 * `dolt sql -s <name> -q <query>` now saves the query with id = name