### PR TITLE
Km/doc checkout bug

### DIFF
--- a/bats/docs.bats
+++ b/bats/docs.bats
@@ -511,7 +511,7 @@ SQL
      dolt add LICENSE.md README.md
      dolt commit -m "initial license and readme commit"
      echo updated-readme > README.md
-     skip dolt checkout -b test-branch
+     dolt checkout -b test-branch
      run dolt status
      [[ "$output" =~ "README.md" ]] || false
      run cat README.md

--- a/bats/docs.bats
+++ b/bats/docs.bats
@@ -479,7 +479,7 @@ SQL
      [[ "$output" =~ "This is a repository level README" ]] || false
  }
 
- @test "dolt checkout <branch> should save docs to the file system, leaving any untacked files" {
+ @test "dolt checkout <branch> should save docs to the file system, leaving any untracked files" {
      dolt add LICENSE.md
      dolt commit -m "license commit"
      dolt checkout -b test-branch
@@ -505,6 +505,28 @@ SQL
      [[ ! "$output" =~ "README.md" ]] || false
      run cat LICENSE.md
      [[ "$output" =~ "new-license" ]] || false
+ }
+
+ @test "dolt checkout <branch>, assuming no conflicts, should preserve changes in the working set (on the filesystem)" {
+     dolt add LICENSE.md README.md
+     dolt commit -m "initial license and readme commit"
+     echo updated-readme > README.md
+     skip dolt checkout -b test-branch
+     run dolt status
+     [[ "$output" =~ "README.md" ]] || false
+     run cat README.md
+     [[ "$output" =~ "updated-readme" ]] || false
+     run cat LICENSE.md
+     [[ "$output" =~ "This is a repository level LICENSE" ]] || false
+
+     dolt add README.md
+     dolt commit -m "commit of updated-readme"
+     echo "another new README!" > README.md
+     dolt checkout master
+     run dolt status
+     [[ "$output" =~ "README.md" ]] || false
+     run cat README.md
+     [[ "$output" =~ "another new README!" ]] || false
  }
 
 @test "dolt diff shows diffs between working root and file system docs" {

--- a/bats/remotes.bats
+++ b/bats/remotes.bats
@@ -124,7 +124,7 @@ teardown() {
     run cat LICENSE.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "updated-license" ]] || false
-    skip run cat README.md
+    run cat README.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "this text should remain after pull :p" ]] || false
 }

--- a/bats/remotes.bats
+++ b/bats/remotes.bats
@@ -115,6 +115,7 @@ teardown() {
     dolt push test-remote master
 
     cd dolt-repo-clones/test-repo
+    echo "this text should remain after pull :p" > README.md
     run dolt pull
     [[ "$output" =~ "Updating" ]] || false
     run dolt log
@@ -123,9 +124,9 @@ teardown() {
     run cat LICENSE.md
     [ "$status" -eq 0 ]
     [[ "$output" =~ "updated-license" ]] || false
-    run cat README.md
+    skip run cat README.md
     [ "$status" -eq 0 ]
-    [[ "$output" =~ "readme-text" ]] || false
+    [[ "$output" =~ "this text should remain after pull :p" ]] || false
 }
 
 @test "clone a remote" {

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -257,7 +257,7 @@ func executeFFMerge(ctx context.Context, dEnv *env.DoltEnv, cm2 *doltdb.Commit, 
 		}
 	}
 
-	unstagedDocs, err :=actions.GetUnstagedDocs(ctx, dEnv)
+	unstagedDocs, err := actions.GetUnstagedDocs(ctx, dEnv)
 	if err != nil {
 		return errhand.BuildDError("error: unable to determine unstaged docs").AddCause(err).Build()
 	}

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -257,6 +257,11 @@ func executeFFMerge(ctx context.Context, dEnv *env.DoltEnv, cm2 *doltdb.Commit, 
 		}
 	}
 
+	unstagedDocs, err :=actions.GetUnstagedDocs(ctx, dEnv)
+	if err != nil {
+		return errhand.BuildDError("error: unable to determine unstaged docs").AddCause(err).Build()
+	}
+
 	err = dEnv.DoltDB.FastForward(ctx, dEnv.RepoState.CWBHeadRef(), cm2)
 
 	if err != nil {
@@ -278,7 +283,7 @@ and take the hash for your current branch and use it for the value for "staged" 
 			AddCause(err).Build()
 	}
 
-	err = actions.SaveTrackedDocsFromWorking(ctx, dEnv)
+	err = actions.SaveDocsFromWorkingExcludingFSChanges(ctx, dEnv, unstagedDocs)
 	if err != nil {
 		return errhand.BuildDError("error: failed to update docs to the new working root").AddCause(err).Build()
 	}
@@ -321,6 +326,11 @@ func executeMerge(ctx context.Context, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commi
 		return errhand.BuildDError("Unable to update the repo state").AddCause(err).Build()
 	}
 
+	unstagedDocs, err := actions.GetUnstagedDocs(ctx, dEnv)
+	if err != nil {
+		return errhand.BuildDError("error: failed to determine unstaged docs").AddCause(err).Build()
+	}
+
 	verr := UpdateWorkingWithVErr(dEnv, workingRoot)
 
 	if verr == nil {
@@ -329,7 +339,7 @@ func executeMerge(ctx context.Context, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commi
 		if hasConflicts {
 			cli.Println("Automatic merge failed; fix conflicts and then commit the result.")
 		} else {
-			err = actions.SaveTrackedDocsFromWorking(ctx, dEnv)
+			err = actions.SaveDocsFromWorkingExcludingFSChanges(ctx, dEnv, unstagedDocs)
 			if err != nil {
 				return errhand.BuildDError("error: failed to update docs to the new working root").AddCause(err).Build()
 			}

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
-	"github.com/liquidata-inc/dolt/go/libraries/doltcore/diff"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
@@ -246,7 +245,10 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string) error
 		return err
 	}
 
-	unstagedDocs, err := getUnstagedDocs(ctx, dEnv)
+	unstagedDocs, err := GetUnstagedDocs(ctx, dEnv)
+	if err != nil {
+		return err
+	}
 
 	dEnv.RepoState.Head = ref.MarshalableRef{Ref: dref}
 	dEnv.RepoState.Working = wrkHash.String()
@@ -258,46 +260,8 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string) error
 		return err
 	}
 
-	return saveDocsOnCheckout(ctx, dEnv, unstagedDocs)
+	return SaveDocsFromWorkingExcludingFSChanges(ctx, dEnv, unstagedDocs)
 }
-
-func getUnstagedDocs(ctx context.Context, dEnv *env.DoltEnv) (env.Docs, error) {
-	_, unstagedDocDiffs, err := diff.GetDocDiffs(ctx, dEnv)
-	if err != nil {
-		return nil, err
-	}
-	unstagedDocs := env.Docs{}
-	for _, docName := range unstagedDocDiffs.Docs {
-		docDetail, err := dEnv.GetOneDocDetail(docName)
-		if err != nil {
-			return nil, err
-		}
-		unstagedDocs = append(unstagedDocs, docDetail) 
-	}
-	return unstagedDocs, nil
-}
-
- func saveDocsOnCheckout(ctx context.Context, dEnv *env.DoltEnv, docsToExclude env.Docs) error {
-	workingRoot, err := dEnv.WorkingRoot(ctx)
-	if err != nil {
-		return err
-	}
-
-	var docsToSave env.Docs
-	if len(docsToExclude) > 0 {
-		for _, doc := range dEnv.Docs {
-			for _, excludedDoc := range docsToExclude {
-				if doc.DocPk != excludedDoc.DocPk {
-					docsToSave = append(docsToSave, doc)
-				}
-			}
-		}
-	} else {
-		docsToSave = dEnv.Docs
-	}
-	
-    return SaveTrackedDocs(ctx, dEnv, workingRoot, workingRoot, docsToSave)
- }
 
 var emptyHash = hash.Hash{}
 

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"errors"
 
-	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 	"github.com/liquidata-inc/dolt/go/store/hash"
 	"github.com/liquidata-inc/dolt/go/store/types"

--- a/go/libraries/doltcore/env/actions/docs.go
+++ b/go/libraries/doltcore/env/actions/docs.go
@@ -153,7 +153,7 @@ func GetUnstagedDocs(ctx context.Context, dEnv *env.DoltEnv) (env.Docs, error) {
 		if err != nil {
 			return nil, err
 		}
-		unstagedDocs = append(unstagedDocs, docDetail) 
+		unstagedDocs = append(unstagedDocs, docDetail)
 	}
 	return unstagedDocs, nil
 }
@@ -178,6 +178,6 @@ func SaveDocsFromWorkingExcludingFSChanges(ctx context.Context, dEnv *env.DoltEn
 	} else {
 		docsToSave = dEnv.Docs
 	}
-	
-    return SaveTrackedDocs(ctx, dEnv, workingRoot, workingRoot, docsToSave)
- }
+
+	return SaveTrackedDocs(ctx, dEnv, workingRoot, workingRoot, docsToSave)
+}


### PR DESCRIPTION
Taylor brought a bad docs bug to my attention. If you had a modified doc, and then `dolt checkout <branch>` or `dolt checkout -b <branch>`, your local docs would be overwritten by the working root (your changes vanish).

The intended behavior is to keep the working set exactly as it is on `dolt checkout <branch>`, given there are no conflicts. Since your "working set" for docs is technically on the filesystem, and not on the roots, it was getting wiped. Now i'm pulling the unstagedDocDiffs from the filesystem, and excluding those when it comes time to `saveDocsOnCheckout`. 

Added bats test coverage too