### PR TITLE
Skipping git-dolt bats tests on Windows due to flakiness

### DIFF
--- a/bats/git-dolt.bats
+++ b/bats/git-dolt.bats
@@ -13,6 +13,7 @@ setup() {
     dolt remote add test-remote $REMOTE
     dolt push test-remote master
     export DOLT_HEAD_COMMIT=`get_head_commit`
+    skiponwindows "git-dolt tests are flaky on Windows"
 }
 
 teardown() {


### PR DESCRIPTION
Is this fine? By putting it at the end of the `setup` function, it's equivalent to manually putting a skip on every test. Then whenever we fix it, we can just delete it in one place.