### PR TITLE
sql-server command documentation

### DIFF
--- a/bats/no-repo.bats
+++ b/bats/no-repo.bats
@@ -20,35 +20,6 @@ teardown() {
     run dolt
     [ "$status" -eq 1 ]
     [ "${lines[0]}" = "Valid commands for dolt are" ]
-    # Check help output for supported commands
-    [[ "${lines[1]}" =~ "init - Create an empty Dolt data repository." ]] || false
-    [[ "${lines[2]}" =~ "status - Show the working tree status." ]] || false
-    [[ "${lines[3]}" =~ "add - Add table changes to the list of staged table changes." ]] || false
-    [[ "${lines[4]}" =~ "reset - Remove table changes from the list of staged table changes." ]] || false
-    [[ "${lines[5]}" =~ "commit - Record changes to the repository." ]] || false
-    [[ "${lines[6]}" =~ "sql - Run a SQL query against tables in repository." ]] || false
-    [[ "${lines[7]}" =~ "sql-server - Starts a MySQL-compatible server." ]] || false
-    [[ "${lines[8]}" =~ "log - Show commit logs." ]] || false
-    [[ "${lines[9]}" =~ "diff - Diff a table." ]] || false
-    [[ "${lines[10]}" =~ "blame - Show what revision and author last modified each row of a table." ]] || false
-    [[ "${lines[11]}" =~ "merge - Merge a branch." ]] || false
-    [[ "${lines[12]}" =~ "branch - Create, list, edit, delete branches." ]] || false
-    [[ "${lines[13]}" =~ "checkout - Checkout a branch or overwrite a table from HEAD." ]] || false
-    [[ "${lines[14]}" =~ "remote - Manage set of tracked repositories." ]] || false
-    [[ "${lines[15]}" =~ "push - Push to a dolt remote." ]] || false
-    [[ "${lines[16]}" =~ "pull - Fetch from a dolt remote data repository and merge." ]] || false
-    [[ "${lines[17]}" =~ "fetch - Update the database from a remote data repository." ]] || false
-    [[ "${lines[18]}" =~ "clone - Clone from a remote data repository." ]] || false
-    [[ "${lines[19]}" =~ "creds - Commands for managing credentials." ]] || false
-    [[ "${lines[20]}" =~ "login - Login to a dolt remote host." ]] || false
-    [[ "${lines[21]}" =~ "version - Displays the current Dolt cli version." ]] || false
-    [[ "${lines[22]}" =~ "config - Dolt configuration." ]] || false
-    [[ "${lines[23]}" =~ "ls - List tables in the working set." ]] || false
-    [[ "${lines[24]}" =~ "schema - Commands for showing and importing table schemas." ]] || false
-    [[ "${lines[25]}" =~ "table - Commands for copying, renaming, deleting, and exporting tables." ]] || false
-    [[ "${lines[26]}" =~ "conflicts - Commands for viewing and resolving merge conflicts." ]] || false
-    [[ "${lines[27]}" =~ "migrate - Executes a repository migration to update to the latest format." ]] || false
-    [ "${lines[28]}" = "" ]
 }
 
 @test "testing dolt version output" {

--- a/bats/no-repo.bats
+++ b/bats/no-repo.bats
@@ -20,6 +20,35 @@ teardown() {
     run dolt
     [ "$status" -eq 1 ]
     [ "${lines[0]}" = "Valid commands for dolt are" ]
+
+    # Check help output for supported commands
+    [[ "$output" =~ "init - Create an empty Dolt data repository." ]] || false
+    [[ "$output" =~ "status - Show the working tree status." ]] || false
+    [[ "$output" =~ "add - Add table changes to the list of staged table changes." ]] || false
+    [[ "$output" =~ "reset - Remove table changes from the list of staged table changes." ]] || false
+    [[ "$output" =~ "commit - Record changes to the repository." ]] || false
+    [[ "$output" =~ "sql - Run a SQL query against tables in repository." ]] || false
+    [[ "$output" =~ "sql-server - Start a MySQL-compatible server." ]] || false
+    [[ "$output" =~ "log - Show commit logs." ]] || false
+    [[ "$output" =~ "diff - Diff a table." ]] || false
+    [[ "$output" =~ "blame - Show what revision and author last modified each row of a table." ]] || false
+    [[ "$output" =~ "merge - Merge a branch." ]] || false
+    [[ "$output" =~ "branch - Create, list, edit, delete branches." ]] || false
+    [[ "$output" =~ "checkout - Checkout a branch or overwrite a table from HEAD." ]] || false
+    [[ "$output" =~ "remote - Manage set of tracked repositories." ]] || false
+    [[ "$output" =~ "push - Push to a dolt remote." ]] || false
+    [[ "$output" =~ "pull - Fetch from a dolt remote data repository and merge." ]] || false
+    [[ "$output" =~ "fetch - Update the database from a remote data repository." ]] || false
+    [[ "$output" =~ "clone - Clone from a remote data repository." ]] || false
+    [[ "$output" =~ "creds - Commands for managing credentials." ]] || false
+    [[ "$output" =~ "login - Login to a dolt remote host." ]] || false
+    [[ "$output" =~ "version - Displays the current Dolt cli version." ]] || false
+    [[ "$output" =~ "config - Dolt configuration." ]] || false
+    [[ "$output" =~ "ls - List tables in the working set." ]] || false
+    [[ "$output" =~ "schema - Commands for showing and importing table schemas." ]] || false
+    [[ "$output" =~ "table - Commands for copying, renaming, deleting, and exporting tables." ]] || false
+    [[ "$output" =~ "conflicts - Commands for viewing and resolving merge conflicts." ]] || false
+    [[ "$output" =~ "migrate - Executes a repository migration to update to the latest format." ]] || false
 }
 
 @test "testing dolt version output" {

--- a/go/cmd/dolt/commands/sqlserver/serverconfig.go
+++ b/go/cmd/dolt/commands/sqlserver/serverconfig.go
@@ -44,7 +44,7 @@ const (
 	defaultReadOnly       = false
 	defaultLogLevel       = LogLevel_Info
 	defaultAutoCommit     = true
-	defaultMaxConnections = 0
+	defaultMaxConnections = 1
 )
 
 // String returns the string representation of the log level.

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -63,17 +63,24 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 		"log_level - Level of logging provided. Options are: `trace', `debug`, `info`, `warning`, `error`, and `fatal`.\n" +
 		"\n" +
 		"behavior.read_only - If true database modification is disabled.\n" +
+		"\n" +
 		"behavior.autocommit - If true write queries will automatically alter the working set.  When working with autocommit " +
 		"enabled it is highly recommended that listener.max_connections be set to 1 as concurrency issues will arise otherwise.\n" +
 		"\n" +
 		"user.name - The username that connections should use for authentication.\n" +
+		"\n" +
 		"user.password - The password that connections should use for authentication.\n" +
 		"\n" +
 		"listener.host - The host address that the server will run on.  This may be an `localhost` or an IPv4 or IPv6 address.\n" +
+		"\n" +
 		"listener.port - The port that the server should listen on.\n" +
+		"\n" +
 		"listener.max_connections - The number of simultaneous connections that the server will accept.\n" +
+		"\n" +
 		"listener.read_timeout_millis - The number of milliseconds that the server will wait for a read operation.\n" +
+		"\n" +
 		"listener.write_timeout_millis - The number of milliseconds that the server will wait for a write operation.\n" +
+		"\n" +
 		"\n" +
 		"\n" +
 		"If a config file is not provided many of these settings may be configured on the command line.",

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -46,7 +46,7 @@ const (
 
 var sqlServerDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Start a MySQL-compatible server.",
-	LongDesc: "In it's default configuration, starts a MySQL-compatible server which allows only one user connection at" +
+	LongDesc: "By default, starts a MySQL-compatible server which allows only one user connection at" +
 		"a time to the dolt repository in the current directory. Any edits made through this server will be automatically " +
 		"reflected in the working set.  This behavior can be modified using a yaml configuration file passed to the server " +
 		"via --config <file>, or by using the supported switches and flags to configure the server directly on the " +
@@ -69,9 +69,9 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 		"\n" +
 		"user.name - The username that connections should use for authentication.\n" +
 		"\n" +
-		"user.password - The password that connections should use for authentication.\n" +
+		"user.password - The password that connections should use for authentication.\n " +
 		"\n" +
-		"listener.host - The host address that the server will run on.  This may be an `localhost` or an IPv4 or IPv6 address.\n" +
+		"listener.host - The host address that the server will run on.  This may be `localhost` or an IPv4 or IPv6 address.\n" +
 		"\n" +
 		"listener.port - The port that the server should listen on.\n" +
 		"\n" +
@@ -81,6 +81,12 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 		"\n" +
 		"listener.write_timeout_millis - The number of milliseconds that the server will wait for a write operation.\n" +
 		"\n" +
+		"databases - a list of dolt data repositories to make available as SQL databases. If databases is missing or " +
+		"empty then the working directory must be a valid dolt data repository which will be made available as a SQL database\n" +
+		"\n" +
+		"databases[i].path - A path to a dolt data repository.\n" +
+		"\n" +
+		"databases[i].name - The name that the database corresponding to the given path should be referenced via SQL.\n" +
 		"\n" +
 		"\n" +
 		"If a config file is not provided many of these settings may be configured on the command line.",

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -46,7 +46,7 @@ const (
 
 var sqlServerDocs = cli.CommandDocumentationContent{
 	ShortDesc: "Start a MySQL-compatible server.",
-	LongDesc:  "In it's default configuration, starts a MySQL-compatible server which allows only one user connection at" +
+	LongDesc: "In it's default configuration, starts a MySQL-compatible server which allows only one user connection at" +
 		"a time to the dolt repository in the current directory. Any edits made through this server will be automatically " +
 		"reflected in the working set.  This behavior can be modified using a yaml configuration file passed to the server " +
 		"via --config <file>, or by using the supported switches and flags to configure the server directly on the " +

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -58,7 +58,7 @@ var sqlServerDocs = cli.CommandDocumentationContent{
 		"{{.EmphasisLeft}}" + serverConfigAsYAMLConfig(DefaultServerConfig()).String() + "{{.EmphasisRight}}\n" +
 		"\n" +
 		"\n" +
-		"SUPPORTED FIELDS CONFIG FILE FIELDS:\n" +
+		"SUPPORTED CONFIG FILE FIELDS:\n" +
 		"\n" +
 		"log_level - Level of logging provided. Options are: `trace', `debug`, `info`, `warning`, `error`, and `fatal`.\n" +
 		"\n" +

--- a/go/cmd/dolt/commands/sqlserver/yaml_config.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config.go
@@ -15,10 +15,11 @@
 package sqlserver
 
 import (
-	"gopkg.in/yaml.v2"
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 )
@@ -77,15 +78,15 @@ type YAMLConfig struct {
 
 func serverConfigAsYAMLConfig(cfg ServerConfig) YAMLConfig {
 	return YAMLConfig{
-		LogLevelStr: strPtr(string(cfg.LogLevel())),
+		LogLevelStr:    strPtr(string(cfg.LogLevel())),
 		BehaviorConfig: BehaviorYAMLConfig{boolPtr(cfg.ReadOnly()), boolPtr(cfg.AutoCommit())},
-		UserConfig: UserYAMLConfig{strPtr(cfg.User()), strPtr(cfg.Password())},
+		UserConfig:     UserYAMLConfig{strPtr(cfg.User()), strPtr(cfg.Password())},
 		ListenerConfig: ListenerYAMLConfig{
-				strPtr(cfg.Host()),
-				intPtr(cfg.Port()),
-				uint64Ptr(cfg.MaxConnections()),
-				uint64Ptr(cfg.ReadTimeout()),
-				uint64Ptr(cfg.WriteTimeout()),
+			strPtr(cfg.Host()),
+			intPtr(cfg.Port()),
+			uint64Ptr(cfg.MaxConnections()),
+			uint64Ptr(cfg.ReadTimeout()),
+			uint64Ptr(cfg.WriteTimeout()),
 		},
 		DatabaseConfig: nil,
 	}
@@ -224,4 +225,3 @@ func (cfg YAMLConfig) MaxConnections() uint64 {
 
 	return *cfg.ListenerConfig.MaxConnections
 }
-

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -23,21 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func strPtr(s string) *string {
-	return &s
-}
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func uint64Ptr(n uint64) *uint64 {
-	return &n
-}
-
-func intPtr(n int) *int {
-	return &n
-}
 
 func TestUnmarshall(t *testing.T) {
 	testStr := `
@@ -49,12 +35,12 @@ behavior:
 
 user:
     name: root
-    password: 1234
+    password: 3306
 
 listener:
-    host: 0.0.0.0
+    host: localhost
     port: 3306
-    max_connections: 100
+    max_connections: 1
     read_timeout_millis: 0
     write_timeout_millis: 0
     

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestUnmarshall(t *testing.T) {
 	testStr := `
-log_level: debug
+log_level: info
 
 behavior:
     read_only: false
@@ -35,14 +35,14 @@ behavior:
 
 user:
     name: root
-    password: 3306
+    password: ""
 
 listener:
     host: localhost
     port: 3306
     max_connections: 1
-    read_timeout_millis: 0
-    write_timeout_millis: 0
+    read_timeout_millis: 30000
+    write_timeout_millis: 30000
     
 databases:
     - name: irs_soi
@@ -51,32 +51,15 @@ databases:
       path: /Users/brian/datasets/noaa
 `
 
-	expected := YAMLConfig{
-		LogLevelStr: strPtr("debug"),
-		BehaviorConfig: BehaviorYAMLConfig{
-			ReadOnly:   boolPtr(false),
-			AutoCommit: boolPtr(true),
+	expected := serverConfigAsYAMLConfig(DefaultServerConfig())
+	expected.DatabaseConfig = []DatabaseYAMLConfig{
+		{
+			Name: "irs_soi",
+			Path: "./datasets/irs-soi",
 		},
-		UserConfig: UserYAMLConfig{
-			Name:     strPtr("root"),
-			Password: strPtr("1234"),
-		},
-		ListenerConfig: ListenerYAMLConfig{
-			HostStr:            strPtr("0.0.0.0"),
-			PortNumber:         intPtr(3306),
-			MaxConnections:     uint64Ptr(100),
-			ReadTimeoutMillis:  uint64Ptr(0),
-			WriteTimeoutMillis: uint64Ptr(0),
-		},
-		DatabaseConfig: []DatabaseYAMLConfig{
-			{
-				Name: "irs_soi",
-				Path: "./datasets/irs-soi",
-			},
-			{
-				Name: "noaa",
-				Path: "/Users/brian/datasets/noaa",
-			},
+		{
+			Name: "noaa",
+			Path: "/Users/brian/datasets/noaa",
 		},
 	}
 

--- a/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
+++ b/go/cmd/dolt/commands/sqlserver/yaml_config_test.go
@@ -23,8 +23,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-
-
 func TestUnmarshall(t *testing.T) {
 	testStr := `
 log_level: info


### PR DESCRIPTION
```
NAME
	dolt sql-server - Start a MySQL-compatible server.

SYNOPSIS
	dolt sql-server --config <file>
	dolt sql-server [-H <host>] [-P <port>] [-u <user>] [-p <password>] [-t <timeout>] [-l <loglevel>] [--multi-db-dir <directory>] [-r]

DESCRIPTION
	By default, starts a MySQL-compatible server which allows only one user connection ata time to the dolt repository in the current directory. Any edits made through this server will be automatically reflected
	in the working set.  This behavior can be modified using a yaml configuration file passed to the server via --config <file>, or by using the supported switches and flags to configure the server directly on
	the command line (If --config <file> is provided all other command line arguments are ignored).

	This is an example yaml configuration file showing all supported items and their default values:


	log_level: info

	behavior:
	  read_only: false
	  autocommit: true

	user:
	  name: root
	  password: ""

	listener:
	  host: localhost
	  port: 3306
	  max_connections: 1
	  read_timeout_millis: 30000
	  write_timeout_millis: 30000

	databases: []


	SUPPORTED CONFIG FILE FIELDS:

	log_level - Level of logging provided. Options are: `trace', `debug`, `info`, `warning`, `error`, and `fatal`.

	behavior.read_only - If true database modification is disabled.

	behavior.autocommit - If true write queries will automatically alter the working set.  When working with autocommit enabled it is highly recommended that listener.max_connections be set to 1 as concurrency
	issues will arise otherwise.

	user.name - The username that connections should use for authentication.

	user.password - The password that connections should use for authentication.
	listener.host - The host address that the server will run on.  This may be `localhost` or an IPv4 or IPv6 address.

	listener.port - The port that the server should listen on.

	listener.max_connections - The number of simultaneous connections that the server will accept.

	listener.read_timeout_millis - The number of milliseconds that the server will wait for a read operation.

	listener.write_timeout_millis - The number of milliseconds that the server will wait for a write operation.

	databases - a list of dolt data repositories to make available as SQL databases. If databases is missing or empty then the working directory must be a valid dolt data repository which will be made available
	as a SQL database

	databases[i].path - A path to a dolt data repository.

	databases[i].name - The name that the database corresponding to the given path should be referenced via SQL.


	If a config file is not provided many of these settings may be configured on the command line.

OPTIONS
	--config=<file>
	  When provided configuration is taken from the yaml config file and all command line parameters are ignored.

	-H <Host address>, --host=<Host address>
	  Defines the host address that the server will run on (default `localhost`)

	-P <Port>, --port=<Port>
	  Defines the port that the server will run on (default `3306`)

	-u <User>, --user=<User>
	  Defines the server user (default `root`)

	-p <Password>, --password=<Password>
	  Defines the server password (default ``)

	-t <Connection timeout>, --timeout=<Connection timeout>
	  Defines the timeout, in seconds, used for connections
	  A value of `0` represents an infinite timeout (default `30000`)

	-r, --readonly
	  Disables modification of the database

	-l <Log level>, --loglevel=<Log level>
	  Defines the level of logging provided
	  Options are: `trace', `debug`, `info`, `warning`, `error`, `fatal` (default `info`)

	--multi-db-dir=<directory>
	  Defines a directory whose subdirectories should all be dolt data repositories accessible as independent databases.

	--no-auto-commit
	  When provided sessions will not automatically commit their changes to the working set. Anything not manually committed will be lost.
```