### PR TITLE
Fixed a bug in the newly created skipped bats test for diff --cached …

### DIFF
--- a/bats/diff.bats
+++ b/bats/diff.bats
@@ -320,7 +320,7 @@ SQL
     dolt sql -q "insert into test values (0, 0, 0, 0, 0, 0)"
     run dolt diff
     [ $status -eq 0 ]
-    CORRECT_DIFF=$status
+    CORRECT_DIFF=$output
     dolt add test
     run dolt diff --cached
     [ $status -eq 0 ]


### PR DESCRIPTION
…where I referred to  instead of correctly using