### PR TITLE
Db/push to regressions latest

### DIFF
--- a/benchmark/sql_regressions/DoltRegressionsJenkinsfile
+++ b/benchmark/sql_regressions/DoltRegressionsJenkinsfile
@@ -1,36 +1,30 @@
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            label "liquidata-inc-ld-build"
+        }
+    }
     stages {
-        stage('Test Dolt nightly') {
-            parallel {
-                stage ("Update Liquidata/dolt-sql-performance:nightly") {
-                    agent {
-                        kubernetes {
-                            label "liquidata-inc-ld-build"
-                        }
-                    }
-                    environment {
-                        PATH = "${pwd()}/.ci_bin/node_modules/.bin:${env.PATH}"
-                        DOLT_VERSION = "${env.GIT_COMMIT}"
-                        TMPDIR = "${pwd()}/tempDir"
-                        DOLT_ROOT_PATH="${pwd()}/tempRoot"
-                        DOLT_CREDS = credentials("system-account-dolthub-creds")
-                        DOLT_GLOBAL_CONFIG = credentials("system-account-dolthub-config")
-                    }
-                    steps {
-                        sh "rm -rf $TMPDIR && mkdir $TMPDIR"
-                        sh "rm -rf $DOLT_ROOT_PATH && mkdir $DOLT_ROOT_PATH"
-                        dir ("sqllogictest") {
-                            git url: "https://github.com/liquidata-inc/sqllogictest.git"
-                        }
-                        dir ("benchmark/sql_regressions") {
-                            script {
-                                try {
-                                    sh "nice ./run_regressions.sh ./nightly.vars"
-                                } catch(err) {
-                                    sh "if [ \"${err.getMessage()}\" = 'script returned exit code 155' ]; then echo 'Result data found in dolt-sql-performance, silently exiting...'; else echo \"${err.getMessage()}\" && exit 1; fi"
-                                }
-                            }
+        stage ("Update Liquidata/dolt-sql-performance:nightly") {
+            environment {
+                PATH = "${pwd()}/.ci_bin/node_modules/.bin:${env.PATH}"
+                DOLT_VERSION = "${env.GIT_COMMIT}"
+                TMPDIR = "${pwd()}/tempDir"
+                DOLT_ROOT_PATH="${pwd()}/tempRoot"
+                DOLT_CREDS = credentials("system-account-dolthub-creds")
+            }
+            steps {
+                sh "rm -rf $TMPDIR && mkdir $TMPDIR"
+                sh "rm -rf $DOLT_ROOT_PATH && mkdir $DOLT_ROOT_PATH"
+                dir ("sqllogictest") {
+                    git url: "https://github.com/liquidata-inc/sqllogictest.git"
+                }
+                dir ("benchmark/sql_regressions") {
+                    script {
+                        try {
+                            sh "nice ./run_regressions.sh ./nightly.vars"
+                        } catch(err) {
+                            sh "if [ \"${err.getMessage()}\" = 'script returned exit code 155' ]; then echo 'Result data found in dolt-sql-performance, silently exiting...'; else echo \"${err.getMessage()}\" && exit 1; fi"
                         }
                     }
                 }

--- a/benchmark/sql_regressions/DoltReleaseBenchmarkJenkinsfile
+++ b/benchmark/sql_regressions/DoltReleaseBenchmarkJenkinsfile
@@ -1,32 +1,26 @@
 pipeline {
-    agent none
+    agent {
+        kubernetes {
+            label "liquidata-inc-ld-build"
+        }
+    }
     stages {
-        stage('Test Dolt release') {
-            parallel {
-                stage ("Update Liquidata/dolt-sql-performance:releases") {
-                    agent {
-                        kubernetes {
-                            label "liquidata-inc-ld-build"
-                        }
-                    }
-                    environment {
-                        PATH = "${pwd()}/.ci_bin/node_modules/.bin:${env.PATH}"
-                        TMPDIR = "${pwd()}/tempDir"
-                        DOLT_ROOT_PATH="${pwd()}/tempRoot"
-                        DOLT_CREDS = credentials("system-account-dolthub-creds")
-                        DOLT_GLOBAL_CONFIG = credentials("system-account-dolthub-config")
-                        DOLT_RELEASE_URL = "https://github.com/liquidata-inc/dolt/releases/download/v${DOLT_RELEASE}/dolt-linux-amd64.tar.gz"
-                    }
-                    steps {
-                        sh "rm -rf $TMPDIR && mkdir $TMPDIR"
-                        sh "rm -rf $DOLT_ROOT_PATH && mkdir $DOLT_ROOT_PATH"
-                        dir ("sqllogictest") {
-                            git url: "https://github.com/liquidata-inc/sqllogictest.git"
-                        }
-                        dir ("benchmark/sql_regressions") {
-                            sh "nice ./run_regressions.sh ./releases.vars"
-                        }
-                    }
+        stage ("Update Liquidata/dolt-sql-performance:releases") {
+            environment {
+                PATH = "${pwd()}/.ci_bin/node_modules/.bin:${env.PATH}"
+                TMPDIR = "${pwd()}/tempDir"
+                DOLT_ROOT_PATH="${pwd()}/tempRoot"
+                DOLT_CREDS = credentials("system-account-dolthub-creds")
+                DOLT_RELEASE_URL = "https://github.com/liquidata-inc/dolt/releases/download/v${DOLT_RELEASE}/dolt-linux-amd64.tar.gz"
+            }
+            steps {
+                sh "rm -rf $TMPDIR && mkdir $TMPDIR"
+                sh "rm -rf $DOLT_ROOT_PATH && mkdir $DOLT_ROOT_PATH"
+                dir ("sqllogictest") {
+                    git url: "https://github.com/liquidata-inc/sqllogictest.git"
+                }
+                dir ("benchmark/sql_regressions") {
+                    sh "nice ./run_regressions.sh ./releases.vars"
                 }
             }
         }

--- a/benchmark/sql_regressions/run_regressions.sh
+++ b/benchmark/sql_regressions/run_regressions.sh
@@ -18,10 +18,8 @@ fi
 source "$1"
 if [ -z "$DOLT_ROOT_PATH" ]; then fail Must supply DOLT_ROOT_PATH; fi
 if [ -z "$DOLT_CONFIG_PATH" ]; then fail Must supply DOLT_CONFIG_PATH; fi
-if [ -z "$DOLT_GLOBAL_CONFIG" ]; then fail Must supply DOLT_GLOBAL_CONFIG; fi
 if [ -z "$CREDSDIR" ]; then fail Must supply CREDSDIR; fi
 if [ -z "$DOLT_CREDS" ]; then fail Must supply DOLT_CREDS; fi
-if [ -z "$CREDS_HASH" ]; then fail Must supply CREDS_HASH; fi
 if [ -z "$JOB_TYPE" ]; then fail Must supply JOB_TYPE; fi
 if [ -z "$TEST_N_TIMES" ]; then fail Must supply TEST_N_TIMES; fi
 if [ -z "$FAIL_ON_EXISTING_VERSION" ]; then fail Must supply FAIL_ON_EXISTING_VERSION; fi
@@ -39,10 +37,8 @@ fi
 function setup() {
     rm -rf "$CREDSDIR"
     mkdir -p "$CREDSDIR"
-    cat "$DOLT_CREDS" > "$CREDSDIR"/"$CREDS_HASH".jwk
-    echo "$DOLT_GLOBAL_CONFIG" > "$DOLT_CONFIG_PATH"/config_global.json
-    dolt config --global --add user.creds "$CREDS_HASH"
     dolt config --global --add metrics.disabled true
+    dolt creds import "$DOLT_CREDS"
     dolt version
     rm -rf temp
     mkdir temp

--- a/benchmark/sql_regressions/run_regressions.sh
+++ b/benchmark/sql_regressions/run_regressions.sh
@@ -108,7 +108,6 @@ function branch_from_base() {
 }
 
 function update_regressions_latest() {
-  dolt checkout master
   exists=$(dolt branch --list regressions-tip-previous | sed '/^\s*$/d' | wc -l | tr -d '[:space:]')
 
   if [ "$exists" -eq 1 ]; then
@@ -137,7 +136,6 @@ function update_regressions_latest() {
     dolt checkout regressions-tip-latest
     dolt push regressions-tip-latest;
   fi
-  dolt checkout master
 }
 
 function import_one_nightly() {
@@ -165,8 +163,6 @@ select version, test_file, line_num, avg(duration) as mean_duration, result from
     dolt add .
     dolt commit -m "merge nightly"
     dolt push origin regressions
-
-    update_regressions_latest
 
     dolt checkout releases
     dolt sql -r csv -q "\
@@ -247,6 +243,8 @@ select version, test_file, line_num, avg(duration) as mean_duration, result from
     dolt add .
     dolt commit -m "merge releases"
     dolt push origin regressions
+
+    update_regressions_latest
 }
 
 rm -rf dolt-sql-performance

--- a/benchmark/sqllogictest_tester/run_tester.sh
+++ b/benchmark/sqllogictest_tester/run_tester.sh
@@ -25,7 +25,6 @@ if [ -z "$DOLT_ROOT_PATH" ]; then fail Must supply DOLT_ROOT_PATH; fi
 if [ -z "$DOLT_CONFIG_PATH" ]; then fail Must supply DOLT_CONFIG_PATH; fi
 if [ -z "$CREDSDIR" ]; then fail Must supply CREDSDIR; fi
 if [ -z "$DOLT_CREDS" ]; then fail Must supply DOLT_CREDS; fi
-if [ -z "$CREDS_HASH" ]; then fail Must supply CREDS_HASH; fi
 if [ -z "$TMP_TESTING_DIR" ]; then fail Must supply TMP_TESTING_DIR; fi
 if [ -z "$TMP_CSV_DIR" ]; then fail Must supply TMP_CSV_DIR; fi
 if [ -z "$TEST_FILE_DIR_LIST" ]; then fail Must supply TEST_FILE_DIR_LIST; fi


### PR DESCRIPTION
idea here is to maintain two shallow branches used to help with the `sqllogictest-tester` jenkins job. whenever we run the `releases` job, we update branch `regressions-tip-latest` to the latest release results and also update `regressions-tip-previous` to be what `regressions-tip-latest` was... 

Decided to have two branches since we may not always get fixing a regression right away, and this gives us a _little_ time to do so... 