### PR TITLE
SELECT comparisons and BETWEEN now use indexes

### DIFF
--- a/bats/query-catalog.bats
+++ b/bats/query-catalog.bats
@@ -126,7 +126,7 @@ teardown() {
     # update an existing verify output, and verify query catalog is updated
     dolt sql -q "$Q1_UPDATED" -s name1
 
-    EXPECTED=$(echo -e "pk,pk1,pk2\n0,0,0\n1,0,1\n2,1,0")
+    EXPECTED=$(echo -e "pk,pk1,pk2\n2,1,0\n1,0,1\n0,0,0")
     run dolt sql -r csv -x name1
     [ "$status" -eq 0 ]
     [[ "$output" =~ "$EXPECTED" ]] || false

--- a/go/libraries/doltcore/sqle/dolt_index.go
+++ b/go/libraries/doltcore/sqle/dolt_index.go
@@ -25,24 +25,10 @@ import (
 	"github.com/liquidata-inc/dolt/go/store/types"
 )
 
-/*
-TODO: implement these interfaces so that >, >=, <, and <= works with indexes
-
-sql.AscendIndex
-
-AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLookup, error)
-AscendLessThan(keys ...interface{}) (sql.IndexLookup, error)
-AscendRange(greaterOrEqual, lessThan []interface{}) (sql.IndexLookup, error)
-
-sql.DescendIndex
-
-DescendGreater(keys ...interface{}) (sql.IndexLookup, error)
-DescendLessOrEqual(keys ...interface{}) (sql.IndexLookup, error)
-DescendRange(lessOrEqual, greaterThan []interface{}) (sql.IndexLookup, error)
-*/
-
 type DoltIndex interface {
 	sql.Index
+	sql.AscendIndex
+	sql.DescendIndex
 	DoltDatabase() Database
 	Schema() schema.Schema
 }
@@ -60,7 +46,64 @@ type doltIndex struct {
 	tableSch  schema.Schema
 }
 
+type compExpr func(left sql.Expression, right sql.Expression) sql.Expression
+
 var _ DoltIndex = (*doltIndex)(nil)
+
+func (di *doltIndex) AscendGreaterOrEqual(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(keys) {
+		return nil, errors.New("keys must specify all columns for index")
+	}
+	return di.keysToIter(di.keysToExpr(keys, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewGreaterThanOrEqual(left, right)
+	}))
+}
+
+func (di *doltIndex) AscendLessThan(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(keys) {
+		return nil, errors.New("keys must specify all columns for index")
+	}
+	return di.keysToIter(di.keysToExpr(keys, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewLessThan(left, right)
+	}))
+}
+
+// TODO: rename this from AscendRange to BetweenRange or something
+func (di *doltIndex) AscendRange(greaterOrEqual, lessThanOrEqual []interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(greaterOrEqual) || len(di.cols) != len(lessThanOrEqual) {
+		return nil, errors.New("keys must specify all columns for index")
+	}
+	greaterEqualExprs := di.keysToExpr(greaterOrEqual, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewGreaterThanOrEqual(left, right)
+	})
+	lessEqualExprs := di.keysToExpr(lessThanOrEqual, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewLessThanOrEqual(left, right)
+	})
+	return di.keysToIter(expression.NewAnd(greaterEqualExprs, lessEqualExprs))
+}
+
+func (di *doltIndex) DescendGreater(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(keys) {
+		return nil, errors.New("keys must specify all columns for index")
+	}
+	return di.keysToIter(di.keysToExpr(keys, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewGreaterThan(left, right)
+	}))
+}
+
+func (di *doltIndex) DescendLessOrEqual(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(keys) {
+		return nil, errors.New("keys must specify all columns for index")
+	}
+	return di.keysToIter(di.keysToExpr(keys, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewLessThanOrEqual(left, right)
+	}))
+}
+
+// TODO: fix go-mysql-server to remove this duplicate function
+func (di *doltIndex) DescendRange(lessOrEqual, greaterOrEqual []interface{}) (sql.IndexLookup, error) {
+	return di.AscendRange(greaterOrEqual, lessOrEqual)
+}
 
 func (di *doltIndex) Database() string {
 	return di.db.name
@@ -82,38 +125,13 @@ func (di *doltIndex) Expressions() []string {
 	return strs
 }
 
-func (di *doltIndex) Get(key ...interface{}) (sql.IndexLookup, error) {
-	if len(di.cols) != len(key) {
-		return nil, errors.New("key must specify all columns for index")
+func (di *doltIndex) Get(keys ...interface{}) (sql.IndexLookup, error) {
+	if len(di.cols) != len(keys) {
+		return nil, errors.New("keys must specify all columns for index")
 	}
-
-	equals := make([]*expression.Equals, len(key))
-	for i := 0; i < len(key); i++ {
-		equals[i] = expression.NewEquals(
-			expression.NewGetField(i, di.cols[i].TypeInfo.ToSqlType(), di.cols[i].Name, di.cols[i].IsNullable()),
-			expression.NewLiteral(key[i], di.cols[i].TypeInfo.ToSqlType()),
-		)
-	}
-	var lastExpr sql.Expression = equals[len(equals)-1]
-	for i := len(equals) - 2; i >= 0; i-- {
-		lastExpr = expression.NewAnd(equals[i], lastExpr)
-	}
-
-	crf, err := CreateReaderFuncLimitedByExpressions(di.rowData.Format(), di.mapSch, []sql.Expression{lastExpr})
-	if err != nil {
-		return nil, err
-	}
-	mapIter, err := crf(di.ctx, di.rowData)
-	if err != nil {
-		return nil, err
-	}
-
-	return &doltIndexLookup{
-		di,
-		&doltIndexKeyIter{
-			indexMapIter: mapIter,
-		},
-	}, nil
+	return di.keysToIter(di.keysToExpr(keys, func(left sql.Expression, right sql.Expression) sql.Expression {
+		return expression.NewEquals(left, right)
+	}))
 }
 
 func (*doltIndex) Has(partition sql.Partition, key ...interface{}) (bool, error) {
@@ -131,4 +149,37 @@ func (di *doltIndex) Schema() schema.Schema {
 
 func (di *doltIndex) Table() string {
 	return di.tableName
+}
+
+func (di *doltIndex) keysToExpr(keys []interface{}, compFunc compExpr) sql.Expression {
+	exprs := make([]sql.Expression, len(keys))
+	for i := 0; i < len(keys); i++ {
+		exprs[i] = compFunc(
+			expression.NewGetField(i, di.cols[i].TypeInfo.ToSqlType(), di.cols[i].Name, di.cols[i].IsNullable()),
+			expression.NewLiteral(keys[i], di.cols[i].TypeInfo.ToSqlType()),
+		)
+	}
+	lastExpr := exprs[len(exprs)-1]
+	for i := len(exprs) - 2; i >= 0; i-- {
+		lastExpr = expression.NewAnd(exprs[i], lastExpr)
+	}
+	return lastExpr
+}
+
+func (di *doltIndex) keysToIter(expr sql.Expression) (sql.IndexLookup, error) {
+	crf, err := CreateReaderFuncLimitedByExpressions(di.rowData.Format(), di.mapSch, []sql.Expression{expr})
+	if err != nil {
+		return nil, err
+	}
+	mapIter, err := crf(di.ctx, di.rowData)
+	if err != nil {
+		return nil, err
+	}
+
+	return &doltIndexLookup{
+		di,
+		&doltIndexKeyIter{
+			indexMapIter: mapIter,
+		},
+	}, nil
 }

--- a/go/libraries/doltcore/sqle/filtered_reader.go
+++ b/go/libraries/doltcore/sqle/filtered_reader.go
@@ -354,7 +354,11 @@ func rangeForInterval(nbf *types.NomsBinFormat, tag types.Uint, in setalgebra.In
 		reverse = true
 
 		var err error
-		startKey, err = types.NewTuple(nbf, tag, in.Start.Val)
+		if inclusive {
+			startKey, err = types.NewTuple(nbf, tag, in.End.Val, types.Uint(uint64(0xffffffffffffffff)))
+		} else {
+			startKey, err = types.NewTuple(nbf, tag, in.End.Val)
+		}
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`SELECT` `<`, `<=`, `>`, `>=`, and `BETWEEN` all now use indexes. Previously, only `=` used indexes or primary keys, so this should be a pretty huge win.