### PR TITLE
go/cmd/dolt/commands/diff.go: Handle error from `rowconv.NewJoiner` in `diffRows`

### DIFF
--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -598,6 +598,10 @@ func diffRows(ctx context.Context, newRows, oldRows types.Map, newSch, oldSch sc
 		map[string]rowconv.ColNamingFunc{diff.To: toNamer, diff.From: fromNamer},
 	)
 
+	if err != nil {
+		return errhand.BuildDError("").AddCause(err).Build()
+	}
+
 	unionSch, ds, verr := createSplitter(newSch, oldSch, joiner, dArgs)
 	if verr != nil {
 		return verr


### PR DESCRIPTION
I was just poking around a little bit and noticed that we weren't handling this error.