### PR TITLE
Tim/bats schema import tags

### DIFF
--- a/bats/schema-import.bats
+++ b/bats/schema-import.bats
@@ -173,7 +173,7 @@ teardown() {
 }
 
 @test "schema import of two tables" {
-    dolt schema imporT -c --pks=pk test1 `batshelper 1pksupportedt\
+    dolt schema import -c --pks=pk test1 `batshelper 1pksupportedt\
 ypes.csv`
     skip "Guaranteed tag collision right now"
     dolt schema import -c --pks=pk test2 `batshelper 1pk-datetime.csv`

--- a/bats/schema-import.bats
+++ b/bats/schema-import.bats
@@ -173,8 +173,7 @@ teardown() {
 }
 
 @test "schema import of two tables" {
-    dolt schema import -c --pks=pk test1 `batshelper 1pksupportedt\
-ypes.csv`
+    dolt schema import -c --pks=pk test1 `batshelper 1pksupportedtypes.csv`
     skip "Guaranteed tag collision right now"
     dolt schema import -c --pks=pk test2 `batshelper 1pk-datetime.csv`
     

--- a/bats/schema-import.bats
+++ b/bats/schema-import.bats
@@ -171,3 +171,11 @@ teardown() {
     skip "schema import does not support datetime"
     [[ "$output" =~ "DATETIME" ]] || false;
 }
+
+@test "schema import of two tables" {
+    dolt schema imporT -c --pks=pk test1 `batshelper 1pksupportedt\
+ypes.csv`
+    skip "Guaranteed tag collision right now"
+    dolt schema import -c --pks=pk test2 `batshelper 1pk-datetime.csv`
+    
+}


### PR DESCRIPTION
Skipped bats test for two sequential schema imports causing a guaranteed tag collision