### PR TITLE
added --with-tags flag to schema export

### DIFF
--- a/bats/schema-export.bats
+++ b/bats/schema-export.bats
@@ -82,3 +82,12 @@ teardown() {
     [[ ! "$output" =~ "working" ]] || false
     [[ ! "$output" =~ "dolt_" ]] || false
 }
+
+@test "dolt schema export --with-tags" {
+    run dolt schema export
+    [ "$status" -eq 0 ]
+    [[ ! "$output" =~ "COMMENT 'tag:" ]] || false
+    run dolt schema export --with-tags
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "COMMENT 'tag:" ]] || false
+}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -466,18 +466,18 @@ func tabularSchemaDiff(tableName string, tags []uint64, diffs map[uint64]diff.Sc
 				newPks = append(newPks, sqlfmt.QuoteIdentifier(dff.New.Name))
 				oldPks = append(oldPks, sqlfmt.QuoteIdentifier(dff.Old.Name))
 			}
-			cli.Println(sqlfmt.FmtCol(4, 0, 0, *dff.New))
+			cli.Println(sqlfmt.FmtColWithTag(4, 0, 0, *dff.New))
 		case diff.SchDiffColAdded:
 			if dff.New.IsPartOfPK {
 				newPks = append(newPks, sqlfmt.QuoteIdentifier(dff.New.Name))
 			}
-			cli.Println(color.GreenString("+ " + sqlfmt.FmtCol(2, 0, 0, *dff.New)))
+			cli.Println(color.GreenString("+ " + sqlfmt.FmtColWithTag(2, 0, 0, *dff.New)))
 		case diff.SchDiffColRemoved:
 			// removed from sch2
 			if dff.Old.IsPartOfPK {
 				oldPks = append(oldPks, sqlfmt.QuoteIdentifier(dff.Old.Name))
 			}
-			cli.Println(color.RedString("- " + sqlfmt.FmtCol(2, 0, 0, *dff.Old)))
+			cli.Println(color.RedString("- " + sqlfmt.FmtColWithTag(2, 0, 0, *dff.Old)))
 		case diff.SchDiffColModified:
 			// changed in sch2
 			oldSqlType := dff.Old.TypeInfo.ToSqlType()
@@ -507,7 +507,7 @@ func tabularSchemaDiff(tableName string, tags []uint64, diffs map[uint64]diff.Sc
 				} else {
 					newPks = append(newPks, sqlfmt.QuoteIdentifier(n1))
 				}
-				cli.Println(sqlfmt.FmtCol(4, 0, 0, *dff.New))
+				cli.Println(sqlfmt.FmtColWithTag(4, 0, 0, *dff.New))
 			} else {
 				cli.Println("< " + sqlfmt.FmtColWithNameAndType(2, nameLen, typeLen, n0, t0, *dff.Old))
 				cli.Println("> " + sqlfmt.FmtColWithNameAndType(2, nameLen, typeLen, n1, t1, *dff.New))
@@ -536,7 +536,7 @@ func sqlSchemaDiff(tableName string, tags []uint64, diffs map[uint64]diff.Schema
 		switch dff.DiffType {
 		case diff.SchDiffNone:
 		case diff.SchDiffColAdded:
-			cli.Println(sqlfmt.AlterTableAddColStmt(tableName, sqlfmt.FmtCol(0, 0, 0, *dff.New)))
+			cli.Println(sqlfmt.AlterTableAddColStmt(tableName, sqlfmt.FmtColWithTag(0, 0, 0, *dff.New)))
 		case diff.SchDiffColRemoved:
 			cli.Print(sqlfmt.AlterTableDropColStmt(tableName, dff.Old.Name))
 		case diff.SchDiffColModified:

--- a/go/cmd/dolt/commands/schcmds/import.go
+++ b/go/cmd/dolt/commands/schcmds/import.go
@@ -285,7 +285,7 @@ func importSchema(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPars
 	}
 
 	tblName := impArgs.tableName
-	cli.Println(sqlfmt.SchemaAsCreateStmt(tblName, sch))
+	cli.Println(sqlfmt.CreateTableStmtWithTags(tblName, sch))
 
 	if !apr.Contains(dryRunFlag) {
 		tbl, tblExists, err := root.GetTable(ctx, tblName)

--- a/go/cmd/dolt/commands/schcmds/show.go
+++ b/go/cmd/dolt/commands/schcmds/show.go
@@ -165,6 +165,6 @@ func printTblSchema(ctx context.Context, cmStr string, tblName string, tbl *dolt
 		return errhand.BuildDError("unable to get schema").AddCause(err).Build()
 	}
 
-	cli.Println(sqlfmt.SchemaAsCreateStmt(tblName, sch))
+	cli.Println(sqlfmt.CreateTableStmtWithTags(tblName, sch))
 	return nil
 }

--- a/go/libraries/doltcore/diff/sql_diff.go
+++ b/go/libraries/doltcore/diff/sql_diff.go
@@ -179,7 +179,7 @@ func PrintSqlTableDiffs(ctx context.Context, r1, r2 *doltdb.RootValue, wr io.Wri
 			if sch, err := tbl.GetSchema(ctx); err != nil {
 				return errors.New("error unable to get schema for table " + tblName)
 			} else {
-				stmt := sqlfmt.SchemaAsCreateStmt(tblName, sch)
+				stmt := sqlfmt.CreateTableStmtWithTags(tblName, sch)
 				if err = iohelp.WriteLine(wr, stmt); err != nil {
 					return err
 				}

--- a/go/libraries/doltcore/diff/sql_diff_test.go
+++ b/go/libraries/doltcore/diff/sql_diff_test.go
@@ -67,7 +67,7 @@ func TestSqlTableDiffAdd(t *testing.T) {
 
 	var stringWr StringBuilderCloser
 	_ = PrintSqlTableDiffs(ctx, newRoot, oldRoot, &stringWr)
-	expectedOutput := sqlfmt.SchemaAsCreateStmt("addTable", sch) + "\n"
+	expectedOutput := sqlfmt.CreateTableStmtWithTags("addTable", sch) + "\n"
 	assert.Equal(t, expectedOutput, stringWr.String())
 }
 
@@ -88,7 +88,7 @@ func TestSqlTableDiffAddThenInsert(t *testing.T) {
 
 	var stringWr StringBuilderCloser
 	_ = PrintSqlTableDiffs(ctx, newRoot, oldRoot, &stringWr)
-	expectedOutput := sqlfmt.SchemaAsCreateStmt("addTable", sch) + "\n"
+	expectedOutput := sqlfmt.CreateTableStmtWithTags("addTable", sch) + "\n"
 	expectedOutput = expectedOutput +
 		"INSERT INTO `addTable` (`id`,`name`,`age`,`is_married`,`title`) " +
 		"VALUES ('00000000-0000-0000-0000-000000000000','Big Billy',77,FALSE,'Doctor');\n"
@@ -149,7 +149,7 @@ func TestSqlTableDiffRenameChangedTable(t *testing.T) {
 	_ = PrintSqlTableDiffs(ctx, newRoot, oldRoot, &stringWr)
 	expectedOutput := "DROP TABLE `renameTable`;\n"
 	expectedOutput = expectedOutput +
-		sqlfmt.SchemaAsCreateStmt("newTableName", sch) + "\n" +
+		sqlfmt.CreateTableStmtWithTags("newTableName", sch) + "\n" +
 		"INSERT INTO `newTableName` (`id`,`name`,`age`,`is_married`,`title`) " +
 		"VALUES ('00000000-0000-0000-0000-000000000000','Big Billy',77,FALSE,'Doctor');\n"
 	assert.Equal(t, expectedOutput, stringWr.String())

--- a/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/row_fmt_test.go
@@ -56,7 +56,7 @@ type test struct {
 
 func TestSchemaAsCreateStmt(t *testing.T) {
 	tSchema := sqltestutil.PeopleTestSchema
-	stmt := SchemaAsCreateStmt("table_name", tSchema)
+	stmt := CreateTableStmtWithTags("table_name", tSchema)
 
 	assert.Equal(t, expectedCreateSQL, stmt)
 }

--- a/go/libraries/doltcore/sqle/sqlfmt/schema_fmt_test.go
+++ b/go/libraries/doltcore/sqle/sqlfmt/schema_fmt_test.go
@@ -63,7 +63,7 @@ func TestFmtCol(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Expected, func(t *testing.T) {
-			actual := FmtCol(test.Indent, test.NameWidth, test.TypeWidth, test.Col)
+			actual := FmtColWithTag(test.Indent, test.NameWidth, test.TypeWidth, test.Col)
 			assert.Equal(t, test.Expected, actual)
 		})
 	}

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter.go
@@ -83,7 +83,7 @@ func (w *SqlExportWriter) maybeWriteDropCreate() error {
 		var b strings.Builder
 		b.WriteString(sqlfmt.DropTableIfExistsStmt(w.tableName))
 		b.WriteRune('\n')
-		b.WriteString(sqlfmt.SchemaAsCreateStmt(w.tableName, w.sch))
+		b.WriteString(sqlfmt.CreateTableStmtWithTags(w.tableName, w.sch))
 		if err := iohelp.WriteLine(w.wr, b.String()); err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
+++ b/go/libraries/doltcore/table/untyped/sqlexport/sqlwriter_test.go
@@ -47,7 +47,7 @@ func TestEndToEnd(t *testing.T) {
 	id := uuid.MustParse("00000000-0000-0000-0000-000000000000")
 	tableName := "people"
 
-	dropCreateStatement := sqlfmt.DropTableIfExistsStmt(tableName) + "\n" + sqlfmt.SchemaAsCreateStmt(tableName, dtestutils.TypedSchema)
+	dropCreateStatement := sqlfmt.DropTableIfExistsStmt(tableName) + "\n" + sqlfmt.CreateTableStmtWithTags(tableName, dtestutils.TypedSchema)
 
 	type test struct {
 		name           string


### PR DESCRIPTION
I only changed `dolt schema export`. Other commands like `dolt show tables` or `dolt diff --sql` still output tags. This is easy to change on case by case basis.