### PR TITLE
SQL Write Performance Improvements

### DIFF
--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/client_event.pb.go
@@ -6,13 +6,14 @@ package eventsapi
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	duration "github.com/golang/protobuf/ptypes/duration"
 	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
+++ b/go/gen/proto/dolt/services/eventsapi/v1alpha1/event_constants.pb.go
@@ -5,8 +5,9 @@ package eventsapi
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/chunkstore.pb.go
@@ -6,11 +6,12 @@ package remotesapi
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
+++ b/go/gen/proto/dolt/services/remotesapi/v1alpha1/credentials.pb.go
@@ -6,11 +6,12 @@ package remotesapi
 import (
 	context "context"
 	fmt "fmt"
+	math "math"
+
 	proto "github.com/golang/protobuf/proto"
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.

--- a/go/libraries/doltcore/doltdb/table_editor_test.go
+++ b/go/libraries/doltcore/doltdb/table_editor_test.go
@@ -66,7 +66,7 @@ func TestTableEditorConcurrency(t *testing.T) {
 					2: types.Int(val),
 				})
 				require.NoError(t, err)
-				require.NoError(t, tableEditor.Insert(context.Background(), dRow))
+				require.NoError(t, tableEditor.InsertRow(context.Background(), dRow))
 				wg.Done()
 			}(j)
 		}
@@ -87,7 +87,7 @@ func TestTableEditorConcurrency(t *testing.T) {
 					2: types.Int(val + 1),
 				})
 				require.NoError(t, err)
-				require.NoError(t, tableEditor.Update(context.Background(), dOldRow, dNewRow))
+				require.NoError(t, tableEditor.UpdateRow(context.Background(), dOldRow, dNewRow))
 				wg.Done()
 			}(j)
 		}
@@ -102,13 +102,13 @@ func TestTableEditorConcurrency(t *testing.T) {
 					2: types.Int(val),
 				})
 				require.NoError(t, err)
-				require.NoError(t, tableEditor.Delete(context.Background(), dRow))
+				require.NoError(t, tableEditor.DeleteRow(context.Background(), dRow))
 				wg.Done()
 			}(j)
 		}
 		wg.Wait()
 
-		newTable, err := tableEditor.Flush(context.Background())
+		newTable, err := tableEditor.Table()
 		require.NoError(t, err)
 		newTableData, err := newTable.GetRowData(context.Background())
 		require.NoError(t, err)
@@ -157,9 +157,9 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 			2: types.Int(i),
 		})
 		require.NoError(t, err)
-		require.NoError(t, tableEditor.Insert(context.Background(), dRow))
+		require.NoError(t, tableEditor.InsertRow(context.Background(), dRow))
 	}
-	table, err = tableEditor.Flush(context.Background())
+	table, err = tableEditor.Table()
 	require.NoError(t, err)
 
 	for i := 0; i < tableEditorConcurrencyIterations; i++ {
@@ -182,7 +182,7 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 					2: types.Int(val + 1),
 				})
 				require.NoError(t, err)
-				require.NoError(t, tableEditor.Update(context.Background(), dOldRow, dNewRow))
+				require.NoError(t, tableEditor.UpdateRow(context.Background(), dOldRow, dNewRow))
 				wg.Done()
 			}(j)
 		}
@@ -196,13 +196,13 @@ func TestTableEditorConcurrencyPostInsert(t *testing.T) {
 					2: types.Int(val),
 				})
 				require.NoError(t, err)
-				require.NoError(t, tableEditor.Delete(context.Background(), dRow))
+				require.NoError(t, tableEditor.DeleteRow(context.Background(), dRow))
 				wg.Done()
 			}(j)
 		}
 		wg.Wait()
 
-		newTable, err := tableEditor.Flush(context.Background())
+		newTable, err := tableEditor.Table()
 		require.NoError(t, err)
 		newTableData, err := newTable.GetRowData(context.Background())
 		require.NoError(t, err)
@@ -252,10 +252,10 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 			2: types.Int(i),
 		})
 		require.NoError(t, err)
-		require.NoError(t, tableEditor.Insert(context.Background(), dRow))
+		require.NoError(t, tableEditor.InsertRow(context.Background(), dRow))
 	}
 
-	_, err = tableEditor.Flush(context.Background())
+	_, err = tableEditor.Table()
 	require.NoError(t, err)
 
 	for i := 10; i < 20; i++ {
@@ -265,10 +265,10 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 			2: types.Int(i),
 		})
 		require.NoError(t, err)
-		require.NoError(t, tableEditor.Delete(context.Background(), dRow))
+		require.NoError(t, tableEditor.DeleteRow(context.Background(), dRow))
 	}
 
-	newTable, err := tableEditor.Flush(context.Background())
+	newTable, err := tableEditor.Table()
 	require.NoError(t, err)
 	newTableData, err := newTable.GetRowData(context.Background())
 	require.NoError(t, err)
@@ -289,7 +289,7 @@ func TestTableEditorWriteAfterFlush(t *testing.T) {
 		})
 	}
 
-	sameTable, err := tableEditor.Flush(context.Background())
+	sameTable, err := tableEditor.Table()
 	require.NoError(t, err)
 	sameTableData, err := sameTable.GetRowData(context.Background())
 	require.NoError(t, err)

--- a/go/libraries/doltcore/sqle/table_editor.go
+++ b/go/libraries/doltcore/sqle/table_editor.go
@@ -58,7 +58,7 @@ func (te *sqlTableEditor) Insert(ctx *sql.Context, sqlRow sql.Row) error {
 		return err
 	}
 
-	return te.tableEditor.Insert(ctx, dRow)
+	return te.tableEditor.InsertRow(ctx, dRow)
 }
 
 func (te *sqlTableEditor) Delete(ctx *sql.Context, sqlRow sql.Row) error {
@@ -67,7 +67,7 @@ func (te *sqlTableEditor) Delete(ctx *sql.Context, sqlRow sql.Row) error {
 		return err
 	}
 
-	return te.tableEditor.Delete(ctx, dRow)
+	return te.tableEditor.DeleteRow(ctx, dRow)
 }
 
 func (te *sqlTableEditor) Update(ctx *sql.Context, oldRow sql.Row, newRow sql.Row) error {
@@ -80,7 +80,7 @@ func (te *sqlTableEditor) Update(ctx *sql.Context, oldRow sql.Row, newRow sql.Ro
 		return err
 	}
 
-	return te.tableEditor.Update(ctx, dOldRow, dNewRow)
+	return te.tableEditor.UpdateRow(ctx, dOldRow, dNewRow)
 }
 
 // Close implements Closer
@@ -93,7 +93,7 @@ func (te *sqlTableEditor) Close(ctx *sql.Context) error {
 }
 
 func (te *sqlTableEditor) flush(ctx *sql.Context) error {
-	newTable, err := te.tableEditor.Flush(ctx)
+	newTable, err := te.tableEditor.Table()
 	if err != nil {
 		return err
 	}

--- a/go/libraries/utils/async/action_executor.go
+++ b/go/libraries/utils/async/action_executor.go
@@ -1,0 +1,135 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import (
+	"container/list"
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Action is the function called by an ActionExecutor on each given value.
+type Action func(ctx context.Context, val interface{}) error
+
+// ActionExecutor is designed for asynchronous workloads that should run when a new task is available. The closest analog
+// would be to have a long-running goroutine that receives from a channel, however ActionExecutor provides three major
+// points of differentiation. The first is that there is no need to close the queue, as goroutines automatically exit
+// when the queue is empty. The second is that a concurrency parameter may be set, that will spin up goroutines as
+// needed until the maximum number is attained. The third is that you don't have to declare the buffer size beforehand
+// as with channels, allowing the queue to respond to demand. You may declare a max buffer though, for RAM-limited
+// situations, which then blocks appends until the buffer is below the max given.
+type ActionExecutor struct {
+	action      Action
+	ctx         context.Context
+	concurrency uint32
+	err         error
+	finished    *WaitGroup
+	linkedList  *list.List
+	running     uint32
+	maxBuffer   uint64
+	syncCond    *sync.Cond
+}
+
+// NewActionExecutor returns an ActionExecutor that will run the given action on each appended value, and run up to the max
+// number of goroutines as defined by concurrency. If concurrency is 0, then it is set to 1. If maxBuffer is 0, then it
+// is unlimited. Panics on a nil action.
+func NewActionExecutor(ctx context.Context, action Action, concurrency uint32, maxBuffer uint64) *ActionExecutor {
+	if action == nil {
+		panic("action cannot be nil")
+	}
+	if concurrency == 0 {
+		concurrency = 1
+	}
+	return &ActionExecutor{
+		action:      action,
+		concurrency: concurrency,
+		ctx:         ctx,
+		finished:    &WaitGroup{},
+		linkedList:  list.New(),
+		running:     0,
+		maxBuffer:   maxBuffer,
+		syncCond:    sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// Execute adds the value to the end of the queue to be executed. If any action encountered an error before this call,
+// then the value is not added and this returns immediately.
+func (aq *ActionExecutor) Execute(val interface{}) {
+	aq.syncCond.L.Lock()
+	defer aq.syncCond.L.Unlock()
+
+	if aq.err != nil { // if we've errored before, then no point in running anything again
+		return
+	}
+
+	for aq.maxBuffer != 0 && uint64(aq.linkedList.Len()) >= aq.maxBuffer {
+		aq.syncCond.Wait()
+	}
+	aq.finished.Add(1)
+	aq.linkedList.PushBack(val)
+
+	if aq.running < aq.concurrency {
+		aq.running++
+		go aq.work()
+	}
+}
+
+// WaitForEmpty waits until the queue is empty, and then returns any errors that any actions may have encountered.
+func (aq *ActionExecutor) WaitForEmpty() error {
+	aq.finished.Wait()
+	return aq.err
+}
+
+// work runs until the list is empty. If any error occurs from any action, then we do not call any further actions,
+// although we still iterate over the list and clear it.
+func (aq *ActionExecutor) work() {
+	for {
+		aq.syncCond.L.Lock() // check element list and valid state, so we lock
+
+		element := aq.linkedList.Front()
+		if element == nil {
+			aq.running--
+			aq.syncCond.L.Unlock() // early exit, so we unlock
+			return                 // we don't signal here since the buffer is empty, hence the return in the first place
+		}
+		_ = aq.linkedList.Remove(element)
+		encounteredError := aq.err != nil
+
+		aq.syncCond.Signal()   // if an append is waiting because of a full buffer, we signal for it to continue
+		aq.syncCond.L.Unlock() // done checking list and state, so we unlock
+
+		if !encounteredError {
+			var err error
+			func() { // this func is to capture a potential panic from the action, and present it as an error instead
+				defer func() {
+					if r := recover(); r != nil {
+						err = fmt.Errorf("panic in ActionExecutor:\n%v", r)
+					}
+				}()
+				err = aq.action(aq.ctx, element.Value)
+			}()
+			// Technically, two actions could error at the same time and only one would persist their error. For async
+			// tasks, we don't care as much about which action errored, just that an action error.
+			if err != nil {
+				aq.syncCond.L.Lock()
+				aq.err = err
+				aq.syncCond.L.Unlock()
+			}
+		}
+
+		aq.finished.Done()
+	}
+}

--- a/go/libraries/utils/async/action_executor_test.go
+++ b/go/libraries/utils/async/action_executor_test.go
@@ -1,0 +1,168 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionExecutorOrdered(t *testing.T) {
+	expectedStr := "abcdefghijklmnopqrstuvwxyz"
+	outStr := ""
+	actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+		str := val.(string)
+		outStr += str
+		return nil
+	}, 1, 0)
+	for _, char := range expectedStr {
+		actionExecutor.Execute(string(char))
+	}
+	err := actionExecutor.WaitForEmpty()
+	require.NoError(t, err)
+	assert.Equal(t, expectedStr, outStr)
+}
+
+func TestActionExecutorOrderedBuffered(t *testing.T) {
+	expectedStr := "abcdefghijklmnopqrstuvwxyz"
+	outStr := ""
+	actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+		str := val.(string)
+		outStr += str
+		return nil
+	}, 1, 3)
+	for _, char := range expectedStr {
+		actionExecutor.Execute(string(char))
+	}
+	err := actionExecutor.WaitForEmpty()
+	require.NoError(t, err)
+	assert.Equal(t, expectedStr, outStr)
+}
+
+func TestActionExecutorUnordered(t *testing.T) {
+	expectedValue := int64(50005000)
+	outValue := int64(0)
+	actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+		atomic.AddInt64(&outValue, val.(int64))
+		return nil
+	}, 5, 0)
+	for i := int64(1); i <= 10000; i++ {
+		actionExecutor.Execute(i)
+	}
+	err := actionExecutor.WaitForEmpty()
+	require.NoError(t, err)
+	assert.Equal(t, expectedValue, outValue)
+}
+
+func TestActionExecutorUnorderedBuffered(t *testing.T) {
+	expectedValue := int64(50005000)
+	outValue := int64(0)
+	actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+		atomic.AddInt64(&outValue, val.(int64))
+		return nil
+	}, 5, 10)
+	for i := int64(1); i <= 10000; i++ {
+		actionExecutor.Execute(i)
+	}
+	err := actionExecutor.WaitForEmpty()
+	require.NoError(t, err)
+	assert.Equal(t, expectedValue, outValue)
+}
+
+func TestActionExecutorUnnecessaryWaits(t *testing.T) {
+	outValue := int64(0)
+	actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+		atomic.AddInt64(&outValue, val.(int64))
+		return nil
+	}, 5, 10)
+	for i := int64(1); i <= 10000; i++ {
+		actionExecutor.Execute(i)
+	}
+	for i := 0; i < 10; i++ {
+		err := actionExecutor.WaitForEmpty()
+		assert.NoError(t, err)
+	}
+}
+
+func TestActionExecutorError(t *testing.T) {
+	for _, conBuf := range []struct {
+		concurrency uint32
+		maxBuffer   uint64
+	}{
+		{1, 0},
+		{5, 0},
+		{10, 0},
+		{1, 1},
+		{5, 1},
+		{10, 1},
+		{1, 5},
+		{5, 5},
+		{10, 5},
+		{1, 10},
+		{5, 10},
+		{10, 10},
+	} {
+		actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+			if val.(int64) == 11 {
+				return errors.New("hey there")
+			}
+			return nil
+		}, conBuf.concurrency, conBuf.maxBuffer)
+		for i := int64(1); i <= 100; i++ {
+			actionExecutor.Execute(i)
+		}
+		err := actionExecutor.WaitForEmpty()
+		assert.Error(t, err)
+		sameErr := actionExecutor.WaitForEmpty()
+		assert.Equal(t, err, sameErr)
+	}
+}
+
+func TestActionExecutorPanicRecovery(t *testing.T) {
+	for _, conBuf := range []struct {
+		concurrency uint32
+		maxBuffer   uint64
+	}{
+		{1, 0},
+		{5, 0},
+		{10, 0},
+		{1, 1},
+		{5, 1},
+		{10, 1},
+		{1, 5},
+		{5, 5},
+		{10, 5},
+		{1, 10},
+		{5, 10},
+		{10, 10},
+	} {
+		actionExecutor := NewActionExecutor(context.Background(), func(ctx context.Context, val interface{}) error {
+			if val.(int64) == 22 {
+				panic("hey there")
+			}
+			return nil
+		}, conBuf.concurrency, conBuf.maxBuffer)
+		for i := int64(1); i <= 100; i++ {
+			actionExecutor.Execute(i)
+		}
+		err := actionExecutor.WaitForEmpty()
+		require.Error(t, err)
+	}
+}

--- a/go/libraries/utils/async/wait_group.go
+++ b/go/libraries/utils/async/wait_group.go
@@ -1,0 +1,66 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import "sync"
+
+// WaitGroup functions similarly to sync.WaitGroup that ships with Go, with the key difference being that this one
+// allows calls to Add with a positive delta to occur while another thread is waiting, while the sync version
+// may panic. The tradeoff is a performance reduction since we now lock on all modifications to the counter.
+type WaitGroup struct {
+	counter  int64 // we allow negative counters and don't panic on them, as it could be useful for the caller
+	initOnce sync.Once
+	syncCond *sync.Cond
+}
+
+// Add adds delta, which may be negative, to the WaitGroup counter. If the counter becomes zero, all goroutines blocked
+// on Wait are released. If the counter goes negative, Add panics.
+func (wg *WaitGroup) Add(delta int64) {
+	wg.init()
+	wg.syncCond.L.Lock()
+	defer wg.syncCond.L.Unlock()
+
+	wg.counter += delta
+	if wg.counter < 0 {
+		panic("negative WaitGroup counter")
+	} else if wg.counter == 0 {
+		wg.syncCond.Broadcast()
+	}
+}
+
+// Done decrements the WaitGroup counter by one.
+func (wg *WaitGroup) Done() {
+	wg.Add(-1)
+}
+
+// Wait blocks until the WaitGroup counter is less than or equal to zero.
+func (wg *WaitGroup) Wait() {
+	wg.init()
+	wg.syncCond.L.Lock()
+	defer wg.syncCond.L.Unlock()
+
+	for wg.counter > 0 {
+		wg.syncCond.Wait()
+	}
+}
+
+// sync.WaitGroup allows the user to use the zero value of a wait group with &sync.WaitGroup{}. Since this is supposed
+// to be a drop-in replacement, the user would expect to call &async.WaitGroup{}. Since we need some setup, we make use
+// of sync.Once to run that setup the first time the wait group is used.
+func (wg *WaitGroup) init() {
+	wg.initOnce.Do(func() {
+		wg.syncCond = sync.NewCond(&sync.Mutex{})
+	})
+}

--- a/go/libraries/utils/async/wait_group_test.go
+++ b/go/libraries/utils/async/wait_group_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package async
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitGroupAddWait(_ *testing.T) {
+	wg := &WaitGroup{}
+	wg.Add(100)
+	go func() {
+		for i := 0; i < 100; i++ {
+			wg.Done()
+		}
+	}()
+	wg.Wait()
+}
+
+func TestWaitGroupAddWhileWait(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.Nil(t, r)
+	}()
+	wg := &WaitGroup{}
+	for i := 0; i < 5000000; i++ {
+		wg.Add(1)
+		go wg.Done()
+	}
+	go func() {
+		for i := 0; i < 5000000; i++ {
+			wg.Add(1)
+			wg.Done()
+		}
+	}()
+	wg.Wait()
+}
+
+func TestWaitGroupPanicOnNegative(t *testing.T) {
+	defer func() {
+		r := recover()
+		assert.NotNil(t, r)
+	}()
+	wg := &WaitGroup{}
+	wg.Add(1)
+	wg.Done()
+	wg.Done()
+}


### PR DESCRIPTION
@bheni mentioned that we did not flush concurrently while performing other writes, and this idea was taken and executed upon. Lowering the flush threshold from `65536` to `16384` also seemed to improve performance just a bit with the new parallelism, which was not true with the previous implementation.

For performance numbers, we have `Original`, which is how it performed before I did any of the write path merging stuff. We have `Thread Safe`, which are my most recent changes. Then we have `Concurrent`, which is this current PR. Just for fun, we have `No-op` last. Here I made all of the write functions on `TableEditor` immediately return, just to see the true overhead that `TableEditor` actually adds to any particular write path.

Importing a 10 million row `.psv`:
```
Original:    53.521s
Thread Safe: 107.816s
Concurrent:  76.974s
No-op:       33.110s
```
Here we can see that we've gained around a 40% improvement in performance over my last PR, which is fairly substantial. As a result, the `TableEditor` is only about 31% slower than the original implementation, which should be perfectly acceptable given the additional bookkeeping.

Since these changes are made to `TableEditor`, the benefits also work for the standard SQL path. Here are the results of 1 million `INSERT` statements:
```
Original:    67.074s
Thread Safe: 67.363s
Concurrent:  59.325s
No-op:       57.839s
```
We've improved performance by 13%! Not as large as the 40% before, but that's due to the additional overhead that the SQL engine brings. In fact, with how close `Concurrent` is to `No-op`, we're at the point that any further speed increases on the SQL path will have to come from the engine, since the `TableEditor` is performing quickly enough to keep up with the engine already.