### PR TITLE
Andy/Init commits don't need migration

### DIFF
--- a/bats/compatibility/test_files/bats/compatibility.bats
+++ b/bats/compatibility/test_files/bats/compatibility.bats
@@ -163,3 +163,17 @@ teardown() {
 
     dolt sql -q 'drop table abc2'
 }
+
+
+@test "dolt migrate no-data" {
+    # this will fail for older dolt versions but BATS will swallow the error
+    run dolt migrate
+
+    dolt checkout no-data
+    run dolt sql -q 'show tables;'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "+-------+" ]] || false
+    [[ "$output" =~ "| Table |" ]] || false
+    [[ "$output" =~ "+-------+" ]] || false
+    [[ "$output" =~ "+-------+" ]] || false
+}

--- a/bats/compatibility/test_files/setup_repo.sh
+++ b/bats/compatibility/test_files/setup_repo.sh
@@ -7,6 +7,8 @@ cd "$1"
 
 dolt init
 
+dolt branch no-data
+
 dolt sql <<SQL
 CREATE TABLE abc (
   pk BIGINT NOT NULL COMMENT 'tag:0',


### PR DESCRIPTION
If a repo created with an old client ( < 0.16.0) has a branch with only the init commit, newer clients will always register that repo as un-migrated.

This change ignores init commits when checking if a repo has been migrated