### PR TITLE
fixing column ordering after deleted columns

### DIFF
--- a/go/cmd/dolt/cli/arg_helpers.go
+++ b/go/cmd/dolt/cli/arg_helpers.go
@@ -176,7 +176,7 @@ func ParseKeyValues(nbf *types.NomsBinFormat, sch schema.Schema, args []string) 
 			taggedVals[k] = val
 		}
 
-		tpl, err := taggedVals.NomsTupleForTags(nbf, pkCols.Tags, true).Value(context.TODO())
+		tpl, err := taggedVals.NomsTupleForPKCols(nbf, pkCols).Value(context.TODO())
 
 		if err != nil {
 			return nil, err

--- a/go/cmd/dolt/cli/arg_helpers_test.go
+++ b/go/cmd/dolt/cli/arg_helpers_test.go
@@ -75,7 +75,7 @@ func TestParseKeyValues(t *testing.T) {
 			singleKeySch,
 			[]string{"robertson"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForTags(types.Format_7_18, singleKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForPKCols(types.Format_7_18, singleKeyColColl).Value(ctx)),
 			},
 			false,
 		},
@@ -84,7 +84,7 @@ func TestParseKeyValues(t *testing.T) {
 			singleKeySch,
 			[]string{"last", "robertson"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForTags(types.Format_7_18, singleKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForPKCols(types.Format_7_18, singleKeyColColl).Value(ctx)),
 			},
 			false,
 		},
@@ -98,7 +98,7 @@ func TestParseKeyValues(t *testing.T) {
 			singleKeySch,
 			[]string{"last", "last"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("last")}.NomsTupleForTags(types.Format_7_18, singleKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("last")}.NomsTupleForPKCols(types.Format_7_18, singleKeyColColl).Value(ctx)),
 			},
 			false,
 		},
@@ -106,8 +106,8 @@ func TestParseKeyValues(t *testing.T) {
 			singleKeySch,
 			[]string{"last", "robertson", "johnson"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForTags(types.Format_7_18, singleKeyColColl.Tags, true).Value(ctx)),
-				mustValue(row.TaggedValues{lnColTag: types.String("johnson")}.NomsTupleForTags(types.Format_7_18, singleKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForPKCols(types.Format_7_18, singleKeyColColl).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("johnson")}.NomsTupleForPKCols(types.Format_7_18, singleKeyColColl).Value(ctx)),
 			},
 			false,
 		},
@@ -122,8 +122,8 @@ func TestParseKeyValues(t *testing.T) {
 			sch,
 			[]string{"last", "robertson", "johnson"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForTags(types.Format_7_18, testKeyColColl.Tags, true).Value(ctx)),
-				mustValue(row.TaggedValues{lnColTag: types.String("johnson")}.NomsTupleForTags(types.Format_7_18, testKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("robertson")}.NomsTupleForPKCols(types.Format_7_18, testKeyColColl).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("johnson")}.NomsTupleForPKCols(types.Format_7_18, testKeyColColl).Value(ctx)),
 			},
 			false,
 		},
@@ -131,8 +131,8 @@ func TestParseKeyValues(t *testing.T) {
 			sch,
 			[]string{"first,last", "robert,robertson", "john,johnson"},
 			[]types.Value{
-				mustValue(row.TaggedValues{lnColTag: types.String("robertson"), fnColTag: types.String("robert")}.NomsTupleForTags(types.Format_7_18, testKeyColColl.Tags, true).Value(ctx)),
-				mustValue(row.TaggedValues{lnColTag: types.String("johnson"), fnColTag: types.String("john")}.NomsTupleForTags(types.Format_7_18, testKeyColColl.Tags, true).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("robertson"), fnColTag: types.String("robert")}.NomsTupleForPKCols(types.Format_7_18, testKeyColColl).Value(ctx)),
+				mustValue(row.TaggedValues{lnColTag: types.String("johnson"), fnColTag: types.String("john")}.NomsTupleForPKCols(types.Format_7_18, testKeyColColl).Value(ctx)),
 			},
 			false,
 		},

--- a/go/cmd/dolt/commands/sql_test.go
+++ b/go/cmd/dolt/commands/sql_test.go
@@ -387,7 +387,7 @@ func TestInsert(t *testing.T) {
 					table, _, err := root.GetTable(context.Background(), tableName)
 					assert.NoError(t, err)
 					taggedVals := row.TaggedValues{dtestutils.IdTag: types.UUID(expectedid)}
-					key := taggedVals.NomsTupleForTags(types.Format_7_18, []uint64{dtestutils.IdTag}, true)
+					key := taggedVals.NomsTupleForPKCols(types.Format_7_18, dtestutils.TypedSchema.GetPKCols())
 					kv, err := key.Value(context.Background())
 					assert.NoError(t, err)
 					_, ok, err := table.GetRow(context.Background(), kv.(types.Tuple), dtestutils.TypedSchema)
@@ -471,7 +471,7 @@ func TestUpdate(t *testing.T) {
 					table, _, err := root.GetTable(context.Background(), tableName)
 					assert.NoError(t, err)
 					taggedVals := row.TaggedValues{dtestutils.IdTag: types.UUID(expectedid)}
-					key := taggedVals.NomsTupleForTags(types.Format_7_18, []uint64{dtestutils.IdTag}, true)
+					key := taggedVals.NomsTupleForPKCols(types.Format_7_18, dtestutils.TypedSchema.GetPKCols())
 					kv, err := key.Value(ctx)
 					assert.NoError(t, err)
 					row, ok, err := table.GetRow(ctx, kv.(types.Tuple), dtestutils.TypedSchema)
@@ -550,7 +550,7 @@ func TestDelete(t *testing.T) {
 					table, _, err := root.GetTable(context.Background(), tableName)
 					assert.NoError(t, err)
 					taggedVals := row.TaggedValues{dtestutils.IdTag: types.UUID(expectedid)}
-					key := taggedVals.NomsTupleForTags(types.Format_7_18, []uint64{dtestutils.IdTag}, true)
+					key := taggedVals.NomsTupleForPKCols(types.Format_7_18, dtestutils.TypedSchema.GetPKCols())
 					kv, err := key.Value(ctx)
 					assert.NoError(t, err)
 					_, ok, err := table.GetRow(ctx, kv.(types.Tuple), dtestutils.TypedSchema)

--- a/go/libraries/doltcore/doltdb/key_itr.go
+++ b/go/libraries/doltcore/doltdb/key_itr.go
@@ -48,7 +48,6 @@ func SingleColPKItr(nbf *types.NomsBinFormat, pkTag uint64, vals []types.Value) 
 }
 
 func TaggedValueSliceItr(nbf *types.NomsBinFormat, sch schema.Schema, vals []row.TaggedValues) func() (types.Tuple, bool, error) {
-	pkTags := sch.GetPKCols().Tags
 	next := 0
 	size := len(vals)
 	return func() (types.Tuple, bool, error) {
@@ -56,7 +55,7 @@ func TaggedValueSliceItr(nbf *types.NomsBinFormat, sch schema.Schema, vals []row
 		next++
 
 		if current < size {
-			tpl := vals[current].NomsTupleForTags(nbf, pkTags, true)
+			tpl := vals[current].NomsTupleForPKCols(nbf, sch.GetPKCols())
 			v, err := tpl.Value(context.TODO())
 
 			if err != nil {

--- a/go/libraries/doltcore/doltdb/table.go
+++ b/go/libraries/doltcore/doltdb/table.go
@@ -411,7 +411,7 @@ func (t *Table) HashOf() (hash.Hash, error) {
 }
 
 func (t *Table) GetRowByPKVals(ctx context.Context, pkVals row.TaggedValues, sch schema.Schema) (row.Row, bool, error) {
-	pkTuple := pkVals.NomsTupleForTags(t.vrw.Format(), sch.GetPKCols().Tags, true)
+	pkTuple := pkVals.NomsTupleForPKCols(t.vrw.Format(), sch.GetPKCols())
 	pkTupleVal, err := pkTuple.Value(ctx)
 
 	if err != nil {

--- a/go/libraries/doltcore/merge/merge.go
+++ b/go/libraries/doltcore/merge/merge.go
@@ -489,7 +489,7 @@ func rowMerge(ctx context.Context, nbf *types.NomsBinFormat, sch schema.Schema, 
 		return nil, true, nil
 	}
 
-	tpl := resultVals.NomsTupleForTags(nbf, sch.GetNonPKCols().SortedTags, false)
+	tpl := resultVals.NomsTupleForNonPKCols(nbf, sch.GetNonPKCols())
 	v, err := tpl.Value(ctx)
 
 	if err != nil {

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -579,7 +579,7 @@ func dropValsForDeletedColumns(ctx context.Context, nbf *types.NomsBinFormat, ro
 			}
 		}
 
-		re.Set(k, vtv.NomsTupleForTags(nbf, sch.GetNonPKCols().Tags, false))
+		re.Set(k, vtv.NomsTupleForNonPKCols(nbf, sch.GetNonPKCols()))
 	}
 
 	prunedRowData, err := re.Map(ctx)

--- a/go/libraries/doltcore/row/noms_row.go
+++ b/go/libraries/doltcore/row/noms_row.go
@@ -181,9 +181,9 @@ func FromNoms(sch schema.Schema, nomsKey, nomsVal types.Tuple) (Row, error) {
 }
 
 func (nr nomsRow) NomsMapKey(sch schema.Schema) types.LesserValuable {
-	return nr.key.NomsTupleForTags(nr.nbf, sch.GetPKCols().Tags, true)
+	return nr.key.NomsTupleForPKCols(nr.nbf, sch.GetPKCols())
 }
 
 func (nr nomsRow) NomsMapValue(sch schema.Schema) types.Valuable {
-	return nr.value.NomsTupleForTags(nr.nbf, sch.GetNonPKCols().SortedTags, false)
+	return nr.value.NomsTupleForNonPKCols(nr.nbf, sch.GetNonPKCols())
 }

--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -17,8 +17,8 @@ package row
 import (
 	"context"
 	"fmt"
-	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 

--- a/go/libraries/doltcore/row/tagged_values.go
+++ b/go/libraries/doltcore/row/tagged_values.go
@@ -17,6 +17,7 @@ package row
 import (
 	"context"
 	"fmt"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
@@ -61,7 +62,15 @@ func (tvs TupleVals) Less(nbf *types.NomsBinFormat, other types.LesserValuable) 
 	return types.TupleKind < other.Kind(), nil
 }
 
-func (tt TaggedValues) NomsTupleForTags(nbf *types.NomsBinFormat, tags []uint64, encodeNulls bool) TupleVals {
+func (tt TaggedValues) NomsTupleForPKCols(nbf *types.NomsBinFormat, pkCols *schema.ColCollection) TupleVals {
+	return tt.nomsTupleForTags(nbf, pkCols.Tags, true)
+}
+
+func (tt TaggedValues) NomsTupleForNonPKCols(nbf *types.NomsBinFormat, nonPKCols *schema.ColCollection) TupleVals {
+	return tt.nomsTupleForTags(nbf, nonPKCols.SortedTags, false)
+}
+
+func (tt TaggedValues) nomsTupleForTags(nbf *types.NomsBinFormat, tags []uint64, encodeNulls bool) TupleVals {
 	numVals := 0
 	for _, tag := range tags {
 		val := tt[tag]

--- a/go/libraries/doltcore/row/tagged_values_test.go
+++ b/go/libraries/doltcore/row/tagged_values_test.go
@@ -95,8 +95,8 @@ func TestTupleValsLess(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			lesserTplVals := test.lesserTVs.NomsTupleForTags(types.Format_7_18, test.tags, true)
-			greaterTplVals := test.greaterTVs.NomsTupleForTags(types.Format_7_18, test.tags, true)
+			lesserTplVals := test.lesserTVs.nomsTupleForTags(types.Format_7_18, test.tags, true)
+			greaterTplVals := test.greaterTVs.nomsTupleForTags(types.Format_7_18, test.tags, true)
 
 			lessLTGreater, err := lesserTplVals.Less(types.Format_7_18, greaterTplVals)
 			assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestTaggedTuple_NomsTupleForTags(t *testing.T) {
 		//{map[uint64]types.Value{}, []uint64{}, types.NewTuple()},
 	}
 	for _, test := range tests {
-		if got, err := tt.NomsTupleForTags(types.Format_7_18, test.tags, test.encodeNulls).Value(ctx); err != nil {
+		if got, err := tt.nomsTupleForTags(types.Format_7_18, test.tags, test.encodeNulls).Value(ctx); err != nil {
 			t.Error(err)
 		} else if !reflect.DeepEqual(got, test.want) {
 			gotStr, err := types.EncodedValue(ctx, got)
@@ -170,7 +170,7 @@ func TestTaggedTuple_NomsTupleForTags(t *testing.T) {
 				t.Error(err)
 			}
 
-			t.Errorf("TaggedValues.NomsTupleForTags() = %v, want %v", gotStr, wantStr)
+			t.Errorf("TaggedValues.nomsTupleForTags() = %v, want %v", gotStr, wantStr)
 		}
 	}
 }

--- a/go/libraries/doltcore/schema/alterschema/dropcolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/dropcolumn.go
@@ -121,7 +121,7 @@ func dropColumnValuesForTag(ctx context.Context, nbf *types.NomsBinFormat, newSc
 		_, found := tv[dropTag]
 		if found {
 			delete(tv, dropTag)
-			re.Set(k, tv.NomsTupleForTags(nbf, newSch.GetNonPKCols().SortedTags, false))
+			re.Set(k, tv.NomsTupleForNonPKCols(nbf, newSch.GetNonPKCols()))
 		}
 	}
 

--- a/go/libraries/doltcore/schema/alterschema/dropcolumn.go
+++ b/go/libraries/doltcore/schema/alterschema/dropcolumn.go
@@ -121,7 +121,7 @@ func dropColumnValuesForTag(ctx context.Context, nbf *types.NomsBinFormat, newSc
 		_, found := tv[dropTag]
 		if found {
 			delete(tv, dropTag)
-			re.Set(k, tv.NomsTupleForTags(nbf, newSch.GetNonPKCols().Tags, false))
+			re.Set(k, tv.NomsTupleForTags(nbf, newSch.GetNonPKCols().SortedTags, false))
 		}
 	}
 


### PR DESCRIPTION
The primary fix is in the [first commit](https://github.com/liquidata-inc/dolt/pull/626/commits/a7d9667509ea9b4e2a232b7a5275ca123167b313). I changed the the `TaggedValues` api to make this mistake harder to make in the future. 

Before this changes, Noms tuples were being reordered by a column deletion which was causing erroneous diffs. The same column values were stored in different orders, leading to different content addresses between root values. 

_Should we add a pipeline stage to `diff` to filter out rows that are unchanged?_