### PR TITLE
Help Fix

### DIFF
--- a/bats/no-repo.bats
+++ b/bats/no-repo.bats
@@ -226,6 +226,6 @@ NOT_VALID_REPO_ERROR="The current directory is not a valid dolt repository."
 @test "all versions of help work outside a repository" {
     dolt checkout --help
     dolt checkout -help
-    skip "No dashes in front of help segfaults right now"
-    dolt checkout help
+    run dolt checkout help
+    [ "$status" -ne 0 ]
 }

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -27,14 +27,15 @@ import (
 )
 
 func isHelp(str string) bool {
-	switch {
-	case str == "-h":
-		return true
-	case strings.TrimLeft(str, "- ") == "help":
-		return true
+	str = strings.TrimSpace(str)
+
+	if str[0] != '-' {
+		return false
 	}
 
-	return false
+	str = strings.ToLower(strings.TrimLeft(str, "- "))
+
+	return str == "h" || str == "help"
 }
 
 func hasHelpFlag(args []string) bool {

--- a/go/cmd/dolt/cli/command_test.go
+++ b/go/cmd/dolt/cli/command_test.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
 	"testing"
@@ -127,4 +128,14 @@ func runCommand(root Command, commandLine string) int {
 	}
 
 	return root.Exec(context.Background(), appName, tokens[1:], nil)
+}
+
+func TestHasHelpFlag(t *testing.T) {
+	assert.False(t, hasHelpFlag([]string{}))
+	assert.False(t, hasHelpFlag([]string{"help"}))
+	assert.True(t, hasHelpFlag([]string{"--help"}))
+	assert.True(t, hasHelpFlag([]string{"-h"}))
+	assert.False(t, hasHelpFlag([]string{"--param","value","--flag","help","arg2","arg3"}))
+	assert.True(t, hasHelpFlag([]string{"--param","value","-f","--help","arg1","arg2"}))
+	assert.True(t, hasHelpFlag([]string{"--param","value","--flag","-h","arg1","arg2"}))
 }

--- a/go/cmd/dolt/cli/command_test.go
+++ b/go/cmd/dolt/cli/command_test.go
@@ -16,14 +16,14 @@ package cli
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
+	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -135,7 +135,7 @@ func TestHasHelpFlag(t *testing.T) {
 	assert.False(t, hasHelpFlag([]string{"help"}))
 	assert.True(t, hasHelpFlag([]string{"--help"}))
 	assert.True(t, hasHelpFlag([]string{"-h"}))
-	assert.False(t, hasHelpFlag([]string{"--param","value","--flag","help","arg2","arg3"}))
-	assert.True(t, hasHelpFlag([]string{"--param","value","-f","--help","arg1","arg2"}))
-	assert.True(t, hasHelpFlag([]string{"--param","value","--flag","-h","arg1","arg2"}))
+	assert.False(t, hasHelpFlag([]string{"--param", "value", "--flag", "help", "arg2", "arg3"}))
+	assert.True(t, hasHelpFlag([]string{"--param", "value", "-f", "--help", "arg1", "arg2"}))
+	assert.True(t, hasHelpFlag([]string{"--param", "value", "--flag", "-h", "arg1", "arg2"}))
 }

--- a/go/libraries/utils/argparser/parser.go
+++ b/go/libraries/utils/argparser/parser.go
@@ -84,32 +84,42 @@ func (ap *ArgParser) SupportOption(opt *Option) {
 }
 
 // Adds support for a new flag (argument with no value). See SupportOpt for details on params.
-func (ap *ArgParser) SupportsFlag(name, abbrev, desc string) {
+func (ap *ArgParser) SupportsFlag(name, abbrev, desc string) *ArgParser {
 	opt := &Option{name, abbrev, "", OptionalFlag, desc, nil}
 	ap.SupportOption(opt)
+
+	return ap
 }
 
 // Adds support for a new string argument with the description given. See SupportOpt for details on params.
-func (ap *ArgParser) SupportsString(name, abbrev, valDesc, desc string) {
+func (ap *ArgParser) SupportsString(name, abbrev, valDesc, desc string) *ArgParser {
 	opt := &Option{name, abbrev, valDesc, OptionalValue, desc, nil}
 	ap.SupportOption(opt)
+
+	return ap
 }
 
-func (ap *ArgParser) SupportsValidatedString(name, abbrev, valDesc, desc string, validator ValidationFunc) {
+func (ap *ArgParser) SupportsValidatedString(name, abbrev, valDesc, desc string, validator ValidationFunc) *ArgParser {
 	opt := &Option{name, abbrev, valDesc, OptionalValue, desc, validator}
 	ap.SupportOption(opt)
+
+	return ap
 }
 
 // Adds support for a new uint argument with the description given. See SupportOpt for details on params.
-func (ap *ArgParser) SupportsUint(name, abbrev, valDesc, desc string) {
+func (ap *ArgParser) SupportsUint(name, abbrev, valDesc, desc string) *ArgParser {
 	opt := &Option{name, abbrev, valDesc, OptionalValue, desc, isUintStr}
 	ap.SupportOption(opt)
+
+	return ap
 }
 
 // Adds support for a new int argument with the description given. See SupportOpt for details on params.
-func (ap *ArgParser) SupportsInt(name, abbrev, valDesc, desc string) {
+func (ap *ArgParser) SupportsInt(name, abbrev, valDesc, desc string) *ArgParser {
 	opt := &Option{name, abbrev, valDesc, OptionalValue, desc, isIntStr}
 	ap.SupportOption(opt)
+
+	return ap
 }
 
 func splitOption(optStr string) (string, *string) {
@@ -135,7 +145,7 @@ func splitOption(optStr string) (string, *string) {
 // methods. Any unrecognized arguments or incorrect types will result in an appropriate error being returned. If the
 // universal --help or -h flag is found, an ErrHelp error is returned.
 func (ap *ArgParser) Parse(args []string) (*ArgParseResults, error) {
-	var list []string
+	list := make([]string, 0, 16)
 	results := make(map[string]string)
 
 	i := 0

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -1,18 +1,33 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package argparser
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestArgParser(t *testing.T) {
-	tests := []struct{
-		ap *ArgParser
-		args []string
-		expectedErr error
+	tests := []struct {
+		ap              *ArgParser
+		args            []string
+		expectedErr     error
 		expectedOptions map[string]string
-		expectedArgs []string
+		expectedArgs    []string
 	}{
 		{
 			NewArgParser(),

--- a/go/libraries/utils/argparser/parser_test.go
+++ b/go/libraries/utils/argparser/parser_test.go
@@ -1,0 +1,77 @@
+package argparser
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestArgParser(t *testing.T) {
+	tests := []struct{
+		ap *ArgParser
+		args []string
+		expectedErr error
+		expectedOptions map[string]string
+		expectedArgs []string
+	}{
+		{
+			NewArgParser(),
+			[]string{},
+			nil,
+			map[string]string{},
+			[]string{},
+		},
+		{
+			NewArgParser(),
+			[]string{"arg1", "arg2"},
+			nil,
+			map[string]string{},
+			[]string{"arg1", "arg2"},
+		},
+		{
+			NewArgParser(),
+			[]string{"--unknown_flag"},
+			UnknownArgumentParam{"unknown_flag"},
+			map[string]string{},
+			[]string{},
+		},
+		{
+			NewArgParser(),
+			[]string{"--help"},
+			ErrHelp,
+			map[string]string{},
+			[]string{},
+		},
+		{
+			NewArgParser(),
+			[]string{"-h"},
+			ErrHelp,
+			map[string]string{},
+			[]string{},
+		},
+		{
+			NewArgParser(),
+			[]string{"help"},
+			nil,
+			map[string]string{},
+			[]string{"help"},
+		},
+		{
+			NewArgParser().SupportsString("param", "p", "", ""),
+			[]string{"--param", "value", "arg1"},
+			nil,
+			map[string]string{"param": "value"},
+			[]string{"arg1"},
+		},
+	}
+
+	for _, test := range tests {
+		apr, err := test.ap.Parse(test.args)
+		require.Equal(t, test.expectedErr, err)
+
+		if err == nil {
+			assert.Equal(t, test.expectedOptions, apr.options)
+			assert.Equal(t, test.expectedArgs, apr.args)
+		}
+	}
+}


### PR DESCRIPTION
As identified by Asgavar in https://github.com/liquidata-inc/dolt/pull/553 there is a segfault caused by differences in logic between isHelp and the Parse function of the ArgParser.  I found that changing the Parser to be like the isHelp function caused issues for some commands if you have a branch named help or a table named help.  As a result I opted to change the isHelp logic instead.

Thank you @Asgavar 
