### PR TITLE
go/libraries/doltcore/env/dolt_docs.go: Add newline to end of initial LICENSE/README text

### DIFF
--- a/go/libraries/doltcore/env/dolt_docs.go
+++ b/go/libraries/doltcore/env/dolt_docs.go
@@ -21,8 +21,8 @@ import (
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
-var initialReadme = "This is a repository level README. Either edit it, add it, and commit it, or remove the file."
-var initialLicense = "This is a repository level LICENSE. Either edit it, add it, and commit it, or remove the file."
+var initialReadme = "This is a repository level README. Either edit it, add it, and commit it, or remove the file.\n"
+var initialLicense = "This is a repository level LICENSE. Either edit it, add it, and commit it, or remove the file.\n"
 
 type Docs []doltdb.DocDetails
 


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/871117/78416497-f3662000-75dd-11ea-8a95-757d7cb3d97c.png)
