### PR TITLE
Avoid segfaulting when dashes in 'dolt command --help' are missing

### DIFF
--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -142,15 +142,15 @@ func (ap *ArgParser) Parse(args []string) (*ArgParseResults, error) {
 	for ; i < len(args); i++ {
 		arg := args[i]
 
-		if len(arg) == 0 || arg[0] != '-' || arg == "--" { // empty strings should get passed through like other naked words
-			list = append(list, arg)
-			continue
-		}
-
 		optName, value := splitOption(arg)
 
 		if optName == "help" || optName == "h" {
 			return nil, ErrHelp
+		}
+
+		if len(arg) == 0 || arg[0] != '-' || arg == "--" { // empty strings should get passed through like other naked words
+			list = append(list, arg)
+			continue
 		}
 
 		supOpt, ok := ap.NameOrAbbrevToOpt[optName]


### PR DESCRIPTION
So, recently I noticed a funny bug in dolt: running e.g. `dolt blame help`
in a non-repo directory results in a segfault [1], while `dolt blame whatever`,
as expected, complains that the current dir is not a proper repository.
After taking a look around the code it became apparent that there is a divergence
in what is considered a 'help request' by the parser and what subcommand
handlers (i.e. the `isHelp()` function in dolt/cli/command.go) mark as such.

This patch makes an arbitrary decision that `dolt whatever help` is equivalent
to `dolt whatever -help`, which is in line with current isHelp() definition.

[1] $> dolt blame help
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x55c491049594]

[...]