### PR TITLE
Update doc generation

### DIFF
--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -23,7 +23,6 @@ import (
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/events"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 func isHelp(str string) bool {
@@ -56,7 +55,7 @@ type Command interface {
 	// Exec executes the command
 	Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int
 	// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-	CreateMarkdown(fs filesys.Filesys, path, commandStr string) error
+	CreateMarkdown(commandStr string) CommandDocumentation
 }
 
 // This type is to store the content of a documented command, elsewhere we can transform this struct into
@@ -120,8 +119,8 @@ func (hc SubCommandHandler) RequiresRepo() bool {
 	return false
 }
 
-func (hc SubCommandHandler) CreateMarkdown(_ filesys.Filesys, _, _ string) error {
-	return nil
+func (hc SubCommandHandler) CreateMarkdown(_ string) CommandDocumentation {
+	return CommandDocumentation{}
 }
 
 func (hc SubCommandHandler) Hidden() bool {

--- a/go/cmd/dolt/cli/command.go
+++ b/go/cmd/dolt/cli/command.go
@@ -54,8 +54,8 @@ type Command interface {
 	Description() string
 	// Exec executes the command
 	Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int
-	// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-	CreateMarkdown(commandStr string) CommandDocumentation
+	// Returns an instance of CommandDocumentation for this command using passed command string
+	GetCommandDocumentation(commandStr string) CommandDocumentation
 }
 
 // This type is to store the content of a documented command, elsewhere we can transform this struct into
@@ -119,7 +119,7 @@ func (hc SubCommandHandler) RequiresRepo() bool {
 	return false
 }
 
-func (hc SubCommandHandler) CreateMarkdown(_ string) CommandDocumentation {
+func (hc SubCommandHandler) GetCommandDocumentation(_ string) CommandDocumentation {
 	return CommandDocumentation{}
 }
 

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -135,7 +135,7 @@ func (cmdDoc CommandDocumentation) cmdDocToCmdDocMd(options string) (commandDocu
 }
 
 // Creates a CommandDocumentation given command string, arg parser, and a CommandDocumentationContent
-func GetCommandDocumentation(commandStr string, cmdDoc CommandDocumentationContent, argParser *argparser.ArgParser) CommandDocumentation {
+func BuildCommandDocumentation(commandStr string, cmdDoc CommandDocumentationContent, argParser *argparser.ArgParser) CommandDocumentation {
 	return CommandDocumentation{
 		CommandStr: commandStr,
 		ShortDesc:  cmdDoc.ShortDesc,

--- a/go/cmd/dolt/cli/documentation_helper.go
+++ b/go/cmd/dolt/cli/documentation_helper.go
@@ -31,9 +31,8 @@ type commandDocumentForMarkdown struct {
 	Options             string
 }
 
-var cmdMdDocTempl = `---
-title: {{.Command}}
----
+var cmdMdDocTempl = `
+# {{.Command}}
 
 ## Command
 {{.CommandAndShortDesc}}
@@ -46,7 +45,6 @@ title: {{.Command}}
 
 ## Options
 {{.Options}}
-
 `
 
 func (cmdDoc CommandDocumentation) CmdDocToMd() (string, error) {

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -17,8 +17,6 @@ package commands
 import (
 	"context"
 
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
@@ -57,9 +55,9 @@ func (cmd AddCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd AddCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd AddCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, addDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, addDocs, ap)
 }
 
 func (cmd AddCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/add.go
+++ b/go/cmd/dolt/commands/add.go
@@ -54,10 +54,10 @@ func (cmd AddCmd) Description() string {
 	return "Add table changes to the list of staged table changes."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd AddCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd AddCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, addDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, addDocs, ap)
 }
 
 func (cmd AddCmd) createArgParser() *argparser.ArgParser {
@@ -70,7 +70,7 @@ func (cmd AddCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd AddCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPr, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, addDocs, ap))
+	helpPr, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, addDocs, ap))
 	apr := cli.ParseArgs(ap, args, helpPr)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -30,7 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/hash"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
@@ -87,9 +86,9 @@ func (cmd BlameCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd BlameCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd BlameCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, blameDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, blameDocs, ap)
 }
 
 func (cmd BlameCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -85,10 +85,10 @@ func (cmd BlameCmd) Description() string {
 	return "Show what revision and author last modified each row of a table."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd BlameCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd BlameCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, blameDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, blameDocs, ap)
 }
 
 func (cmd BlameCmd) createArgParser() *argparser.ArgParser {
@@ -119,7 +119,7 @@ func (cmd BlameCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd BlameCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, blameDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, blameDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 || apr.NArg() > 2 {

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -30,7 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
 
@@ -82,9 +81,9 @@ func (cmd BranchCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd BranchCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd BranchCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, branchDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, branchDocs, ap)
 }
 
 func (cmd BranchCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -80,10 +80,10 @@ func (cmd BranchCmd) Description() string {
 	return "Create, list, edit, delete branches."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd BranchCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// Returns command
+func (cmd BranchCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, branchDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, branchDocs, ap)
 }
 
 func (cmd BranchCmd) createArgParser() *argparser.ArgParser {
@@ -108,7 +108,7 @@ func (cmd BranchCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd BranchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, branchDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, branchDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	switch {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -25,7 +25,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var checkoutDocs = cli.CommandDocumentationContent{
@@ -64,9 +63,9 @@ func (cmd CheckoutCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CheckoutCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CheckoutCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, checkoutDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, checkoutDocs, ap)
 }
 
 func (cmd CheckoutCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/checkout.go
+++ b/go/cmd/dolt/commands/checkout.go
@@ -62,10 +62,10 @@ func (cmd CheckoutCmd) Description() string {
 	return "Checkout a branch or overwrite a table from HEAD."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CheckoutCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CheckoutCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, checkoutDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, checkoutDocs, ap)
 }
 
 func (cmd CheckoutCmd) createArgParser() *argparser.ArgParser {
@@ -82,7 +82,7 @@ func (cmd CheckoutCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CheckoutCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	helpPrt, usagePrt := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, checkoutDocs, ap))
+	helpPrt, usagePrt := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, checkoutDocs, ap))
 	apr := cli.ParseArgs(ap, args, helpPrt)
 
 	if (apr.Contains(coBranchArg) && apr.NArg() > 1) || (!apr.Contains(coBranchArg) && apr.NArg() == 0) {

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -76,10 +76,10 @@ func (cmd CloneCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CloneCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CloneCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, cloneDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, cloneDocs, ap)
 }
 
 func (cmd CloneCmd) createArgParser() *argparser.ArgParser {
@@ -101,7 +101,7 @@ func (cmd CloneCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CloneCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cloneDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, cloneDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remoteName := apr.GetValueOrDefault(remoteParam, "origin")

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -77,9 +77,9 @@ func (cmd CloneCmd) RequiresRepo() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CloneCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CloneCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, cloneDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, cloneDocs, ap)
 }
 
 func (cmd CloneCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -54,10 +54,10 @@ func (cmd CatCmd) Description() string {
 	return "Writes out the table conflicts."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CatCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CatCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, catDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, catDocs, ap)
 }
 
 // EventType returns the type of the event to log
@@ -75,7 +75,7 @@ func (cmd CatCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, catDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, catDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/cnfcmds/cat.go
+++ b/go/cmd/dolt/commands/cnfcmds/cat.go
@@ -17,12 +17,10 @@ package cnfcmds
 import (
 	"context"
 
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/merge"
@@ -57,9 +55,9 @@ func (cmd CatCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CatCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CatCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, catDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, catDocs, ap)
 }
 
 // EventType returns the type of the event to log

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -17,12 +17,10 @@ package cnfcmds
 import (
 	"context"
 
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
@@ -77,9 +75,9 @@ func (cmd ResolveCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ResolveCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ResolveCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, resDocumentation, ap))
+	return cli.GetCommandDocumentation(commandStr, resDocumentation, ap)
 }
 
 // EventType returns the type of the event to log

--- a/go/cmd/dolt/commands/cnfcmds/resolve.go
+++ b/go/cmd/dolt/commands/cnfcmds/resolve.go
@@ -74,10 +74,10 @@ func (cmd ResolveCmd) Description() string {
 	return "Removes rows from list of conflicts"
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ResolveCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ResolveCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, resDocumentation, ap)
+	return cli.BuildCommandDocumentation(commandStr, resDocumentation, ap)
 }
 
 // EventType returns the type of the event to log
@@ -98,7 +98,7 @@ func (cmd ResolveCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResolveCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, resDocumentation, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, resDocumentation, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -68,10 +68,10 @@ func (cmd CommitCmd) Description() string {
 	return "Record changes to the repository."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CommitCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CommitCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, commitDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, commitDocs, ap)
 }
 
 func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
@@ -85,7 +85,7 @@ func (cmd CommitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CommitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, commitDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, commitDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	msg, msgOk := apr.GetValue(commitMessageArg)

--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -32,7 +32,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/merge"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/editor"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -70,9 +69,9 @@ func (cmd CommitCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CommitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CommitCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, commitDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, commitDocs, ap)
 }
 
 func (cmd CommitCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/config"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
 
@@ -74,9 +73,9 @@ func (cmd ConfigCmd) RequiresRepo() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ConfigCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ConfigCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, cfgDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, cfgDocs, ap)
 }
 
 func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/config.go
+++ b/go/cmd/dolt/commands/config.go
@@ -72,10 +72,10 @@ func (cmd ConfigCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ConfigCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ConfigCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, cfgDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, cfgDocs, ap)
 }
 
 func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
@@ -93,7 +93,7 @@ func (cmd ConfigCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ConfigCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cfgDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, cfgDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	cfgTypes := apr.FlagsEqualTo([]string{globalParamName, localParamName}, true)

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"fmt"
 
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	remotesapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/remotesapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/creds"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
@@ -53,9 +51,9 @@ func (cmd CheckCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CheckCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CheckCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, checkDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, checkDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement

--- a/go/cmd/dolt/commands/credcmds/check.go
+++ b/go/cmd/dolt/commands/credcmds/check.go
@@ -50,10 +50,10 @@ func (cmd CheckCmd) Description() string {
 	return checkShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CheckCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CheckCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, checkDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, checkDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -77,7 +77,7 @@ func (cmd CheckCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd CheckCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, checkDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, checkDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	endpoint := loadEndpoint(dEnv, apr)

--- a/go/cmd/dolt/commands/credcmds/import.go
+++ b/go/cmd/dolt/commands/credcmds/import.go
@@ -29,7 +29,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var importDocs = cli.CommandDocumentationContent{
@@ -62,9 +61,9 @@ func (cmd ImportCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, importDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, importDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement

--- a/go/cmd/dolt/commands/credcmds/import.go
+++ b/go/cmd/dolt/commands/credcmds/import.go
@@ -60,10 +60,10 @@ func (cmd ImportCmd) Description() string {
 	return importDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ImportCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, importDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, importDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -89,7 +89,7 @@ func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, importDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, importDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	credsDir, verr := actions.EnsureCredsDir(dEnv)

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var lsDocs = cli.CommandDocumentationContent{
@@ -53,9 +52,9 @@ func (cmd LsCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd LsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, lsDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, lsDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement

--- a/go/cmd/dolt/commands/credcmds/ls.go
+++ b/go/cmd/dolt/commands/credcmds/ls.go
@@ -51,10 +51,10 @@ func (cmd LsCmd) Description() string {
 	return lsDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd LsCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, lsDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, lsDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -77,7 +77,7 @@ func (cmd LsCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, lsDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, lsDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.Contains("verbose") {

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -48,10 +48,10 @@ func (cmd NewCmd) Description() string {
 	return newDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd NewCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd NewCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, newDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, newDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -73,7 +73,7 @@ func (cmd NewCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd NewCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, newDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, newDocs, ap))
 	cli.ParseArgs(ap, args, help)
 
 	_, newCreds, verr := actions.NewCredsFile(dEnv)

--- a/go/cmd/dolt/commands/credcmds/new.go
+++ b/go/cmd/dolt/commands/credcmds/new.go
@@ -26,7 +26,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/config"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var newDocs = cli.CommandDocumentationContent{
@@ -50,9 +49,9 @@ func (cmd NewCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd NewCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd NewCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, newDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, newDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -45,10 +45,10 @@ func (cmd RmCmd) Description() string {
 	return rmDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RmCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd RmCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, rmDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, rmDocs, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -70,7 +70,7 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, rmDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, rmDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 

--- a/go/cmd/dolt/commands/credcmds/rm.go
+++ b/go/cmd/dolt/commands/credcmds/rm.go
@@ -25,7 +25,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var rmDocs = cli.CommandDocumentationContent{
@@ -47,9 +46,9 @@ func (cmd RmCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd RmCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, rmDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, rmDocs, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -25,7 +25,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var useDocs = cli.CommandDocumentationContent{
@@ -53,9 +52,9 @@ func (cmd UseCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd UseCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd UseCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, useDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, useDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement

--- a/go/cmd/dolt/commands/credcmds/use.go
+++ b/go/cmd/dolt/commands/credcmds/use.go
@@ -51,10 +51,10 @@ func (cmd UseCmd) Description() string {
 	return useDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd UseCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd UseCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, useDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, useDocs, ap)
 }
 
 // RequiresRepo should return false if this interface is implemented, and the command does not have the requirement
@@ -76,7 +76,7 @@ func (cmd UseCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd UseCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, useDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, useDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	args = apr.Args()
 	if len(args) != 1 {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -41,7 +41,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/fwt"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/nullprinter"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/mathutil"
 	"github.com/liquidata-inc/dolt/go/store/atomicerr"
@@ -125,9 +124,9 @@ func (cmd DiffCmd) EventType() eventsapi.ClientEventType {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd DiffCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd DiffCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, diffDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, diffDocs, ap)
 }
 
 func (cmd DiffCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -123,10 +123,10 @@ func (cmd DiffCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_DIFF
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd DiffCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd DiffCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, diffDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, diffDocs, ap)
 }
 
 func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
@@ -143,7 +143,7 @@ func (cmd DiffCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd DiffCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, diffDocs, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, diffDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	diffParts := SchemaAndDataDiff

--- a/go/cmd/dolt/commands/dump_docs.go
+++ b/go/cmd/dolt/commands/dump_docs.go
@@ -57,8 +57,8 @@ func (cmd *DumpDocsCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd *DumpDocsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd *DumpDocsCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -66,7 +66,7 @@ func (cmd *DumpDocsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentati
 func (cmd *DumpDocsCmd) Exec(_ context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := argparser.NewArgParser()
 	ap.SupportsString(dirParamName, "", "dir", "The directory where the md files should be dumped")
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cli.CommandDocumentationContent{}, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, cli.CommandDocumentationContent{}, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	dirStr := apr.GetValueOrDefault(dirParamName, ".")
@@ -113,7 +113,7 @@ func (cmd *DumpDocsCmd) dumpDocs(dEnv *env.DoltEnv, dirStr, cmdStr string, subCo
 				}
 			} else {
 				currCmdStr := fmt.Sprintf("%s %s", cmdStr, curr.Name())
-				cmdDoc := curr.CreateMarkdown(currCmdStr)
+				cmdDoc := curr.GetCommandDocumentation(currCmdStr)
 				if cmdDoc.CommandStr != "" {
 					currCmdMkd, err := cmdDoc.CmdDocToMd()
 					if err != nil {

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/events"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/earl"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -66,9 +65,9 @@ func (cmd FetchCmd) EventType() eventsapi.ClientEventType {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd FetchCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd FetchCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, fetchDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, fetchDocs, ap)
 }
 
 func (cmd FetchCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -64,10 +64,10 @@ func (cmd FetchCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_FETCH
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd FetchCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd FetchCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, fetchDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, fetchDocs, ap)
 }
 
 func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
@@ -79,7 +79,7 @@ func (cmd FetchCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd FetchCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, fetchDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, fetchDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, _ := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/indexcmds/cat.go
+++ b/go/cmd/dolt/commands/indexcmds/cat.go
@@ -35,7 +35,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/nullprinter"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/tabular"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
@@ -71,8 +70,8 @@ func (cmd CatCmd) Description() string {
 	return "Internal debugging command to display the contents of an index."
 }
 
-func (cmd CatCmd) CreateMarkdown(filesys.Filesys, string, string) error {
-	return nil
+func (cmd CatCmd) CreateMarkdown(string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 func (cmd CatCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/indexcmds/cat.go
+++ b/go/cmd/dolt/commands/indexcmds/cat.go
@@ -70,7 +70,7 @@ func (cmd CatCmd) Description() string {
 	return "Internal debugging command to display the contents of an index."
 }
 
-func (cmd CatCmd) CreateMarkdown(string) cli.CommandDocumentation {
+func (cmd CatCmd) GetCommandDocumentation(string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -84,7 +84,7 @@ func (cmd CatCmd) createArgParser() *argparser.ArgParser {
 
 func (cmd CatCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, catDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, catDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 {

--- a/go/cmd/dolt/commands/indexcmds/ls.go
+++ b/go/cmd/dolt/commands/indexcmds/ls.go
@@ -24,7 +24,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var lsDocs = cli.CommandDocumentationContent{
@@ -46,8 +45,8 @@ func (cmd LsCmd) Description() string {
 	return "Internal debugging command to display the list of indexes."
 }
 
-func (cmd LsCmd) CreateMarkdown(filesys.Filesys, string, string) error {
-	return nil
+func (cmd LsCmd) CreateMarkdown(string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 func (cmd LsCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/indexcmds/ls.go
+++ b/go/cmd/dolt/commands/indexcmds/ls.go
@@ -45,7 +45,7 @@ func (cmd LsCmd) Description() string {
 	return "Internal debugging command to display the list of indexes."
 }
 
-func (cmd LsCmd) CreateMarkdown(string) cli.CommandDocumentation {
+func (cmd LsCmd) GetCommandDocumentation(string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -57,7 +57,7 @@ func (cmd LsCmd) createArgParser() *argparser.ArgParser {
 
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, lsDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, lsDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -21,7 +21,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var rebuildDocs = cli.CommandDocumentationContent{
@@ -45,8 +44,8 @@ func (cmd RebuildCmd) Description() string {
 	return "Internal debugging command to rebuild the contents of an index."
 }
 
-func (cmd RebuildCmd) CreateMarkdown(filesys.Filesys, string, string) error {
-	return nil
+func (cmd RebuildCmd) CreateMarkdown(string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 func (cmd RebuildCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/indexcmds/rebuild.go
+++ b/go/cmd/dolt/commands/indexcmds/rebuild.go
@@ -44,7 +44,7 @@ func (cmd RebuildCmd) Description() string {
 	return "Internal debugging command to rebuild the contents of an index."
 }
 
-func (cmd RebuildCmd) CreateMarkdown(string) cli.CommandDocumentation {
+func (cmd RebuildCmd) GetCommandDocumentation(string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -57,7 +57,7 @@ func (cmd RebuildCmd) createArgParser() *argparser.ArgParser {
 
 func (cmd RebuildCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, rebuildDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, rebuildDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 {

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -63,10 +63,10 @@ func (cmd InitCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd InitCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd InitCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, initDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, initDocs, ap)
 }
 
 func (cmd InitCmd) createArgParser() *argparser.ArgParser {
@@ -81,7 +81,7 @@ func (cmd InitCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd InitCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, initDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, initDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if dEnv.HasDoltDir() {

--- a/go/cmd/dolt/commands/init.go
+++ b/go/cmd/dolt/commands/init.go
@@ -25,7 +25,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
@@ -65,9 +64,9 @@ func (cmd InitCmd) RequiresRepo() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd InitCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd InitCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, initDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, initDocs, ap)
 }
 
 func (cmd InitCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions/commitwalk"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/hash"
 )
 
@@ -99,9 +98,9 @@ func (cmd LogCmd) EventType() eventsapi.ClientEventType {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LogCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd LogCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := createLogArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, logDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, logDocs, ap)
 }
 
 func createLogArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -97,10 +97,10 @@ func (cmd LogCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_LOG
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LogCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd LogCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := createLogArgParser()
-	return cli.GetCommandDocumentation(commandStr, logDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, logDocs, ap)
 }
 
 func createLogArgParser() *argparser.ArgParser {
@@ -116,7 +116,7 @@ func (cmd LogCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 
 func logWithLoggerFunc(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv, loggerFunc commitLoggerFunc) int {
 	ap := createLogArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, logDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, logDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() > 1 {

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -60,10 +60,10 @@ func (cmd LoginCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LoginCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd LoginCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, loginDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, loginDocs, ap)
 }
 
 func (cmd LoginCmd) createArgParser() *argparser.ArgParser {
@@ -80,7 +80,7 @@ func (cmd LoginCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LoginCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, loginDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, loginDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/login.go
+++ b/go/cmd/dolt/commands/login.go
@@ -29,7 +29,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -62,9 +61,9 @@ func (cmd LoginCmd) RequiresRepo() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LoginCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd LoginCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, loginDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, loginDocs, ap)
 }
 
 func (cmd LoginCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -26,7 +26,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
 
@@ -61,9 +60,9 @@ func (cmd LsCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd LsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, lsDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, lsDocs, ap)
 }
 
 func (cmd LsCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -59,10 +59,10 @@ func (cmd LsCmd) Description() string {
 	return "List tables in the working set."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd LsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd LsCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, lsDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, lsDocs, ap)
 }
 
 func (cmd LsCmd) createArgParser() *argparser.ArgParser {
@@ -81,7 +81,7 @@ func (cmd LsCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, lsDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, lsDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.Contains(systemFlag) && apr.Contains(allFlag) {

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -70,10 +70,10 @@ func (cmd MergeCmd) Description() string {
 	return "Merge a branch."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MergeCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd MergeCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, mergeDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, mergeDocs, ap)
 }
 
 func (cmd MergeCmd) createArgParser() *argparser.ArgParser {
@@ -90,7 +90,7 @@ func (cmd MergeCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, mergeDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, mergeDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -31,7 +31,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/merge"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/hash"
 )
 
@@ -72,9 +71,9 @@ func (cmd MergeCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MergeCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd MergeCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, mergeDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, mergeDocs, ap)
 }
 
 func (cmd MergeCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -49,8 +49,8 @@ func (cmd MigrateCmd) Description() string {
 	return "Executes a repository migration to update to the latest format."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MigrateCmd) CreateMarkdown(string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd MigrateCmd) GetCommandDocumentation(string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -69,7 +69,7 @@ func (cmd MigrateCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MigrateCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, pushDocs, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, pushDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.Contains(migratePushFlag) && apr.Contains(migratePullFlag) {

--- a/go/cmd/dolt/commands/migrate.go
+++ b/go/cmd/dolt/commands/migrate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/rebase"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 const (
@@ -51,8 +50,8 @@ func (cmd MigrateCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MigrateCmd) CreateMarkdown(_ filesys.Filesys, _, _ string) error {
-	return nil
+func (cmd MigrateCmd) CreateMarkdown(string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 func (cmd MigrateCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -23,7 +23,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var pullDocs = cli.CommandDocumentationContent{
@@ -50,9 +49,9 @@ func (cmd PullCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd PullCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd PullCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, pullDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, pullDocs, ap)
 }
 
 func (cmd PullCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -48,10 +48,10 @@ func (cmd PullCmd) Description() string {
 	return "Fetch from a dolt remote data repository and merge."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd PullCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd PullCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, pullDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, pullDocs, ap)
 }
 
 func (cmd PullCmd) createArgParser() *argparser.ArgParser {
@@ -67,7 +67,7 @@ func (cmd PullCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PullCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, pullDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, pullDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	branch := dEnv.RepoState.CWBHeadRef()
 

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -33,7 +33,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/events"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/earl"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/datas"
 )
 
@@ -71,9 +70,9 @@ func (cmd PushCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd PushCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd PushCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, pushDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, pushDocs, ap)
 }
 
 func (cmd PushCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -69,10 +69,10 @@ func (cmd PushCmd) Description() string {
 	return "Push to a dolt remote."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd PushCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd PushCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, pushDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, pushDocs, ap)
 }
 
 func (cmd PushCmd) createArgParser() *argparser.ArgParser {
@@ -90,7 +90,7 @@ func (cmd PushCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd PushCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, pushDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, pushDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	remotes, err := dEnv.GetRemotes()

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -88,10 +88,10 @@ func (cmd RemoteCmd) Description() string {
 	return "Manage set of tracked repositories."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RemoteCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd RemoteCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, remoteDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, remoteDocs, ap)
 }
 
 func (cmd RemoteCmd) createArgParser() *argparser.ArgParser {
@@ -115,7 +115,7 @@ func (cmd RemoteCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd RemoteCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, remoteDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, remoteDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	var verr errhand.VerboseError

--- a/go/cmd/dolt/commands/remote.go
+++ b/go/cmd/dolt/commands/remote.go
@@ -89,9 +89,9 @@ func (cmd RemoteCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RemoteCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd RemoteCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, remoteDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, remoteDocs, ap)
 }
 
 func (cmd RemoteCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/diff"
@@ -70,9 +68,9 @@ func (cmd ResetCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ResetCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ResetCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, resetDocContent, ap))
+	return cli.GetCommandDocumentation(commandStr, resetDocContent, ap)
 }
 
 func (cmd ResetCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/reset.go
+++ b/go/cmd/dolt/commands/reset.go
@@ -67,10 +67,10 @@ func (cmd ResetCmd) Description() string {
 	return "Remove table changes from the list of staged table changes."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ResetCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ResetCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, resetDocContent, ap)
+	return cli.BuildCommandDocumentation(commandStr, resetDocContent, ap)
 }
 
 func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
@@ -83,7 +83,7 @@ func (cmd ResetCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ResetCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, resetDocContent, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, resetDocContent, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.ContainsArg(doltdb.DocTableName) {

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -54,10 +54,10 @@ func (cmd ExportCmd) Description() string {
 	return "Exports a table's schema."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ExportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ExportCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, schExportDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, schExportDocs, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {
@@ -76,7 +76,7 @@ func (cmd ExportCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, schExportDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, schExportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	root, verr := commands.GetWorkingWithVErr(dEnv)

--- a/go/cmd/dolt/commands/schcmds/export.go
+++ b/go/cmd/dolt/commands/schcmds/export.go
@@ -28,7 +28,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle/sqlfmt"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var schExportDocs = cli.CommandDocumentationContent{
@@ -56,9 +55,9 @@ func (cmd ExportCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ExportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, schExportDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, schExportDocs, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -113,9 +113,9 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, schImportDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, schImportDocs, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -112,10 +112,10 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_SCHEMA
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ImportCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, schImportDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, schImportDocs, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
@@ -139,7 +139,7 @@ func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, schImportDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, schImportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/sqle/sqlfmt"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var tblSchemaDocs = cli.CommandDocumentationContent{
@@ -55,9 +54,9 @@ func (cmd ShowCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ShowCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ShowCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap)
 }
 
 func (cmd ShowCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -53,10 +53,10 @@ func (cmd ShowCmd) Description() string {
 	return "Shows the schema of one or more tables."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ShowCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ShowCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, tblSchemaDocs, ap)
 }
 
 func (cmd ShowCmd) createArgParser() *argparser.ArgParser {
@@ -74,7 +74,7 @@ func (cmd ShowCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd ShowCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblSchemaDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, tblSchemaDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	verr := printSchemas(ctx, apr, dEnv)

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -28,7 +28,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/events"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 // SendMetricsCommand is the command used for sending metrics
@@ -62,8 +61,8 @@ func (cmd SendMetricsCmd) Hidden() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SendMetricsCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
-	return nil
+func (cmd SendMetricsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 // Exec is the implementation of the command that flushes the events to the grpc service

--- a/go/cmd/dolt/commands/send_metrics.go
+++ b/go/cmd/dolt/commands/send_metrics.go
@@ -60,8 +60,8 @@ func (cmd SendMetricsCmd) Hidden() bool {
 	return true
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SendMetricsCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd SendMetricsCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 
@@ -71,7 +71,7 @@ func (cmd SendMetricsCmd) Exec(ctx context.Context, commandStr string, args []st
 	ap := argparser.NewArgParser()
 	ap.SupportsFlag(outputFlag, "o", "Flush events to stdout.")
 
-	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, cli.CommandDocumentationContent{ShortDesc: sendMetricsShortDesc}, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, cli.CommandDocumentationContent{ShortDesc: sendMetricsShortDesc}, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	metricsDisabled := dEnv.Config.GetStringOrDefault(env.MetricsDisabled, "false")

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -50,7 +50,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/nullprinter"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/untyped/tabular"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/osutil"
 	"github.com/liquidata-inc/dolt/go/store/types"
@@ -107,9 +106,9 @@ func (cmd SqlCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SqlCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd SqlCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, sqlDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, sqlDocs, ap)
 }
 
 func (cmd SqlCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -105,10 +105,10 @@ func (cmd SqlCmd) Description() string {
 	return "Run a SQL query against tables in repository."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SqlCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd SqlCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, sqlDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, sqlDocs, ap)
 }
 
 func (cmd SqlCmd) createArgParser() *argparser.ArgParser {
@@ -140,7 +140,7 @@ func (cmd SqlCmd) RequiresRepo() bool {
 // Exec executes the command
 func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, sqlDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, sqlDocs, ap))
 
 	apr := cli.ParseArgs(ap, args, help)
 	err := validateSqlArgs(apr)

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -103,10 +103,10 @@ func (cmd SqlServerCmd) Description() string {
 	return sqlServerDocs.ShortDesc
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SqlServerCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd SqlServerCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := createArgParser()
-	return cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, sqlServerDocs, ap)
 }
 
 func createArgParser() *argparser.ArgParser {
@@ -146,7 +146,7 @@ func (cmd SqlServerCmd) Exec(ctx context.Context, commandStr string, args []stri
 
 func startServer(ctx context.Context, versionStr, commandStr string, args []string, dEnv *env.DoltEnv, serverController *ServerController) int {
 	ap := createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, sqlServerDocs, ap))
 
 	apr := cli.ParseArgs(ap, args, help)
 	serverConfig, err := getServerConfig(dEnv, apr)

--- a/go/cmd/dolt/commands/sqlserver/sqlserver.go
+++ b/go/cmd/dolt/commands/sqlserver/sqlserver.go
@@ -24,7 +24,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
-	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
@@ -105,9 +104,9 @@ func (cmd SqlServerCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd SqlServerCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd SqlServerCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, sqlServerDocs, ap)
 }
 
 func createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -30,7 +30,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/merge"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/set"
 )
@@ -54,9 +53,9 @@ func (cmd StatusCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd StatusCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd StatusCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, statusDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, statusDocs, ap)
 }
 
 func (cmd StatusCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/status.go
+++ b/go/cmd/dolt/commands/status.go
@@ -52,10 +52,10 @@ func (cmd StatusCmd) Description() string {
 	return "Show the working tree status."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd StatusCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd StatusCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, statusDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, statusDocs, ap)
 }
 
 func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
@@ -66,7 +66,7 @@ func (cmd StatusCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd StatusCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, _ := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, statusDocs, ap))
+	help, _ := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, statusDocs, ap))
 	cli.ParseArgs(ap, args, help)
 
 	stagedTblDiffs, notStagedTblDiffs, err := diff.GetTableDiffs(ctx, dEnv)

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -52,10 +52,10 @@ func (cmd CpCmd) Description() string {
 	return "Copies a table"
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CpCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd CpCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, tblCpDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, tblCpDocs, ap)
 }
 
 func (cmd CpCmd) createArgParser() *argparser.ArgParser {
@@ -75,7 +75,7 @@ func (cmd CpCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblCpDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, tblCpDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() < 2 || apr.NArg() > 3 {

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -17,15 +17,13 @@ package tblcmds
 import (
 	"context"
 
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/doltcore/mvdata"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/mvdata"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 )
 
@@ -55,9 +53,9 @@ func (cmd CpCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd CpCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd CpCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblCpDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, tblCpDocs, ap)
 }
 
 func (cmd CpCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -90,7 +90,7 @@ func validateExportArgs(apr *argparser.ArgParseResults, usage cli.UsagePrinter) 
 }
 
 func parseExportArgs(ap *argparser.ArgParser, commandStr string, args []string) *mvdata.MoveOptions {
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, exportDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, exportDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 	tableName, tableLoc, fileLoc := validateExportArgs(apr, usage)
 
@@ -127,10 +127,10 @@ func (cmd ExportCmd) Description() string {
 	return "Export a table to a file."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ExportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ExportCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, exportDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, exportDocs, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {
@@ -163,7 +163,7 @@ func (cmd ExportCmd) Exec(ctx context.Context, commandStr string, args []string,
 	verr := executeMove(ctx, dEnv, mvOpts)
 
 	if verr != nil {
-		_, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, exportDocs, ap))
+		_, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, exportDocs, ap))
 		return commands.HandleVErrAndExitCode(verr, usage)
 	}
 

--- a/go/cmd/dolt/commands/tblcmds/export.go
+++ b/go/cmd/dolt/commands/tblcmds/export.go
@@ -27,7 +27,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/mvdata"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 )
 
@@ -129,9 +128,9 @@ func (cmd ExportCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ExportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ExportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, exportDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, exportDocs, ap)
 }
 
 func (cmd ExportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -32,7 +32,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/pipeline"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/table/typed/noms"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/iohelp"
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
@@ -256,9 +255,9 @@ func (cmd ImportCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, importDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, importDocs, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/import.go
+++ b/go/cmd/dolt/commands/tblcmds/import.go
@@ -254,10 +254,10 @@ func (cmd ImportCmd) Description() string {
 	return "Creates, overwrites, replaces, or updates a table from the data in a file."
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd ImportCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd ImportCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, importDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, importDocs, ap)
 }
 
 func (cmd ImportCmd) createArgParser() *argparser.ArgParser {
@@ -274,7 +274,7 @@ func (cmd ImportCmd) EventType() eventsapi.ClientEventType {
 func (cmd ImportCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
 
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, importDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, importDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	verr := validateImportArgs(apr)

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -24,7 +24,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 )
 
 var tblMvDocs = cli.CommandDocumentationContent{
@@ -56,9 +55,9 @@ func (cmd MvCmd) Description() string {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MvCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd MvCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblMvDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, tblMvDocs, ap)
 }
 
 func (cmd MvCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/mv.go
+++ b/go/cmd/dolt/commands/tblcmds/mv.go
@@ -54,10 +54,10 @@ func (cmd MvCmd) Description() string {
 	return "Moves a table"
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd MvCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd MvCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, tblMvDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, tblMvDocs, ap)
 }
 
 func (cmd MvCmd) createArgParser() *argparser.ArgParser {
@@ -76,7 +76,7 @@ func (cmd MvCmd) EventType() eventsapi.ClientEventType {
 // Exec executes the command
 func (cmd MvCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblMvDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, tblMvDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() != 2 {

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -17,12 +17,10 @@ package tblcmds
 import (
 	"context"
 
-	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/commands"
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/errhand"
+	eventsapi "github.com/liquidata-inc/dolt/go/gen/proto/dolt/services/eventsapi/v1alpha1"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/doltdb"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
@@ -54,9 +52,9 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RmCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
+func (cmd RmCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return commands.CreateMarkdown(fs, path, cli.GetCommandDocumentation(commandStr, tblRmDocs, ap))
+	return cli.GetCommandDocumentation(commandStr, tblRmDocs, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {

--- a/go/cmd/dolt/commands/tblcmds/rm.go
+++ b/go/cmd/dolt/commands/tblcmds/rm.go
@@ -51,10 +51,10 @@ func (cmd RmCmd) EventType() eventsapi.ClientEventType {
 	return eventsapi.ClientEventType_TABLE_RM
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd RmCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd RmCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	ap := cmd.createArgParser()
-	return cli.GetCommandDocumentation(commandStr, tblRmDocs, ap)
+	return cli.BuildCommandDocumentation(commandStr, tblRmDocs, ap)
 }
 
 func (cmd RmCmd) createArgParser() *argparser.ArgParser {
@@ -66,7 +66,7 @@ func (cmd RmCmd) createArgParser() *argparser.ArgParser {
 // Exec executes the command
 func (cmd RmCmd) Exec(ctx context.Context, commandStr string, args []string, dEnv *env.DoltEnv) int {
 	ap := cmd.createArgParser()
-	help, usage := cli.HelpAndUsagePrinters(cli.GetCommandDocumentation(commandStr, tblRmDocs, ap))
+	help, usage := cli.HelpAndUsagePrinters(cli.BuildCommandDocumentation(commandStr, tblRmDocs, ap))
 	apr := cli.ParseArgs(ap, args, help)
 
 	if apr.NArg() == 0 {

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -41,8 +41,8 @@ func (cmd VersionCmd) RequiresRepo() bool {
 	return false
 }
 
-// CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd VersionCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+// BuildCommandDocumentation creates a markdown file containing the helptext for the command at the given path
+func (cmd VersionCmd) GetCommandDocumentation(commandStr string) cli.CommandDocumentation {
 	return cli.CommandDocumentation{}
 }
 

--- a/go/cmd/dolt/commands/version.go
+++ b/go/cmd/dolt/commands/version.go
@@ -17,8 +17,6 @@ package commands
 import (
 	"context"
 
-	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
-
 	"github.com/liquidata-inc/dolt/go/cmd/dolt/cli"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 )
@@ -44,8 +42,8 @@ func (cmd VersionCmd) RequiresRepo() bool {
 }
 
 // CreateMarkdown creates a markdown file containing the helptext for the command at the given path
-func (cmd VersionCmd) CreateMarkdown(fs filesys.Filesys, path, commandStr string) error {
-	return nil
+func (cmd VersionCmd) CreateMarkdown(commandStr string) cli.CommandDocumentation {
+	return cli.CommandDocumentation{}
 }
 
 // Version displays the version of the running dolt client


### PR DESCRIPTION
Update Dolt doc generation process to generate a single file with CLI docs for new docs site.

The only interesting thing going on here is `dump_docs.go`, and I'd hardly call that interesting. I still don't love this implementation but it works for now.