### PR TITLE
Merge Block

### DIFF
--- a/bats/back-compat.bats
+++ b/bats/back-compat.bats
@@ -122,6 +122,7 @@ teardown() {
 }
 
 @test "back-compat: resolving conflicts" {
+    skip https://github.com/liquidata-inc/dolt/issues/773
     for testdir in */; do
         cd "$testdir"
         run dolt migrate

--- a/bats/conflict-detection.bats
+++ b/bats/conflict-detection.bats
@@ -291,6 +291,7 @@ SQL
 }
 
 @test "two branches add different column. merge. no conflict" {
+    skip https://github.com/liquidata-inc/dolt/issues/773
     dolt sql <<SQL
 CREATE TABLE test (
   pk BIGINT NOT NULL,
@@ -384,6 +385,7 @@ SQL
 }
 
 @test "two branches delete different column. merge. no conflict" {
+    skip https://github.com/liquidata-inc/dolt/issues/773
     dolt sql <<SQL
 CREATE TABLE test (
   pk BIGINT NOT NULL COMMENT 'tag:0',

--- a/bats/index.bats
+++ b/bats/index.bats
@@ -2217,29 +2217,3 @@ SQL
     [ "$status" -eq "1" ]
     [[ "$output" =~ "UNIQUE" ]] || false
 }
-
-@test "index: Merge auto-resolve violates UNIQUE" {
-    dolt sql <<SQL
-CREATE UNIQUE INDEX idx_v1 ON onepk(v1);
-INSERT INTO onepk VALUES (1, 11, 101), (2, 22, 202), (3, 33, 303), (4, 44, 404);
-SQL
-    dolt add -A
-    dolt commit -m "baseline commit"
-    dolt checkout -b other
-    dolt checkout master
-    dolt sql -q "INSERT INTO onepk VALUES (5, 55, 505)"
-    dolt add -A
-    dolt commit -m "master changes"
-    dolt checkout other
-    dolt sql <<SQL
-DROP INDEX idx_v1 ON onepk;
-INSERT INTO onepk VALUES (5, 11, 505);
-SQL
-    dolt add -A
-    dolt commit -m "other changes"
-    dolt checkout master
-    dolt merge other
-    run dolt conflicts resolve --theirs onepk
-    [ "$status" -eq "1" ]
-    [[ "$output" =~ "UNIQUE" ]] || false
-}

--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -273,7 +273,8 @@ var RebaseTagTests = []RebaseTagTest{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 		},
 	},
-	{
+	// https://github.com/liquidata-inc/dolt/issues/773
+	/*{
 		Name: "create new column on master, insert to table on other branch, merge",
 		Commands: []tc.Command{
 			tc.Query{Query: createPeopleTable},
@@ -358,7 +359,7 @@ var RebaseTagTests = []RebaseTagTest{
 			newRow(row.TaggedValues{IdTag: types.Int(9), NameTag: types.String("Jacqueline Bouvier"), AgeTag: types.Int(80)}, people),
 			newRow(row.TaggedValues{IdTag: types.Int(11), NameTag: types.String("Selma Bouvier"), AgeTag: types.Int(40), DripTagRebased: types.Float(8.5)}, peopleWithDrip),
 		},
-	},
+	},*/
 	{
 		Name: "create new column, use on multiple branches, merge",
 		Commands: []tc.Command{

--- a/go/libraries/doltcore/envtestutils/super_schema_test.go
+++ b/go/libraries/doltcore/envtestutils/super_schema_test.go
@@ -232,7 +232,8 @@ var SuperSchemaTests = []SuperSchemaTest{
 			newColTypeInfo("c11", c11Tag, typeinfo.Int32Type, false),
 		)),
 	},
-	{
+	// https://github.com/liquidata-inc/dolt/issues/773
+	/*{
 		Name:      "super schema merge",
 		TableName: "testable",
 		Commands: []tc.Command{
@@ -296,7 +297,7 @@ var SuperSchemaTests = []SuperSchemaTest{
 			newColTypeInfo("c11", c11Tag, typeinfo.Int32Type, false),
 			newColTypeInfo("c12", c12Tag, typeinfo.Int32Type, false),
 		)),
-	},
+	},*/
 	{
 		Name:      "super schema with table add/drops",
 		TableName: "testable",


### PR DESCRIPTION
As discussed (and in relation to https://github.com/liquidata-inc/dolt/issues/773), we will fail on all merges where the schemas are not the same. As a result, one index bats test no longer makes sense, and all other tests that rely on the behavior have been skipped/commented out.