### PR TITLE
/.github/workflows/ci-check-repo.yaml: Iterating on github actions check repo

### DIFF
--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -1,0 +1,33 @@
+name: Check Dolt Repo
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    name: Check Dolt Repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go 1.13
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+        id: go
+      - uses: actions/checkout@v2
+      - name: Check Repo
+        working-directory: ./go
+        # Keep this in sync with //go/utils/prepr/prepr.sh.
+        run: |
+          echo "The branch name is : $BRANCH_NAME"
+          echo "The target name is : $CHANGE_TARGET"
+          go get -mod=readonly ./...
+          ./utils/repofmt/check_fmt.sh
+          ./Godeps/verify.sh
+          ./utils/checkcommitters/check_pr.sh
+          go vet -mod=readonly ./...
+          go run -mod=readonly ./utils/copyrightshdrs/
+          go test -mod=readonly -test.v ./...
+        env:
+          BRANCH_NAME: ${{ format('{0}', github.head_ref) }}
+          CHANGE_TARGET: ${{ format('{0}', github.base_ref) }}

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -21,7 +21,6 @@ jobs:
         working-directory: ./go
         # Keep this in sync with //go/utils/prepr/prepr.sh.
         run: |
-          go get -mod=readonly ./...
           ./utils/repofmt/check_fmt.sh
           ./Godeps/verify.sh
           ./utils/checkcommitters/check_pr.sh

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -1,12 +1,12 @@
-name: Check Dolt Repo
+name: Check Formatting and Commiters
 
 on:
   pull_request:
     branches: [ master ]
 
 jobs:
-  test:
-    name: Check Dolt Repo
+  verify:
+    name: Verify format and commiters
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go 1.13
@@ -17,11 +17,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Check Repo
+      - name: Check all
         working-directory: ./go
         # Keep this in sync with //go/utils/prepr/prepr.sh.
         run: |
-          git log -n 2
           go get -mod=readonly ./...
           ./utils/repofmt/check_fmt.sh
           ./Godeps/verify.sh
@@ -30,5 +29,5 @@ jobs:
           go run -mod=readonly ./utils/copyrightshdrs/
           go test -mod=readonly -test.v ./...
         env:
-          BRANCH_NAME: ${{ format('{0}', github.head_ref) }}
-          CHANGE_TARGET: ${{ format('{0}', github.base_ref) }}
+          BRANCH_NAME: ${{ github.head_ref }}
+          CHANGE_TARGET: ${{ github.base_ref }}

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -9,10 +9,10 @@ jobs:
     name: Verify format and commiters
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go 1.13
+      - name: Setup Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: ^1.13
         id: go
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -15,12 +15,13 @@ jobs:
           go-version: 1.13
         id: go
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Check Repo
         working-directory: ./go
         # Keep this in sync with //go/utils/prepr/prepr.sh.
         run: |
-          echo "The branch name is : $BRANCH_NAME"
-          echo "The target name is : $CHANGE_TARGET"
+          git log -n 2
           go get -mod=readonly ./...
           ./utils/repofmt/check_fmt.sh
           ./Godeps/verify.sh

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -21,6 +21,7 @@ jobs:
         working-directory: ./go
         # Keep this in sync with //go/utils/prepr/prepr.sh.
         run: |
+          GOFLAGS="-mod=readonly" go build ./...
           ./utils/repofmt/check_fmt.sh
           ./Godeps/verify.sh
           ./utils/checkcommitters/check_pr.sh

--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -27,7 +27,6 @@ jobs:
           ./utils/checkcommitters/check_pr.sh
           go vet -mod=readonly ./...
           go run -mod=readonly ./utils/copyrightshdrs/
-          go test -mod=readonly -test.v ./...
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           CHANGE_TARGET: ${{ github.base_ref }}

--- a/go/utils/checkcommitters/main.go
+++ b/go/utils/checkcommitters/main.go
@@ -109,8 +109,6 @@ func PrintUsageAndExit() {
 }
 
 func Check(source, target string) bool {
-	fmt.Printf("source: %s \n", source)
-	fmt.Printf("terget: %s \n", target)
 	mbc := exec.Command("git", "merge-base", source, target)
 	mbco, err := mbc.CombinedOutput()
 	if err != nil {

--- a/go/utils/checkcommitters/main.go
+++ b/go/utils/checkcommitters/main.go
@@ -109,6 +109,8 @@ func PrintUsageAndExit() {
 }
 
 func Check(source, target string) bool {
+	fmt.Printf("source: %s \n", source)
+	fmt.Printf("terget: %s \n", target)
 	mbc := exec.Command("git", "merge-base", source, target)
 	mbco, err := mbc.CombinedOutput()
 	if err != nil {

--- a/go/utils/prepr/prepr.sh
+++ b/go/utils/prepr/prepr.sh
@@ -10,7 +10,7 @@ if [[ $# -eq 1 ]]; then
     target="$1"
 fi
 
-# Keep this in sync with Jenkinsfile contents that
+# Keep this in sync with .github/workflows/ci-check-repo.yaml contents that
 # are easy to evaluate locally and might commonly fail.
 
 go get -mod=readonly ./...

--- a/go/utils/prepr/prepr.sh
+++ b/go/utils/prepr/prepr.sh
@@ -13,7 +13,7 @@ fi
 # Keep this in sync with .github/workflows/ci-check-repo.yaml contents that
 # are easy to evaluate locally and might commonly fail.
 
-go get -mod=readonly ./...
+GOFLAGS="-mod=readonly" go build ./...
 ./utils/repofmt/check_fmt.sh
 ./Godeps/verify.sh
 go run ./utils/checkcommitters -dir "$target"


### PR DESCRIPTION
looking into fixing this: https://github.com/liquidata-inc/dolt/pull/767/checks?check_run_id=808971285#step:4:296
```
2020/06/25 21:04:02 Error running `git merge-base remotes/origin/db/ci-github-actions-check-repo remotes/origin/master` to find merge parent: exit status 128
exit status 1
```

the `exit status 128` is from `//go/utils/checkcommiters/main.go` ... im thinking could be the go version? i had to use `1.13` here to get past the error that occurred when i used go version `^1.13` regarding the `-mod=readonly` flag....