### PR TITLE
store/datas/database.go: Update datas.CanUsePuller to check for write support in TableFileStore.

### DIFF
--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -908,6 +908,14 @@ func (dcs *DoltChunkStore) getDownloadWorkForLoc(ctx context.Context, getRange *
 	return []func() error{dcs.getRangeDownloadFunc(ctx, getRange.Url, getRange.Ranges, chunkChan)}
 }
 
+func (dcs *DoltChunkStore) SupportedOperations() nbs.TableFileStoreOps {
+        return nbs.TableFileStoreOps{
+                CanRead:  true,
+                CanWrite: true,
+        }
+}
+
+
 // WriteTableFile reads a table file from the provided reader and writes it to the chunk store.
 func (dcs *DoltChunkStore) WriteTableFile(ctx context.Context, fileId string, numChunks int, rd io.Reader, contentLength uint64, contentHash []byte) error {
 	fileIdBytes := hash.Parse(fileId)

--- a/go/libraries/doltcore/remotestorage/chunk_store.go
+++ b/go/libraries/doltcore/remotestorage/chunk_store.go
@@ -909,12 +909,11 @@ func (dcs *DoltChunkStore) getDownloadWorkForLoc(ctx context.Context, getRange *
 }
 
 func (dcs *DoltChunkStore) SupportedOperations() nbs.TableFileStoreOps {
-        return nbs.TableFileStoreOps{
-                CanRead:  true,
-                CanWrite: true,
-        }
+	return nbs.TableFileStoreOps{
+		CanRead:  true,
+		CanWrite: true,
+	}
 }
-
 
 // WriteTableFile reads a table file from the provided reader and writes it to the chunk store.
 func (dcs *DoltChunkStore) WriteTableFile(ctx context.Context, fileId string, numChunks int, rd io.Reader, contentLength uint64, contentHash []byte) error {

--- a/go/store/datas/database.go
+++ b/go/store/datas/database.go
@@ -153,9 +153,11 @@ func NewDatabase(cs chunks.ChunkStore) Database {
 // Databases support this yet.
 func CanUsePuller(db Database) bool {
 	cs := db.chunkStore()
-	_, ok := cs.(nbs.TableFileStore)
-
-	return ok
+	if tfs, ok := cs.(nbs.TableFileStore); ok {
+		ops := tfs.SupportedOperations()
+		return ops.CanRead && ops.CanWrite
+	}
+	return false
 }
 
 func GetCSStatSummaryForDB(db Database) string {

--- a/go/store/datas/pull_test.go
+++ b/go/store/datas/pull_test.go
@@ -437,6 +437,13 @@ func (ttfs *TestTableFileStore) SetRootChunk(ctx context.Context, root, previous
 	return nil
 }
 
+func (ttfs *TestTableFileStore) SupportedOperations() nbs.TableFileStoreOps {
+	return nbs.TableFileStoreOps{
+		CanRead:  true,
+		CanWrite: true,
+	}
+}
+
 func TestClone(t *testing.T) {
 	hashBytes := [hash.ByteLen]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13}
 	src := &TestTableFileStore{

--- a/go/store/nbs/nbs_metrics_wrapper.go
+++ b/go/store/nbs/nbs_metrics_wrapper.go
@@ -39,6 +39,8 @@ func NewNBSMetricWrapper(nbs *NomsBlockStore) *NBSMetricWrapper {
 	}
 }
 
+var _ TableFileStore = &NBSMetricWrapper{}
+
 // Sources retrieves the current root hash, and a list of all the table files
 func (nbsMW *NBSMetricWrapper) Sources(ctx context.Context) (hash.Hash, []TableFile, error) {
 	return nbsMW.nbs.Sources(ctx)
@@ -52,6 +54,11 @@ func (nbsMW *NBSMetricWrapper) WriteTableFile(ctx context.Context, fileId string
 // SetRootChunk changes the root chunk hash from the previous value to the new root.
 func (nbsMW *NBSMetricWrapper) SetRootChunk(ctx context.Context, root, previous hash.Hash) error {
 	return nbsMW.nbs.SetRootChunk(ctx, root, previous)
+}
+
+// Forwards SupportedOperations to wrapped block store.
+func (nbsMW *NBSMetricWrapper) SupportedOperations() TableFileStoreOps {
+	return nbsMW.nbs.SupportedOperations()
 }
 
 // GetManyCompressed gets the compressed Chunks with |hashes| from the store. On return,

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -949,6 +949,14 @@ func (nbs *NomsBlockStore) Sources(ctx context.Context) (hash.Hash, []TableFile,
 	return contents.GetRoot(), tableFiles, nil
 }
 
+func (nbs *NomsBlockStore) SupportedOperations() TableFileStoreOps {
+	_, canwrite := nbs.p.(*fsTablePersister)
+	return TableFileStoreOps{
+		CanRead:  true,
+		CanWrite: canwrite,
+	}
+}
+
 // WriteTableFile will read a table file from the provided reader and write it to the TableFileStore
 func (nbs *NomsBlockStore) WriteTableFile(ctx context.Context, fileId string, numChunks int, rd io.Reader, contentLength uint64, contentHash []byte) error {
 	fsPersister, ok := nbs.p.(*fsTablePersister)

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -283,7 +283,7 @@ type TableFile interface {
 // Describes what is possible to do with TableFiles in a TableFileStore.
 type TableFileStoreOps struct {
 	// True is the TableFileStore supports reading table files.
-	CanRead  bool
+	CanRead bool
 	// True is the TableFileStore supports writing table files.
 	CanWrite bool
 }

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -280,6 +280,14 @@ type TableFile interface {
 	Open() (io.ReadCloser, error)
 }
 
+// Describes what is possible to do with TableFiles in a TableFileStore.
+type TableFileStoreOps struct {
+	// True is the TableFileStore supports reading table files.
+	CanRead  bool
+	// True is the TableFileStore supports writing table files.
+	CanWrite bool
+}
+
 // TableFileStore is an interface for interacting with table files directly
 type TableFileStore interface {
 	// Sources retrieves the current root hash, and a list of all the table files
@@ -290,4 +298,7 @@ type TableFileStore interface {
 
 	// SetRootChunk changes the root chunk hash from the previous value to the new root.
 	SetRootChunk(ctx context.Context, root, previous hash.Hash) error
+
+	// Returns a description of the support TableFile operations. Some stores only support reading table files, not writing.
+	SupportedOperations() TableFileStoreOps
 }


### PR DESCRIPTION
The TableFileStore optimizations accidentally broke push support for
non-dotlremoteapi/non-filepath chunk stores. Attempting to push an AWS remote
currently results in an error.

This is a quick minimal PR to check for write support in a TableFileStore and
not use the push/pull fast path if it isn't supported.