### PR TITLE
Andy/baseball databank fix

### DIFF
--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -645,7 +645,6 @@ func modifyDifferenceTag(d *ndiff.Difference, nbf *types.NomsBinFormat, rSch sch
 		valTup = newTv.NomsTupleForNonPKCols(nbf, rSch.GetNonPKCols())
 	}
 
-
 	return keyTup, valTup, nil
 }
 


### PR DESCRIPTION
Baseball databank was breaking the previous migration because it has null values in primary keys 
(see table `allstarfull`)