### PR TITLE
go/cmd/dolt: Change commit spec handling so that abbreviated forms of remotes are supported.

### DIFF
--- a/bats/merge.bats
+++ b/bats/merge.bats
@@ -56,6 +56,26 @@ teardown() {
     [[ "$output" =~ "test1" ]] || false
 }
 
+@test "can merge commit spec with ancestor spec" {
+    dolt checkout -b merge_branch
+    dolt SQL -q "INSERT INTO test1 values (0,1,2)"
+    dolt add test1
+    dolt commit -m "add pk 0 to test1"
+
+    dolt SQL -q "INSERT INTO test1 values (1,2,3)"
+    dolt add test1
+    dolt commit -m "add pk 1 to test1"
+
+    dolt checkout master
+
+    run dolt merge merge_branch~
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "Fast-forward" ]] || false
+    run dolt sql -q 'select count(*) from test1 where pk = 1'
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ "| 0 " ]] || false
+}
+
 @test "ff merge doesn't stomp working changes" {
     dolt checkout -b merge_branch
     dolt SQL -q "INSERT INTO test1 values (0,1,2)"

--- a/bats/remotes.bats
+++ b/bats/remotes.bats
@@ -781,7 +781,6 @@ setup_ref_test() {
 }
 
 @test "can use refs/remotes/origin/... as commit reference for merge" {
-    skip "this currently panics"
     setup_ref_test
     dolt merge refs/remotes/origin/master
 }

--- a/bats/remotes.bats
+++ b/bats/remotes.bats
@@ -787,13 +787,11 @@ setup_ref_test() {
 }
 
 @test "can use remotes/origin/... as commit reference for log" {
-    skip "this does not work"
     setup_ref_test
     dolt log remotes/origin/master
 }
 
 @test "can use remotes/origin/... as commit reference for diff" {
-    skip "this does not work"
     setup_ref_test
     dolt diff HEAD remotes/origin/master
     dolt diff remotes/origin/master HEAD
@@ -805,13 +803,11 @@ setup_ref_test() {
 }
 
 @test "can use origin/... as commit reference for log" {
-    skip "this does not work"
     setup_ref_test
     dolt log origin/master
 }
 
 @test "can use origin/... as commit reference for diff" {
-    skip "this does not work"
     setup_ref_test
     dolt diff HEAD origin/master
     dolt diff origin/master HEAD

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -157,7 +157,7 @@ func parseCommitSpecAndTableName(dEnv *env.DoltEnv, apr *argparser.ArgParseResul
 		return dEnv.RepoState.CWBHeadSpec(), tableName, nil
 	}
 
-	cs, err := doltdb.NewCommitSpec(comSpecStr, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(comSpecStr)
 	if err != nil {
 		return nil, "", fmt.Errorf("invalid commit %s", comSpecStr)
 	}

--- a/go/cmd/dolt/commands/blame.go
+++ b/go/cmd/dolt/commands/blame.go
@@ -166,7 +166,7 @@ func parseCommitSpecAndTableName(dEnv *env.DoltEnv, apr *argparser.ArgParseResul
 }
 
 func runBlame(ctx context.Context, dEnv *env.DoltEnv, cs *doltdb.CommitSpec, tableName string) error {
-	commit, err := dEnv.DoltDB.Resolve(ctx, cs)
+	commit, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 	if err != nil {
 		return err
 	}

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -155,7 +155,7 @@ func printBranches(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 			continue
 		}
 
-		cs, _ := doltdb.NewCommitSpec(branch.String(), "")
+		cs, _ := doltdb.NewCommitSpec(branch.String())
 
 		shouldPrint := false
 		switch branch.GetType() {

--- a/go/cmd/dolt/commands/branch.go
+++ b/go/cmd/dolt/commands/branch.go
@@ -155,7 +155,7 @@ func printBranches(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 			continue
 		}
 
-		cs, _ := doltdb.NewCommitSpec("HEAD", branch.String())
+		cs, _ := doltdb.NewCommitSpec(branch.String(), "")
 
 		shouldPrint := false
 		switch branch.GetType() {
@@ -180,7 +180,7 @@ func printBranches(ctx context.Context, dEnv *env.DoltEnv, apr *argparser.ArgPar
 		}
 
 		if verbose {
-			cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+			cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 			if err == nil {
 				h, err := cm.HashOf()

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -323,7 +323,7 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 		performPull = false
 	}
 
-	cs, _ := doltdb.NewCommitSpec(branch, "")
+	cs, _ := doltdb.NewCommitSpec(branch)
 	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 
 	if err != nil {
@@ -341,7 +341,7 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	// create remote refs corresponding to each of them. We delete all of
 	// the local branches except for the one corresponding to |branch|.
 	for _, brnch := range branches {
-		cs, _ := doltdb.NewCommitSpec(brnch.GetPath(), "")
+		cs, _ := doltdb.NewCommitSpec(brnch.GetPath())
 		cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 		if err != nil {
 			return errhand.BuildDError("error: could not resolve branch ref at " + brnch.String()).AddCause(err).Build()

--- a/go/cmd/dolt/commands/clone.go
+++ b/go/cmd/dolt/commands/clone.go
@@ -323,8 +323,8 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 		performPull = false
 	}
 
-	cs, _ := doltdb.NewCommitSpec("HEAD", branch)
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cs, _ := doltdb.NewCommitSpec(branch, "")
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return errhand.BuildDError("error: could not get " + branch).AddCause(err).Build()
@@ -341,8 +341,8 @@ func cloneRemote(ctx context.Context, srcDB *doltdb.DoltDB, remoteName, branch s
 	// create remote refs corresponding to each of them. We delete all of
 	// the local branches except for the one corresponding to |branch|.
 	for _, brnch := range branches {
-		cs, _ := doltdb.NewCommitSpec("HEAD", brnch.GetPath())
-		cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+		cs, _ := doltdb.NewCommitSpec(brnch.GetPath(), "")
+		cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 		if err != nil {
 			return errhand.BuildDError("error: could not resolve branch ref at " + brnch.String()).AddCause(err).Build()
 		}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -331,7 +331,7 @@ func maybeResolve(ctx context.Context, dEnv *env.DoltEnv, spec string) (*doltdb.
 		return nil, false
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 	if err != nil {
 		return nil, false
 	}

--- a/go/cmd/dolt/commands/diff.go
+++ b/go/cmd/dolt/commands/diff.go
@@ -326,7 +326,7 @@ func getDiffRoots(ctx context.Context, dEnv *env.DoltEnv, args []string) (from, 
 
 // todo: distinguish between non-existent CommitSpec and other errors, don't assume non-existent
 func maybeResolve(ctx context.Context, dEnv *env.DoltEnv, spec string) (*doltdb.RootValue, bool) {
-	cs, err := doltdb.NewCommitSpec(spec, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(spec)
 	if err != nil {
 		return nil, false
 	}

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -236,8 +236,8 @@ func fetchRemoteBranch(ctx context.Context, dEnv *env.DoltEnv, rem env.Remote, s
 		}
 	}
 
-	cs, _ := doltdb.NewCommitSpec("HEAD", srcRef.String())
-	srcDBCommit, err := srcDB.Resolve(ctx, cs)
+	cs, _ := doltdb.NewCommitSpec(srcRef.String(), "")
+	srcDBCommit, err := srcDB.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return nil, errhand.BuildDError("error: unable to find '%s' on '%s'", srcRef.GetPath(), rem.Name).Build()

--- a/go/cmd/dolt/commands/fetch.go
+++ b/go/cmd/dolt/commands/fetch.go
@@ -236,7 +236,7 @@ func fetchRemoteBranch(ctx context.Context, dEnv *env.DoltEnv, rem env.Remote, s
 		}
 	}
 
-	cs, _ := doltdb.NewCommitSpec(srcRef.String(), "")
+	cs, _ := doltdb.NewCommitSpec(srcRef.String())
 	srcDBCommit, err := srcDB.Resolve(ctx, cs, nil)
 
 	if err != nil {

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -141,7 +141,7 @@ func parseCommitSpec(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (*doltdb
 	}
 
 	comSpecStr := apr.Arg(0)
-	cs, err := doltdb.NewCommitSpec(comSpecStr, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(comSpecStr)
 
 	if err != nil {
 		return nil, fmt.Errorf("invalid commit %s\n", comSpecStr)

--- a/go/cmd/dolt/commands/log.go
+++ b/go/cmd/dolt/commands/log.go
@@ -151,7 +151,7 @@ func parseCommitSpec(dEnv *env.DoltEnv, apr *argparser.ArgParseResults) (*doltdb
 }
 
 func logCommits(ctx context.Context, dEnv *env.DoltEnv, cs *doltdb.CommitSpec, loggerFunc commitLoggerFunc, numLines int) int {
-	commit, err := dEnv.DoltDB.Resolve(ctx, cs)
+	commit, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		cli.PrintErrln(color.HiRedString("Fatal error: cannot get HEAD commit for current branch."))

--- a/go/cmd/dolt/commands/log_test.go
+++ b/go/cmd/dolt/commands/log_test.go
@@ -31,7 +31,7 @@ func TestLog(t *testing.T) {
 		t.Error("Failed to init repo")
 	}
 
-	cs, _ := doltdb.NewCommitSpec("master", "")
+	cs, _ := doltdb.NewCommitSpec("master")
 	commit, _ := dEnv.DoltDB.Resolve(context.Background(), cs, nil)
 
 	cli.Println(commit)

--- a/go/cmd/dolt/commands/log_test.go
+++ b/go/cmd/dolt/commands/log_test.go
@@ -31,8 +31,8 @@ func TestLog(t *testing.T) {
 		t.Error("Failed to init repo")
 	}
 
-	cs, _ := doltdb.NewCommitSpec("HEAD", "master")
-	commit, _ := dEnv.DoltDB.Resolve(context.Background(), cs)
+	cs, _ := doltdb.NewCommitSpec("master", "")
+	commit, _ := dEnv.DoltDB.Resolve(context.Background(), cs, nil)
 
 	cli.Println(commit)
 }

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -116,7 +116,7 @@ func (cmd LsCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 }
 
 func getRootForCommitSpecStr(ctx context.Context, csStr string, dEnv *env.DoltEnv) (string, *doltdb.RootValue, errhand.VerboseError) {
-	cs, err := doltdb.NewCommitSpec(csStr, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(csStr)
 
 	if err != nil {
 		bdr := errhand.BuildDError(`"%s" is not a validly formatted branch, or commit reference.`, csStr)

--- a/go/cmd/dolt/commands/ls.go
+++ b/go/cmd/dolt/commands/ls.go
@@ -123,7 +123,7 @@ func getRootForCommitSpecStr(ctx context.Context, csStr string, dEnv *env.DoltEn
 		return "", nil, bdr.AddCause(err).Build()
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		return "", nil, errhand.BuildDError(`Unable to resolve "%s"`, csStr).AddCause(err).Build()

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -159,13 +159,13 @@ func abortMerge(ctx context.Context, doltEnv *env.DoltEnv) errhand.VerboseError 
 }
 
 func mergeBranch(ctx context.Context, dEnv *env.DoltEnv, dref ref.DoltRef) errhand.VerboseError {
-	cm1, verr := ResolveCommitWithVErr(dEnv, "HEAD", dEnv.RepoState.CWBHeadRef().String())
+	cm1, verr := ResolveCommitWithVErr(dEnv, "HEAD")
 
 	if verr != nil {
 		return verr
 	}
 
-	cm2, verr := ResolveCommitWithVErr(dEnv, dref.String(), dEnv.RepoState.CWBHeadRef().String())
+	cm2, verr := ResolveCommitWithVErr(dEnv, dref.String())
 
 	if verr != nil {
 		return verr

--- a/go/cmd/dolt/commands/merge.go
+++ b/go/cmd/dolt/commands/merge.go
@@ -29,7 +29,6 @@ import (
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/env/actions"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/merge"
-	"github.com/liquidata-inc/dolt/go/libraries/doltcore/ref"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/argparser"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/filesys"
 	"github.com/liquidata-inc/dolt/go/store/hash"
@@ -108,13 +107,7 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			return 1
 		}
 
-		branchName := apr.Arg(0)
-		dref, err := dEnv.FindRef(ctx, branchName)
-
-		if err != nil {
-			verr := errhand.BuildDError(fmt.Sprintf("unknown branch: %s", branchName)).Build()
-			return HandleVErrAndExitCode(verr, usage)
-		}
+		commitSpecStr := apr.Arg(0)
 
 		var root *doltdb.RootValue
 		root, verr = GetWorkingWithVErr(dEnv)
@@ -136,7 +129,7 @@ func (cmd MergeCmd) Exec(ctx context.Context, commandStr string, args []string, 
 			}
 
 			if verr == nil {
-				verr = mergeBranch(ctx, dEnv, dref)
+				verr = mergeCommitSpec(ctx, dEnv, commitSpecStr)
 			}
 		}
 	}
@@ -158,14 +151,14 @@ func abortMerge(ctx context.Context, doltEnv *env.DoltEnv) errhand.VerboseError 
 	return errhand.BuildDError("fatal: failed to revert changes").AddCause(err).Build()
 }
 
-func mergeBranch(ctx context.Context, dEnv *env.DoltEnv, dref ref.DoltRef) errhand.VerboseError {
+func mergeCommitSpec(ctx context.Context, dEnv *env.DoltEnv, commitSpecStr string) errhand.VerboseError {
 	cm1, verr := ResolveCommitWithVErr(dEnv, "HEAD")
 
 	if verr != nil {
 		return verr
 	}
 
-	cm2, verr := ResolveCommitWithVErr(dEnv, dref.String())
+	cm2, verr := ResolveCommitWithVErr(dEnv, commitSpecStr)
 
 	if verr != nil {
 		return verr
@@ -211,7 +204,7 @@ func mergeBranch(ctx context.Context, dEnv *env.DoltEnv, dref ref.DoltRef) errha
 		cli.Println("Already up to date.")
 		return nil
 	} else {
-		return executeMerge(ctx, dEnv, cm1, cm2, dref, workingDiffs)
+		return executeMerge(ctx, dEnv, cm1, cm2, workingDiffs)
 	}
 }
 
@@ -291,7 +284,7 @@ and take the hash for your current branch and use it for the value for "staged" 
 	return nil
 }
 
-func executeMerge(ctx context.Context, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commit, dref ref.DoltRef, workingDiffs map[string]hash.Hash) errhand.VerboseError {
+func executeMerge(ctx context.Context, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commit, workingDiffs map[string]hash.Hash) errhand.VerboseError {
 	mergedRoot, tblToStats, err := merge.MergeCommits(ctx, dEnv.DoltDB, cm1, cm2)
 
 	if err != nil {
@@ -320,7 +313,7 @@ func executeMerge(ctx context.Context, dEnv *env.DoltEnv, cm1, cm2 *doltdb.Commi
 		return errhand.BuildDError("error: failed to hash commit").AddCause(err).Build()
 	}
 
-	err = dEnv.RepoState.StartMerge(dref, h2.String(), dEnv.FS)
+	err = dEnv.RepoState.StartMerge(h2.String(), dEnv.FS)
 
 	if err != nil {
 		return errhand.BuildDError("Unable to update the repo state").AddCause(err).Build()

--- a/go/cmd/dolt/commands/pull.go
+++ b/go/cmd/dolt/commands/pull.go
@@ -125,5 +125,5 @@ func pullRemoteBranch(ctx context.Context, dEnv *env.DoltEnv, r env.Remote, srcR
 		return errhand.BuildDError("error: fetch failed").AddCause(err).Build()
 	}
 
-	return mergeBranch(ctx, dEnv, destRef)
+	return mergeCommitSpec(ctx, dEnv, destRef.String())
 }

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -277,7 +277,7 @@ func pushToRemoteBranch(ctx context.Context, dEnv *env.DoltEnv, mode ref.RefUpda
 		}
 	}
 
-	cs, _ := doltdb.NewCommitSpec(srcRef.GetPath(), "")
+	cs, _ := doltdb.NewCommitSpec(srcRef.GetPath())
 	cm, err := localDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {

--- a/go/cmd/dolt/commands/push.go
+++ b/go/cmd/dolt/commands/push.go
@@ -277,8 +277,8 @@ func pushToRemoteBranch(ctx context.Context, dEnv *env.DoltEnv, mode ref.RefUpda
 		}
 	}
 
-	cs, _ := doltdb.NewCommitSpec("HEAD", srcRef.GetPath())
-	cm, err := localDB.Resolve(ctx, cs)
+	cs, _ := doltdb.NewCommitSpec(srcRef.GetPath(), "")
+	cm, err := localDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		return errhand.BuildDError("error: refspec '%v' not found.", srcRef.GetPath()).Build()

--- a/go/cmd/dolt/commands/sql.go
+++ b/go/cmd/dolt/commands/sql.go
@@ -182,7 +182,7 @@ func (cmd SqlCmd) Exec(ctx context.Context, commandStr string, args []string, dE
 				return HandleVErrAndExitCode(errhand.BuildDError("Invalid commit %s", apr.Arg(0)).SetPrintUsage().Build(), usage)
 			}
 
-			cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+			cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 			if err != nil {
 				return HandleVErrAndExitCode(errhand.BuildDError("Invalid commit %s", apr.Arg(0)).SetPrintUsage().Build(), usage)

--- a/go/cmd/dolt/commands/tblcmds/cp.go
+++ b/go/cmd/dolt/commands/tblcmds/cp.go
@@ -130,7 +130,7 @@ func (cmd CpCmd) Exec(ctx context.Context, commandStr string, args []string, dEn
 	var oldTbl, newTbl string
 	if apr.NArg() == 3 {
 		var cm *doltdb.Commit
-		cm, verr = commands.ResolveCommitWithVErr(dEnv, apr.Arg(0), dEnv.RepoState.CWBHeadRef().String())
+		cm, verr = commands.ResolveCommitWithVErr(dEnv, apr.Arg(0))
 		if verr != nil {
 			return commands.HandleVErrAndExitCode(verr, usage)
 		}

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -103,7 +103,9 @@ func ResolveCommitWithVErr(dEnv *env.DoltEnv, cSpecStr string) (*doltdb.Commit, 
 
 	if err != nil {
 		if err == doltdb.ErrInvalidAncestorSpec {
-			return nil, errhand.BuildDError("'%s' is an invalid ancestor spec", cs.ASpec.SpecStr).Build()
+			return nil, errhand.BuildDError("'%s' could not resolve ancestor spec", cSpecStr).Build()
+		} else if err == doltdb.ErrBranchNotFound {
+			return nil, errhand.BuildDError("unknown branch in commit spec: '%s'", cSpecStr).Build()
 		} else if doltdb.IsNotFoundErr(err) {
 			return nil, errhand.BuildDError("'%s' not found", cSpecStr).Build()
 		} else if err == doltdb.ErrFoundHashNotACommit {

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -93,7 +93,7 @@ func ValidateTablesWithVErr(tbls []string, roots ...*doltdb.RootValue) errhand.V
 }
 
 func ResolveCommitWithVErr(dEnv *env.DoltEnv, cSpecStr string) (*doltdb.Commit, errhand.VerboseError) {
-	cs, err := doltdb.NewCommitSpec(cSpecStr, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(cSpecStr)
 
 	if err != nil {
 		return nil, errhand.BuildDError("'%s' is not a valid commit", cSpecStr).Build()

--- a/go/cmd/dolt/commands/utils.go
+++ b/go/cmd/dolt/commands/utils.go
@@ -92,14 +92,14 @@ func ValidateTablesWithVErr(tbls []string, roots ...*doltdb.RootValue) errhand.V
 	return nil
 }
 
-func ResolveCommitWithVErr(dEnv *env.DoltEnv, cSpecStr, cwb string) (*doltdb.Commit, errhand.VerboseError) {
-	cs, err := doltdb.NewCommitSpec(cSpecStr, cwb)
+func ResolveCommitWithVErr(dEnv *env.DoltEnv, cSpecStr string) (*doltdb.Commit, errhand.VerboseError) {
+	cs, err := doltdb.NewCommitSpec(cSpecStr, dEnv.RepoState.CWBHeadRef().String())
 
 	if err != nil {
 		return nil, errhand.BuildDError("'%s' is not a valid commit", cSpecStr).Build()
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(context.TODO(), cs)
+	cm, err := dEnv.DoltDB.Resolve(context.TODO(), cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		if err == doltdb.ErrInvalidAncestorSpec {

--- a/go/libraries/doltcore/doltdb/commit_itr.go
+++ b/go/libraries/doltcore/doltdb/commit_itr.go
@@ -53,13 +53,13 @@ func CommitItrForAllBranches(ctx context.Context, ddb *DoltDB) (CommitItr, error
 
 	rootCommits := make([]*Commit, 0, len(refs))
 	for _, ref := range refs {
-		cs, err := NewCommitSpec("HEAD", ref.String())
+		cs, err := NewCommitSpec(ref.String(), "")
 
 		if err != nil {
 			return nil, err
 		}
 
-		cm, err := ddb.Resolve(ctx, cs)
+		cm, err := ddb.Resolve(ctx, cs, nil)
 
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/doltdb/commit_itr.go
+++ b/go/libraries/doltcore/doltdb/commit_itr.go
@@ -53,7 +53,7 @@ func CommitItrForAllBranches(ctx context.Context, ddb *DoltDB) (CommitItr, error
 
 	rootCommits := make([]*Commit, 0, len(refs))
 	for _, ref := range refs {
-		cs, err := NewCommitSpec(ref.String(), "")
+		cs, err := NewCommitSpec(ref.String())
 
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/doltdb/commit_spec.go
+++ b/go/libraries/doltcore/doltdb/commit_spec.go
@@ -35,12 +35,12 @@ func IsValidBranchRef(dref ref.DoltRef) bool {
 	return dref.GetType() == ref.BranchRefType && IsValidUserBranchName(dref.GetPath())
 }
 
-type CommitSpecType string
+type commitSpecType string
 
 const (
-	RefCommitSpec  CommitSpecType = "ref"
-	HashCommitSpec CommitSpecType = "hash"
-	headCommitSpec CommitSpecType = "head"
+	refCommitSpec  commitSpecType = "ref"
+	hashCommitSpec commitSpecType = "hash"
+	headCommitSpec commitSpecType = "head"
 )
 
 // CommitSpec handles three different types of string representations of commits.  Commits can either be represented
@@ -48,9 +48,9 @@ const (
 // An Ancestor spec can be appended to the end of any of these in order to reach commits that are in the ancestor tree
 // of the referenced commit.
 type CommitSpec struct {
-	BaseRef string
-	CSType  CommitSpecType
-	ASpec   *AncestorSpec
+	baseSpec string
+	csType   commitSpecType
+	aSpec    *AncestorSpec
 }
 
 // NewCommitSpec parses a string specifying a commit using dolt commit spec
@@ -90,10 +90,10 @@ func NewCommitSpec(cSpecStr string) (*CommitSpec, error) {
 		return &CommitSpec{head, headCommitSpec, as}, nil
 	}
 	if hashRegex.MatchString(name) {
-		return &CommitSpec{name, HashCommitSpec, as}, nil
+		return &CommitSpec{name, hashCommitSpec, as}, nil
 	}
 	if !ref.IsValidBranchName(name) {
 		return nil, ErrInvalidBranchOrHash
 	}
-	return &CommitSpec{name, RefCommitSpec, as}, nil
+	return &CommitSpec{name, refCommitSpec, as}, nil
 }

--- a/go/libraries/doltcore/doltdb/commit_spec.go
+++ b/go/libraries/doltcore/doltdb/commit_spec.go
@@ -60,13 +60,35 @@ type CommitSpec struct {
 	ASpec          *AncestorSpec
 }
 
-// NewCommitSpec takes a spec string and the current working branch.  The current working branch is only relevant when
-// using "head" to reference a commit, but if it is not needed it will be ignored.
-func NewCommitSpec(cSpecStr, cwb string) (*CommitSpec, error) {
+// NewCommitSpec parses a string specifying a commit using dolt commit spec
+// syntax and returns a |*CommitSpec|. A commit spec has a base commit and an
+// optional ancestor specification. The syntax admits three types of base
+// commit references:
+// * head -- the literal string HEAD specifies the HEAD reference of the
+// current working set.
+// * a commit hash, like 46m0aqr8c1vuv76ml33cdtr8722hsbhn -- a fully specified
+// commit hash.
+// * a ref -- referring to a branch reference in the current dolt database.
+// Examples include `master`, `heads/master`, `refs/heads/master`,
+// `origin/master`, `refs/remotes/origin/master`.
+//
+// A commit spec has an optional ancestor specification, which describes a
+// traversal of commit parents, starting at the base commit, in order to arrive
+// at the actually specified commit. See |AncestorSpec|. Examples of
+// |CommitSpec|s:
+// * HEAD
+// * master
+// * HEAD~
+// * remotes/origin/master~~
+// * refs/heads/my-feature-branch^2~
+//
+// Constructing a |CommitSpec| does not mean the sepcified branch or commit
+// exists. This carries a description of how to find the specified commit. See
+// |doltdb.Resolve| for resolving a |CommitSpec| to a |Commit|.
+func NewCommitSpec(cSpecStr string) (*CommitSpec, error) {
 	cSpecStrLwr := strings.TrimSpace(cSpecStr)
 
 	name, as, err := SplitAncestorSpec(cSpecStrLwr)
-
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/doltdb/commit_spec.go
+++ b/go/libraries/doltcore/doltdb/commit_spec.go
@@ -47,6 +47,7 @@ type CommitSpecType string
 const (
 	RefCommitSpec  CommitSpecType = "ref"
 	HashCommitSpec CommitSpecType = "hash"
+	headCommitSpec CommitSpecType = "head"
 )
 
 // CommitSpec handles three different types of string representations of commits.  Commits can either be represented
@@ -71,7 +72,7 @@ func NewCommitSpec(cSpecStr, cwb string) (*CommitSpec, error) {
 	}
 
 	if strings.ToLower(name) == head {
-		name = cwb
+		return &CommitSpec{stringer(head), headCommitSpec, as}, nil
 	}
 
 	if hashRegex.MatchString(name) {

--- a/go/libraries/doltcore/doltdb/commit_spec_test.go
+++ b/go/libraries/doltcore/doltdb/commit_spec_test.go
@@ -39,22 +39,21 @@ func TestCommitRegex(t *testing.T) {
 func TestNewCommitSpec(t *testing.T) {
 	tests := []struct {
 		inputStr        string
-		cwbName         string
 		expectedRefStr  string
 		expecteASpecStr string
 		expectErr       bool
 	}{
-		{"master", "", "refs/heads/master", "", false},
-		{"refs/heads/master", "", "refs/heads/master", "", false},
-		{"head", "refs/heads/master", "head", "", false},
-		{"head", "refs/heads/master", "head", "", false},
-		{"head^~2", "master", "head", "^~2", false},
-		{"00000000000000000000000000000000", "", "00000000000000000000000000000000", "", false},
-		{"head", "", "head", "", true},
+		{"master", "refs/heads/master", "", false},
+		{"refs/heads/master", "refs/heads/master", "", false},
+		{"head", "head", "", false},
+		{"head", "head", "", false},
+		{"head^~2", "head", "^~2", false},
+		{"00000000000000000000000000000000", "00000000000000000000000000000000", "", false},
+		{"head", "head", "", true},
 	}
 
 	for _, test := range tests {
-		cs, err := NewCommitSpec(test.inputStr, test.cwbName)
+		cs, err := NewCommitSpec(test.inputStr)
 
 		if err != nil {
 			if !test.expectErr {

--- a/go/libraries/doltcore/doltdb/commit_spec_test.go
+++ b/go/libraries/doltcore/doltdb/commit_spec_test.go
@@ -59,10 +59,10 @@ func TestNewCommitSpec(t *testing.T) {
 			if !test.expectErr {
 				t.Error(test.inputStr, "Error didn't match expected.  Errored: ", err != nil)
 			}
-		} else if cs.BaseRef != test.expectedRefStr {
-			t.Error(test.inputStr, "expected name:", test.expectedRefStr, "actual name:", cs.BaseRef)
-		} else if cs.ASpec.SpecStr != test.expecteASpecStr {
-			t.Error(test.inputStr, "expected ancestor spec:", test.expecteASpecStr, "actual ancestor spec:", cs.ASpec.SpecStr)
+		} else if cs.baseSpec != test.expectedRefStr {
+			t.Error(test.inputStr, "expected name:", test.expectedRefStr, "actual name:", cs.baseSpec)
+		} else if cs.aSpec.SpecStr != test.expecteASpecStr {
+			t.Error(test.inputStr, "expected ancestor spec:", test.expecteASpecStr, "actual ancestor spec:", cs.aSpec.SpecStr)
 		}
 	}
 }

--- a/go/libraries/doltcore/doltdb/commit_spec_test.go
+++ b/go/libraries/doltcore/doltdb/commit_spec_test.go
@@ -43,7 +43,7 @@ func TestNewCommitSpec(t *testing.T) {
 		expecteASpecStr string
 		expectErr       bool
 	}{
-		{"master", "refs/heads/master", "", false},
+		{"master", "master", "", false},
 		{"refs/heads/master", "refs/heads/master", "", false},
 		{"head", "head", "", false},
 		{"head", "head", "", false},
@@ -59,8 +59,8 @@ func TestNewCommitSpec(t *testing.T) {
 			if !test.expectErr {
 				t.Error(test.inputStr, "Error didn't match expected.  Errored: ", err != nil)
 			}
-		} else if cs.CommitStringer.String() != test.expectedRefStr {
-			t.Error(test.inputStr, "expected name:", test.expectedRefStr, "actual name:", cs.CommitStringer.String())
+		} else if cs.BaseRef != test.expectedRefStr {
+			t.Error(test.inputStr, "expected name:", test.expectedRefStr, "actual name:", cs.BaseRef)
 		} else if cs.ASpec.SpecStr != test.expecteASpecStr {
 			t.Error(test.inputStr, "expected ancestor spec:", test.expecteASpecStr, "actual ancestor spec:", cs.ASpec.SpecStr)
 		}

--- a/go/libraries/doltcore/doltdb/commit_spec_test.go
+++ b/go/libraries/doltcore/doltdb/commit_spec_test.go
@@ -46,11 +46,11 @@ func TestNewCommitSpec(t *testing.T) {
 	}{
 		{"master", "", "refs/heads/master", "", false},
 		{"refs/heads/master", "", "refs/heads/master", "", false},
-		{"head", "refs/heads/master", "refs/heads/master", "", false},
-		{"head", "refs/heads/master", "refs/heads/master", "", false},
-		{"head^~2", "master", "refs/heads/master", "^~2", false},
+		{"head", "refs/heads/master", "head", "", false},
+		{"head", "refs/heads/master", "head", "", false},
+		{"head^~2", "master", "head", "^~2", false},
 		{"00000000000000000000000000000000", "", "00000000000000000000000000000000", "", false},
-		{"head", "", "", "", true},
+		{"head", "", "head", "", true},
 	}
 
 	for _, test := range tests {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -273,26 +273,26 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 
 	var commitSt types.Struct
 	var err error
-	switch cs.CSType {
-	case HashCommitSpec:
-		commitSt, err = getCommitStForHash(ctx, ddb.db, cs.BaseRef)
-	case RefCommitSpec:
+	switch cs.csType {
+	case hashCommitSpec:
+		commitSt, err = getCommitStForHash(ctx, ddb.db, cs.baseSpec)
+	case refCommitSpec:
 		// For a ref in a CommitSpec, we have the following behavior.
 		// If it starts with `refs/`, we look for an exact match before
 		// we try any suffix matches. After that, we try a match on the
 		// user supplied input, with the following three prefixes, in
 		// order: `refs/`, `refs/heads/`, `refs/remotes/`.
 		candidates := []string{
-			"refs/" + cs.BaseRef,
-			"refs/heads/" + cs.BaseRef,
-			"refs/remotes/" + cs.BaseRef,
+			"refs/" + cs.baseSpec,
+			"refs/heads/" + cs.baseSpec,
+			"refs/remotes/" + cs.baseSpec,
 		}
-		if strings.HasPrefix(cs.BaseRef, "refs/") {
+		if strings.HasPrefix(cs.baseSpec, "refs/") {
 			candidates = []string{
-				cs.BaseRef,
-				"refs/" + cs.BaseRef,
-				"refs/heads/" + cs.BaseRef,
-				"refs/remotes/" + cs.BaseRef,
+				cs.baseSpec,
+				"refs/" + cs.baseSpec,
+				"refs/heads/" + cs.baseSpec,
+				"refs/remotes/" + cs.baseSpec,
 			}
 		}
 		for _, candidate := range candidates {
@@ -307,14 +307,14 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 	case headCommitSpec:
 		commitSt, err = getCommitStForDatasetName(ctx, ddb.db, cwb.String())
 	default:
-		panic("unrecognized commit spec CSType: " + cs.CSType)
+		panic("unrecognized commit spec csType: " + cs.csType)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	commitSt, err = getAncestor(ctx, ddb.db, commitSt, cs.ASpec)
+	commitSt, err = getAncestor(ctx, ddb.db, commitSt, cs.aSpec)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -187,8 +187,8 @@ func (ddb *DoltDB) WriteEmptyRepoWithCommitTime(ctx context.Context, name, email
 	return err
 }
 
-func getCommitStForDatasetName(ctx context.Context, db datas.Database, datasetName string) (types.Struct, error) {
-	ds, err := db.GetDataset(ctx, datasetName)
+func getCommitStForRefStr(ctx context.Context, db datas.Database, ref string) (types.Struct, error) {
+	ds, err := db.GetDataset(ctx, ref)
 
 	if err != nil {
 		return types.EmptyStruct(db.Format()), err
@@ -265,7 +265,7 @@ func getAncestor(ctx context.Context, vrw types.ValueReadWriter, commitSt types.
 }
 
 // Resolve takes a CommitSpec and returns a Commit, or an error if the commit cannot be found.
-// If the CommitSpec is a HEAD, Resolve also needs the DoltRef of the current working branch.
+// If the CommitSpec is HEAD, Resolve also needs the DoltRef of the current working branch.
 func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef) (*Commit, error) {
 	if cs == nil {
 		panic("nil commit spec")
@@ -296,7 +296,7 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			}
 		}
 		for _, candidate := range candidates {
-			commitSt, err = getCommitStForDatasetName(ctx, ddb.db, candidate)
+			commitSt, err = getCommitStForRefStr(ctx, ddb.db, candidate)
 			if err == nil {
 				break
 			}
@@ -305,7 +305,7 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			}
 		}
 	case headCommitSpec:
-		commitSt, err = getCommitStForDatasetName(ctx, ddb.db, cwb.String())
+		commitSt, err = getCommitStForRefStr(ctx, ddb.db, cwb.String())
 	default:
 		panic("unrecognized commit spec csType: " + cs.csType)
 	}

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -288,7 +288,7 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 			"refs/remotes/" + cs.BaseRef,
 		}
 		if strings.HasPrefix(cs.BaseRef, "refs/") {
-			candidates = []string {
+			candidates = []string{
 				cs.BaseRef,
 				"refs/" + cs.BaseRef,
 				"refs/heads/" + cs.BaseRef,

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -277,6 +277,10 @@ func (ddb *DoltDB) Resolve(ctx context.Context, cs *CommitSpec, cwb ref.DoltRef)
 		commitSt, err = getCommitStForHash(ctx, ddb.db, cs.CommitStringer.String())
 	} else if cs.CSType == RefCommitSpec {
 		commitSt, err = getCommitStForRef(ctx, ddb.db, cs.CommitStringer.(ref.DoltRef))
+	} else if cs.CSType == headCommitSpec {
+		commitSt, err = getCommitStForRef(ctx, ddb.db, cwb)
+	} else {
+		panic("unrecognized commit spec CSType: " + cs.CSType)
 	}
 
 	if err != nil {

--- a/go/libraries/doltcore/doltdb/doltdb.go
+++ b/go/libraries/doltcore/doltdb/doltdb.go
@@ -367,7 +367,7 @@ func (ddb *DoltDB) FastForward(ctx context.Context, branch ref.DoltRef, commit *
 
 // CanFastForward returns whether the given branch can be fast-forwarded to the commit given.
 func (ddb *DoltDB) CanFastForward(ctx context.Context, branch ref.DoltRef, new *Commit) (bool, error) {
-	currentSpec, _ := NewCommitSpec(branch.String(), "")
+	currentSpec, _ := NewCommitSpec(branch.String())
 	current, err := ddb.Resolve(ctx, currentSpec, nil)
 
 	if err != nil {

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -73,7 +73,7 @@ func TestEmptyInMemoryRepoCreation(t *testing.T) {
 		t.Fatal("Unexpected error creating empty repo", err)
 	}
 
-	cs, _ := NewCommitSpec("master", "")
+	cs, _ := NewCommitSpec("master")
 	commit, err := ddb.Resolve(context.Background(), cs, nil)
 
 	if err != nil {
@@ -82,7 +82,7 @@ func TestEmptyInMemoryRepoCreation(t *testing.T) {
 
 	h, err := commit.HashOf()
 	assert.NoError(t, err)
-	cs2, _ := NewCommitSpec(h.String(), "")
+	cs2, _ := NewCommitSpec(h.String())
 	_, err = ddb.Resolve(context.Background(), cs2, nil)
 
 	if err != nil {
@@ -148,7 +148,7 @@ func TestLDNoms(t *testing.T) {
 	var tbl *Table
 	{
 		ddb, _ := LoadDoltDB(context.Background(), types.Format_7_18, LocalDirDoltDB)
-		cs, _ := NewCommitSpec("master", "")
+		cs, _ := NewCommitSpec("master")
 		commit, err := ddb.Resolve(context.Background(), cs, nil)
 
 		if err != nil {

--- a/go/libraries/doltcore/doltdb/doltdb_test.go
+++ b/go/libraries/doltcore/doltdb/doltdb_test.go
@@ -73,8 +73,8 @@ func TestEmptyInMemoryRepoCreation(t *testing.T) {
 		t.Fatal("Unexpected error creating empty repo", err)
 	}
 
-	cs, _ := NewCommitSpec("HEAD", "master")
-	commit, err := ddb.Resolve(context.Background(), cs)
+	cs, _ := NewCommitSpec("master", "")
+	commit, err := ddb.Resolve(context.Background(), cs, nil)
 
 	if err != nil {
 		t.Fatal("Could not find commit")
@@ -83,7 +83,7 @@ func TestEmptyInMemoryRepoCreation(t *testing.T) {
 	h, err := commit.HashOf()
 	assert.NoError(t, err)
 	cs2, _ := NewCommitSpec(h.String(), "")
-	_, err = ddb.Resolve(context.Background(), cs2)
+	_, err = ddb.Resolve(context.Background(), cs2, nil)
 
 	if err != nil {
 		t.Fatal("Failed to get commit by hash")
@@ -149,7 +149,7 @@ func TestLDNoms(t *testing.T) {
 	{
 		ddb, _ := LoadDoltDB(context.Background(), types.Format_7_18, LocalDirDoltDB)
 		cs, _ := NewCommitSpec("master", "")
-		commit, err := ddb.Resolve(context.Background(), cs)
+		commit, err := ddb.Resolve(context.Background(), cs, nil)
 
 		if err != nil {
 			t.Fatal("Couldn't find commit")

--- a/go/libraries/doltcore/doltdb/root_val_test.go
+++ b/go/libraries/doltcore/doltdb/root_val_test.go
@@ -30,7 +30,7 @@ func TestTableDiff(t *testing.T) {
 	ddb, _ := LoadDoltDB(ctx, types.Format_7_18, InMemDoltDB)
 	ddb.WriteEmptyRepo(ctx, "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := NewCommitSpec("master", "")
+	cs, _ := NewCommitSpec("master")
 	cm, _ := ddb.Resolve(ctx, cs, nil)
 
 	root, err := cm.GetRootValue()
@@ -113,7 +113,7 @@ func TestDocDiff(t *testing.T) {
 	ddb, _ := LoadDoltDB(ctx, types.Format_7_18, InMemDoltDB)
 	ddb.WriteEmptyRepo(ctx, "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := NewCommitSpec("master", "")
+	cs, _ := NewCommitSpec("master")
 	cm, _ := ddb.Resolve(ctx, cs, nil)
 
 	root, err := cm.GetRootValue()

--- a/go/libraries/doltcore/doltdb/root_val_test.go
+++ b/go/libraries/doltcore/doltdb/root_val_test.go
@@ -30,8 +30,8 @@ func TestTableDiff(t *testing.T) {
 	ddb, _ := LoadDoltDB(ctx, types.Format_7_18, InMemDoltDB)
 	ddb.WriteEmptyRepo(ctx, "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := NewCommitSpec("head", "master")
-	cm, _ := ddb.Resolve(ctx, cs)
+	cs, _ := NewCommitSpec("master", "")
+	cm, _ := ddb.Resolve(ctx, cs, nil)
 
 	root, err := cm.GetRootValue()
 	assert.NoError(t, err)
@@ -113,8 +113,8 @@ func TestDocDiff(t *testing.T) {
 	ddb, _ := LoadDoltDB(ctx, types.Format_7_18, InMemDoltDB)
 	ddb.WriteEmptyRepo(ctx, "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := NewCommitSpec("head", "master")
-	cm, _ := ddb.Resolve(ctx, cs)
+	cs, _ := NewCommitSpec("master", "")
+	cm, _ := ddb.Resolve(ctx, cs, nil)
 
 	root, err := cm.GetRootValue()
 	assert.NoError(t, err)

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -252,9 +252,9 @@ func (m Merge) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 }
 
 func resolveCommit(t *testing.T, cSpecStr string, dEnv *env.DoltEnv) *doltdb.Commit {
-	cs, err := doltdb.NewCommitSpec(cSpecStr, dEnv.RepoState.Head.Ref.String())
+	cs, err := doltdb.NewCommitSpec(cSpecStr, dEnv.RepoState.CWBHeadRef().String())
 	require.NoError(t, err)
-	cm, err := dEnv.DoltDB.Resolve(context.TODO(), cs)
+	cm, err := dEnv.DoltDB.Resolve(context.TODO(), cs, dEnv.RepoState.CWBHeadRef())
 	require.NoError(t, err)
 	return cm
 }

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -228,7 +228,7 @@ func (m Merge) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 		h2, err := cm2.HashOf()
 		require.NoError(t, err)
 
-		err = dEnv.RepoState.StartMerge(dref, h2.String(), dEnv.FS)
+		err = dEnv.RepoState.StartMerge(h2.String(), dEnv.FS)
 		if err != nil {
 			return err
 		}

--- a/go/libraries/doltcore/dtestutils/testcommands/command.go
+++ b/go/libraries/doltcore/dtestutils/testcommands/command.go
@@ -252,7 +252,7 @@ func (m Merge) Exec(t *testing.T, dEnv *env.DoltEnv) error {
 }
 
 func resolveCommit(t *testing.T, cSpecStr string, dEnv *env.DoltEnv) *doltdb.Commit {
-	cs, err := doltdb.NewCommitSpec(cSpecStr, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(cSpecStr)
 	require.NoError(t, err)
 	cm, err := dEnv.DoltDB.Resolve(context.TODO(), cs, dEnv.RepoState.CWBHeadRef())
 	require.NoError(t, err)

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -80,8 +80,8 @@ func CopyBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, oldBranch, newBranc
 		return doltdb.ErrInvBranchName
 	}
 
-	cs, _ := doltdb.NewCommitSpec("head", oldBranch)
-	cm, err := ddb.Resolve(ctx, cs)
+	cs, _ := doltdb.NewCommitSpec(oldBranch, "")
+	cm, err := ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return err
@@ -123,22 +123,22 @@ func DeleteBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, dref ref.DoltRef,
 	}
 
 	if !opts.Force && !opts.Remote {
-		ms, err := doltdb.NewCommitSpec("head", "master")
+		ms, err := doltdb.NewCommitSpec("master", "")
 		if err != nil {
 			return err
 		}
 
-		master, err := ddb.Resolve(ctx, ms)
+		master, err := ddb.Resolve(ctx, ms, nil)
 		if err != nil {
 			return err
 		}
 
-		cs, err := doltdb.NewCommitSpec("head", dref.String())
+		cs, err := doltdb.NewCommitSpec(dref.String(), "")
 		if err != nil {
 			return err
 		}
 
-		cm, err := ddb.Resolve(ctx, cs)
+		cm, err := ddb.Resolve(ctx, cs, nil)
 		if err != nil {
 			return err
 		}
@@ -178,7 +178,7 @@ func CreateBranch(ctx context.Context, dEnv *env.DoltEnv, newBranch, startingPoi
 		return err
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		return err
@@ -205,13 +205,13 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string) error
 		return err
 	}
 
-	cs, err := doltdb.NewCommitSpec("head", brName)
+	cs, err := doltdb.NewCommitSpec(brName, "")
 
 	if err != nil {
 		return RootValueUnreadable{HeadRoot, err}
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return RootValueUnreadable{HeadRoot, err}
@@ -401,7 +401,7 @@ func MaybeGetCommit(ctx context.Context, dEnv *env.DoltEnv, str string) (*doltdb
 	cs, err := doltdb.NewCommitSpec(str, dEnv.RepoState.CWBHeadRef().String())
 
 	if err == nil {
-		cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+		cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())
 
 		switch err {
 		case nil:

--- a/go/libraries/doltcore/env/actions/branch.go
+++ b/go/libraries/doltcore/env/actions/branch.go
@@ -80,7 +80,7 @@ func CopyBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, oldBranch, newBranc
 		return doltdb.ErrInvBranchName
 	}
 
-	cs, _ := doltdb.NewCommitSpec(oldBranch, "")
+	cs, _ := doltdb.NewCommitSpec(oldBranch)
 	cm, err := ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
@@ -123,7 +123,7 @@ func DeleteBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, dref ref.DoltRef,
 	}
 
 	if !opts.Force && !opts.Remote {
-		ms, err := doltdb.NewCommitSpec("master", "")
+		ms, err := doltdb.NewCommitSpec("master")
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func DeleteBranchOnDB(ctx context.Context, ddb *doltdb.DoltDB, dref ref.DoltRef,
 			return err
 		}
 
-		cs, err := doltdb.NewCommitSpec(dref.String(), "")
+		cs, err := doltdb.NewCommitSpec(dref.String())
 		if err != nil {
 			return err
 		}
@@ -172,7 +172,7 @@ func CreateBranch(ctx context.Context, dEnv *env.DoltEnv, newBranch, startingPoi
 		return doltdb.ErrInvBranchName
 	}
 
-	cs, err := doltdb.NewCommitSpec(startingPoint, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(startingPoint)
 
 	if err != nil {
 		return err
@@ -205,7 +205,7 @@ func CheckoutBranch(ctx context.Context, dEnv *env.DoltEnv, brName string) error
 		return err
 	}
 
-	cs, err := doltdb.NewCommitSpec(brName, "")
+	cs, err := doltdb.NewCommitSpec(brName)
 
 	if err != nil {
 		return RootValueUnreadable{HeadRoot, err}
@@ -398,7 +398,7 @@ func IsBranch(ctx context.Context, dEnv *env.DoltEnv, str string) (bool, error) 
 }
 
 func MaybeGetCommit(ctx context.Context, dEnv *env.DoltEnv, str string) (*doltdb.Commit, error) {
-	cs, err := doltdb.NewCommitSpec(str, dEnv.RepoState.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(str)
 
 	if err == nil {
 		cm, err := dEnv.DoltDB.Resolve(ctx, cs, dEnv.RepoState.CWBHeadRef())

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -88,7 +88,7 @@ func CommitStaged(ctx context.Context, dEnv *env.DoltEnv, props CommitStagedProp
 
 	var mergeCmSpec []*doltdb.CommitSpec
 	if dEnv.IsMergeActive() {
-		spec, err := doltdb.NewCommitSpec(dEnv.RepoState.Merge.Commit, dEnv.RepoState.Merge.Head.Ref.String())
+		spec, err := doltdb.NewCommitSpec(dEnv.RepoState.Merge.Commit)
 
 		if err != nil {
 			panic("Corrupted repostate. Active merge state is not valid.")

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -105,7 +105,7 @@ func (q *q) SetInvisible(ctx context.Context, id hash.Hash) error {
 }
 
 func (q *q) load(ctx context.Context, h hash.Hash) (*doltdb.Commit, error) {
-	cs, err := doltdb.NewCommitSpec(h.String(), "")
+	cs, err := doltdb.NewCommitSpec(h.String())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk.go
@@ -109,7 +109,7 @@ func (q *q) load(ctx context.Context, h hash.Hash) (*doltdb.Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-	c, err := q.ddb.Resolve(ctx, cs)
+	c, err := q.ddb.Resolve(ctx, cs, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk_test.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk_test.go
@@ -50,9 +50,9 @@ func TestGetDotDotRevisions(t *testing.T) {
 	err := env.InitRepo(context.Background(), types.Format_LD_1, "Bill Billerson", "bill@billerson.com")
 	require.NoError(t, err)
 
-	cs, err := doltdb.NewCommitSpec("HEAD", "master")
+	cs, err := doltdb.NewCommitSpec("master", "")
 	require.NoError(t, err)
-	commit, err := env.DoltDB.Resolve(context.Background(), cs)
+	commit, err := env.DoltDB.Resolve(context.Background(), cs, nil)
 	require.NoError(t, err)
 
 	rv, err := commit.GetRootValue()

--- a/go/libraries/doltcore/env/actions/commitwalk/commitwalk_test.go
+++ b/go/libraries/doltcore/env/actions/commitwalk/commitwalk_test.go
@@ -50,7 +50,7 @@ func TestGetDotDotRevisions(t *testing.T) {
 	err := env.InitRepo(context.Background(), types.Format_LD_1, "Bill Billerson", "bill@billerson.com")
 	require.NoError(t, err)
 
-	cs, err := doltdb.NewCommitSpec("master", "")
+	cs, err := doltdb.NewCommitSpec("master")
 	require.NoError(t, err)
 	commit, err := env.DoltDB.Resolve(context.Background(), cs, nil)
 	require.NoError(t, err)
@@ -140,7 +140,7 @@ func mustCreateCommit(t *testing.T, ddb *doltdb.DoltDB, bn string, rvh hash.Hash
 	require.NoError(t, err)
 	pcs := make([]*doltdb.CommitSpec, 0, len(parents))
 	for _, parent := range parents {
-		cs, err := doltdb.NewCommitSpec(mustGetHash(t, parent).String(), bn)
+		cs, err := doltdb.NewCommitSpec(mustGetHash(t, parent).String())
 		require.NoError(t, err)
 		pcs = append(pcs, cs)
 	}

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -326,7 +326,7 @@ func (dEnv *DoltEnv) InitDBWithTime(ctx context.Context, nbf *types.NomsBinForma
 
 // initializeRepoState writes a default repo state to disk, consisting of a master branch and current root hash value.
 func (dEnv *DoltEnv) initializeRepoState(ctx context.Context) error {
-	cs, _ := doltdb.NewCommitSpec(doltdb.MasterBranch, "")
+	cs, _ := doltdb.NewCommitSpec(doltdb.MasterBranch)
 	commit, _ := dEnv.DoltDB.Resolve(ctx, cs, nil)
 
 	root, err := commit.GetRootValue()

--- a/go/libraries/doltcore/env/environment.go
+++ b/go/libraries/doltcore/env/environment.go
@@ -326,8 +326,8 @@ func (dEnv *DoltEnv) InitDBWithTime(ctx context.Context, nbf *types.NomsBinForma
 
 // initializeRepoState writes a default repo state to disk, consisting of a master branch and current root hash value.
 func (dEnv *DoltEnv) initializeRepoState(ctx context.Context) error {
-	cs, _ := doltdb.NewCommitSpec("HEAD", doltdb.MasterBranch)
-	commit, _ := dEnv.DoltDB.Resolve(ctx, cs)
+	cs, _ := doltdb.NewCommitSpec(doltdb.MasterBranch, "")
+	commit, _ := dEnv.DoltDB.Resolve(ctx, cs, nil)
 
 	root, err := commit.GetRootValue()
 	if err != nil {
@@ -382,7 +382,7 @@ func (dEnv *DoltEnv) RepoStateWriter() RepoStateWriter {
 }
 
 func (dEnv *DoltEnv) HeadRoot(ctx context.Context) (*doltdb.RootValue, error) {
-	commit, err := dEnv.DoltDB.Resolve(ctx, dEnv.RepoState.CWBHeadSpec())
+	commit, err := dEnv.DoltDB.Resolve(ctx, dEnv.RepoState.CWBHeadSpec(), dEnv.RepoState.CWBHeadRef())
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -44,8 +44,8 @@ type BranchConfig struct {
 }
 
 type MergeState struct {
-	Commit          string             `json:"commit"`
-	PreMergeWorking string             `json:"working_pre_merge"`
+	Commit          string `json:"commit"`
+	PreMergeWorking string `json:"working_pre_merge"`
 }
 
 type RepoState struct {

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -44,7 +44,6 @@ type BranchConfig struct {
 }
 
 type MergeState struct {
-	Head            ref.MarshalableRef `json:"head"`
 	Commit          string             `json:"commit"`
 	PreMergeWorking string             `json:"working_pre_merge"`
 }
@@ -144,8 +143,8 @@ func (rs *RepoState) CWBHeadSpec() *doltdb.CommitSpec {
 	return spec
 }
 
-func (rs *RepoState) StartMerge(dref ref.DoltRef, commit string, fs filesys.Filesys) error {
-	rs.Merge = &MergeState{ref.MarshalableRef{Ref: dref}, commit, rs.Working}
+func (rs *RepoState) StartMerge(commit string, fs filesys.Filesys) error {
+	rs.Merge = &MergeState{commit, rs.Working}
 	return rs.Save(fs)
 }
 

--- a/go/libraries/doltcore/env/repo_state.go
+++ b/go/libraries/doltcore/env/repo_state.go
@@ -140,8 +140,7 @@ func (rs *RepoState) CWBHeadRef() ref.DoltRef {
 }
 
 func (rs *RepoState) CWBHeadSpec() *doltdb.CommitSpec {
-	spec, _ := doltdb.NewCommitSpec("HEAD", rs.CWBHeadRef().String())
-
+	spec, _ := doltdb.NewCommitSpec("HEAD")
 	return spec
 }
 

--- a/go/libraries/doltcore/envtestutils/history.go
+++ b/go/libraries/doltcore/envtestutils/history.go
@@ -60,7 +60,7 @@ type HistoryNode struct {
 // InitializeWithHistory will go through the provided historyNodes and create the intended commit graph
 func InitializeWithHistory(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, historyNodes ...HistoryNode) {
 	for _, node := range historyNodes {
-		cs, err := doltdb.NewCommitSpec("master", "")
+		cs, err := doltdb.NewCommitSpec("master")
 		require.NoError(t, err)
 
 		cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
@@ -80,7 +80,7 @@ func processNode(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, node Hist
 		require.NoError(t, err)
 	}
 
-	cs, err := doltdb.NewCommitSpec(branchRef.String(), "")
+	cs, err := doltdb.NewCommitSpec(branchRef.String())
 	require.NoError(t, err)
 
 	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)

--- a/go/libraries/doltcore/envtestutils/history.go
+++ b/go/libraries/doltcore/envtestutils/history.go
@@ -60,10 +60,10 @@ type HistoryNode struct {
 // InitializeWithHistory will go through the provided historyNodes and create the intended commit graph
 func InitializeWithHistory(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, historyNodes ...HistoryNode) {
 	for _, node := range historyNodes {
-		cs, err := doltdb.NewCommitSpec("HEAD", "master")
+		cs, err := doltdb.NewCommitSpec("master", "")
 		require.NoError(t, err)
 
-		cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+		cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 		require.NoError(t, err)
 
 		processNode(t, ctx, dEnv, node, cm)
@@ -80,10 +80,10 @@ func processNode(t *testing.T, ctx context.Context, dEnv *env.DoltEnv, node Hist
 		require.NoError(t, err)
 	}
 
-	cs, err := doltdb.NewCommitSpec("HEAD", branchRef.String())
+	cs, err := doltdb.NewCommitSpec(branchRef.String(), "")
 	require.NoError(t, err)
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 	require.NoError(t, err)
 
 	root, err := cm.GetRootValue()

--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -442,8 +442,8 @@ func testRebaseTag(t *testing.T, test RebaseTagTest) {
 		require.NoError(t, err)
 		require.NotNil(t, rebasedCommit)
 
-		mcs, _ := doltdb.NewCommitSpec("HEAD", "master")
-		masterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs)
+		mcs, _ := doltdb.NewCommitSpec("master", "")
+		masterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs, nil)
 		rch, _ := rebasedCommit.HashOf()
 		mch, _ := masterCm.HashOf()
 		require.Equal(t, rch, mch)
@@ -475,10 +475,10 @@ func testRebaseTagHistory(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mcs, _ := doltdb.NewCommitSpec("HEAD", "master")
-	oldMasterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs)
-	ocs, _ := doltdb.NewCommitSpec("HEAD", "other")
-	otherCm, _ := dEnv.DoltDB.Resolve(context.Background(), ocs)
+	mcs, _ := doltdb.NewCommitSpec("master", "")
+	oldMasterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs, nil)
+	ocs, _ := doltdb.NewCommitSpec("other", "")
+	otherCm, _ := dEnv.DoltDB.Resolve(context.Background(), ocs, nil)
 
 	bs, _ := dEnv.DoltDB.GetBranches(context.Background()) // master
 	newMasterCm, err := rebase.TagRebaseForRef(context.Background(), bs[0], dEnv.DoltDB, rebase.TagMapping{"people": map[uint64]uint64{DripTag: DripTagRebased}})

--- a/go/libraries/doltcore/envtestutils/rebase_tag_test.go
+++ b/go/libraries/doltcore/envtestutils/rebase_tag_test.go
@@ -442,7 +442,7 @@ func testRebaseTag(t *testing.T, test RebaseTagTest) {
 		require.NoError(t, err)
 		require.NotNil(t, rebasedCommit)
 
-		mcs, _ := doltdb.NewCommitSpec("master", "")
+		mcs, _ := doltdb.NewCommitSpec("master")
 		masterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs, nil)
 		rch, _ := rebasedCommit.HashOf()
 		mch, _ := masterCm.HashOf()
@@ -475,9 +475,9 @@ func testRebaseTagHistory(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	mcs, _ := doltdb.NewCommitSpec("master", "")
+	mcs, _ := doltdb.NewCommitSpec("master")
 	oldMasterCm, _ := dEnv.DoltDB.Resolve(context.Background(), mcs, nil)
-	ocs, _ := doltdb.NewCommitSpec("other", "")
+	ocs, _ := doltdb.NewCommitSpec("other")
 	otherCm, _ := dEnv.DoltDB.Resolve(context.Background(), ocs, nil)
 
 	bs, _ := dEnv.DoltDB.GetBranches(context.Background()) // master

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -271,7 +271,7 @@ func setupMergeTest() (types.ValueReadWriter, *doltdb.Commit, *doltdb.Commit, ty
 		panic(err)
 	}
 
-	masterHeadSpec, _ := doltdb.NewCommitSpec("master", "")
+	masterHeadSpec, _ := doltdb.NewCommitSpec("master")
 	masterHead, err := ddb.Resolve(context.Background(), masterHeadSpec, nil)
 
 	if err != nil {

--- a/go/libraries/doltcore/merge/merge_test.go
+++ b/go/libraries/doltcore/merge/merge_test.go
@@ -271,8 +271,8 @@ func setupMergeTest() (types.ValueReadWriter, *doltdb.Commit, *doltdb.Commit, ty
 		panic(err)
 	}
 
-	masterHeadSpec, _ := doltdb.NewCommitSpec("head", "master")
-	masterHead, err := ddb.Resolve(context.Background(), masterHeadSpec)
+	masterHeadSpec, _ := doltdb.NewCommitSpec("master", "")
+	masterHead, err := ddb.Resolve(context.Background(), masterHeadSpec, nil)
 
 	if err != nil {
 		panic(err)

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -60,7 +60,7 @@ func createRootAndFS() (*doltdb.DoltDB, *doltdb.RootValue, filesys.Filesys) {
 	ddb, _ := doltdb.LoadDoltDB(context.Background(), types.Format_7_18, doltdb.InMemDoltDB)
 	ddb.WriteEmptyRepo(context.Background(), "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := doltdb.NewCommitSpec("master", "")
+	cs, _ := doltdb.NewCommitSpec("master")
 	commit, _ := ddb.Resolve(context.Background(), cs, nil)
 	root, err := commit.GetRootValue()
 

--- a/go/libraries/doltcore/mvdata/data_loc_test.go
+++ b/go/libraries/doltcore/mvdata/data_loc_test.go
@@ -60,8 +60,8 @@ func createRootAndFS() (*doltdb.DoltDB, *doltdb.RootValue, filesys.Filesys) {
 	ddb, _ := doltdb.LoadDoltDB(context.Background(), types.Format_7_18, doltdb.InMemDoltDB)
 	ddb.WriteEmptyRepo(context.Background(), "billy bob", "bigbillieb@fake.horse")
 
-	cs, _ := doltdb.NewCommitSpec("HEAD", "master")
-	commit, _ := ddb.Resolve(context.Background(), cs)
+	cs, _ := doltdb.NewCommitSpec("master", "")
+	commit, _ := ddb.Resolve(context.Background(), cs, nil)
 	root, err := commit.GetRootValue()
 
 	if err != nil {

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -48,13 +48,13 @@ func NeedsUniqueTagMigration(ctx context.Context, ddb *doltdb.DoltDB) (bool, err
 	}
 
 	for _, b := range bb {
-		cs, err := doltdb.NewCommitSpec("head", b.String())
+		cs, err := doltdb.NewCommitSpec(b.String(), "")
 
 		if err != nil {
 			return false, err
 		}
 
-		c, err := ddb.Resolve(ctx, cs)
+		c, err := ddb.Resolve(ctx, cs, nil)
 
 		if err != nil {
 			return false, err
@@ -92,6 +92,7 @@ func NeedsUniqueTagMigration(ctx context.Context, ddb *doltdb.DoltDB) (bool, err
 func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 	ddb := dEnv.DoltDB
 	cwbSpec := dEnv.RepoState.CWBHeadSpec()
+	cwbRef := dEnv.RepoState.CWBHeadRef()
 	dd, err := dEnv.GetAllValidDocDetails()
 
 	if err != nil {
@@ -107,13 +108,13 @@ func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 	var headCommits []*doltdb.Commit
 	for _, dRef := range branches {
 
-		cs, err := doltdb.NewCommitSpec("head", dRef.String())
+		cs, err := doltdb.NewCommitSpec(dRef.String(), "")
 
 		if err != nil {
 			return err
 		}
 
-		cm, err := ddb.Resolve(ctx, cs)
+		cm, err := ddb.Resolve(ctx, cs, nil)
 
 		if err != nil {
 			return err
@@ -183,7 +184,7 @@ func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 		}
 	}
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cwbSpec)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cwbSpec, cwbRef)
 
 	if err != nil {
 		return err
@@ -219,13 +220,13 @@ func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 
 // TagRebaseForRef rebases the provided DoltRef, swapping all tags in the TagMapping.
 func TagRebaseForRef(ctx context.Context, dRef ref.DoltRef, ddb *doltdb.DoltDB, tagMapping TagMapping) (*doltdb.Commit, error) {
-	cs, err := doltdb.NewCommitSpec("head", dRef.String())
+	cs, err := doltdb.NewCommitSpec(dRef.String(), "")
 
 	if err != nil {
 		return nil, err
 	}
 
-	cm, err := ddb.Resolve(ctx, cs)
+	cm, err := ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/rebase/rebase_tag.go
+++ b/go/libraries/doltcore/rebase/rebase_tag.go
@@ -48,7 +48,7 @@ func NeedsUniqueTagMigration(ctx context.Context, ddb *doltdb.DoltDB) (bool, err
 	}
 
 	for _, b := range bb {
-		cs, err := doltdb.NewCommitSpec(b.String(), "")
+		cs, err := doltdb.NewCommitSpec(b.String())
 
 		if err != nil {
 			return false, err
@@ -108,7 +108,7 @@ func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 	var headCommits []*doltdb.Commit
 	for _, dRef := range branches {
 
-		cs, err := doltdb.NewCommitSpec(dRef.String(), "")
+		cs, err := doltdb.NewCommitSpec(dRef.String())
 
 		if err != nil {
 			return err
@@ -220,7 +220,7 @@ func MigrateUniqueTags(ctx context.Context, dEnv *env.DoltEnv) error {
 
 // TagRebaseForRef rebases the provided DoltRef, swapping all tags in the TagMapping.
 func TagRebaseForRef(ctx context.Context, dRef ref.DoltRef, ddb *doltdb.DoltDB, tagMapping TagMapping) (*doltdb.Commit, error) {
-	cs, err := doltdb.NewCommitSpec(dRef.String(), "")
+	cs, err := doltdb.NewCommitSpec(dRef.String())
 
 	if err != nil {
 		return nil, err

--- a/go/libraries/doltcore/sqle/branches_table.go
+++ b/go/libraries/doltcore/sqle/branches_table.go
@@ -98,7 +98,7 @@ func NewBranchItr(sqlCtx *sql.Context, ddb *doltdb.DoltDB) (*BranchItr, error) {
 	branchNames := make([]string, len(branches))
 	commits := make([]*doltdb.Commit, len(branches))
 	for i, branch := range branches {
-		cs, err := doltdb.NewCommitSpec(branch.GetPath(), "")
+		cs, err := doltdb.NewCommitSpec(branch.GetPath())
 
 		if err != nil {
 			return nil, err
@@ -211,7 +211,7 @@ func (bWr branchWriter) Insert(ctx *sql.Context, r sql.Row) error {
 		return err
 	}
 
-	cs, err := doltdb.NewCommitSpec(commitHash, "")
+	cs, err := doltdb.NewCommitSpec(commitHash)
 
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/branches_table.go
+++ b/go/libraries/doltcore/sqle/branches_table.go
@@ -98,13 +98,13 @@ func NewBranchItr(sqlCtx *sql.Context, ddb *doltdb.DoltDB) (*BranchItr, error) {
 	branchNames := make([]string, len(branches))
 	commits := make([]*doltdb.Commit, len(branches))
 	for i, branch := range branches {
-		cs, err := doltdb.NewCommitSpec("HEAD", branch.GetPath())
+		cs, err := doltdb.NewCommitSpec(branch.GetPath(), "")
 
 		if err != nil {
 			return nil, err
 		}
 
-		commit, err := ddb.Resolve(sqlCtx, cs)
+		commit, err := ddb.Resolve(sqlCtx, cs, nil)
 
 		if err != nil {
 			return nil, err
@@ -218,7 +218,7 @@ func (bWr branchWriter) Insert(ctx *sql.Context, r sql.Row) error {
 	}
 
 	ddb := bWr.bt.ddb
-	cm, err := ddb.Resolve(ctx, cs)
+	cm, err := ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -275,7 +275,7 @@ func (db Database) rootAsOf(ctx *sql.Context, asOf interface{}) (*doltdb.RootVal
 }
 
 func (db Database) getRootForTime(ctx *sql.Context, asOf time.Time) (*doltdb.RootValue, error) {
-	cs, err := doltdb.NewCommitSpec("HEAD", db.rsr.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec("HEAD")
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +317,7 @@ func (db Database) getRootForTime(ctx *sql.Context, asOf time.Time) (*doltdb.Roo
 }
 
 func (db Database) getRootForCommitRef(ctx *sql.Context, commitRef string) (*doltdb.RootValue, error) {
-	cs, err := doltdb.NewCommitSpec(commitRef, db.rsr.CWBHeadRef().String())
+	cs, err := doltdb.NewCommitSpec(commitRef)
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/database.go
+++ b/go/libraries/doltcore/sqle/database.go
@@ -280,7 +280,7 @@ func (db Database) getRootForTime(ctx *sql.Context, asOf time.Time) (*doltdb.Roo
 		return nil, err
 	}
 
-	cm, err := db.ddb.Resolve(ctx, cs)
+	cm, err := db.ddb.Resolve(ctx, cs, db.rsr.CWBHeadRef())
 	if err != nil {
 		return nil, err
 	}
@@ -322,7 +322,7 @@ func (db Database) getRootForCommitRef(ctx *sql.Context, commitRef string) (*dol
 		return nil, err
 	}
 
-	cm, err := db.ddb.Resolve(ctx, cs)
+	cm, err := db.ddb.Resolve(ctx, cs, db.rsr.CWBHeadRef())
 	if err != nil {
 		return nil, err
 	}

--- a/go/libraries/doltcore/sqle/dfunctions/hashof.go
+++ b/go/libraries/doltcore/sqle/dfunctions/hashof.go
@@ -80,7 +80,7 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, err
 		}
 
-		cs, err := doltdb.NewCommitSpec(name, "")
+		cs, err := doltdb.NewCommitSpec(name)
 
 		if err != nil {
 			return nil, err

--- a/go/libraries/doltcore/sqle/dfunctions/hashof.go
+++ b/go/libraries/doltcore/sqle/dfunctions/hashof.go
@@ -80,13 +80,13 @@ func (t *HashOf) Eval(ctx *sql.Context, row sql.Row) (interface{}, error) {
 			return nil, err
 		}
 
-		cs, err := doltdb.NewCommitSpec("HEAD", name)
+		cs, err := doltdb.NewCommitSpec(name, "")
 
 		if err != nil {
 			return nil, err
 		}
 
-		cm, err = ddb.Resolve(ctx, cs)
+		cm, err = ddb.Resolve(ctx, cs, nil)
 	}
 
 	if err != nil {

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -140,13 +140,13 @@ func getBranchCommit(ctx *sql.Context, ok bool, val interface{}, err error, ddb 
 		return nil, hash.Hash{}, err
 	}
 
-	cs, err := doltdb.NewCommitSpec("HEAD", name)
+	cs, err := doltdb.NewCommitSpec(name, "")
 
 	if err != nil {
 		return nil, hash.Hash{}, err
 	}
 
-	cm, err := ddb.Resolve(ctx, cs)
+	cm, err := ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return nil, hash.Hash{}, err

--- a/go/libraries/doltcore/sqle/dfunctions/merge.go
+++ b/go/libraries/doltcore/sqle/dfunctions/merge.go
@@ -140,7 +140,7 @@ func getBranchCommit(ctx *sql.Context, ok bool, val interface{}, err error, ddb 
 		return nil, hash.Hash{}, err
 	}
 
-	cs, err := doltdb.NewCommitSpec(name, "")
+	cs, err := doltdb.NewCommitSpec(name)
 
 	if err != nil {
 		return nil, hash.Hash{}, err

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -148,7 +148,7 @@ func (sess *DoltSession) GetParentCommit(ctx context.Context, dbName string) (*d
 	}
 
 	h := hash.Parse(valStr)
-	cs, err := doltdb.NewCommitSpec(valStr, "")
+	cs, err := doltdb.NewCommitSpec(valStr)
 
 	if err != nil {
 		return nil, hash.Hash{}, err
@@ -177,7 +177,7 @@ func (sess *DoltSession) Set(ctx context.Context, key string, typ sql.Type, valu
 			return doltdb.ErrInvalidHash
 		}
 
-		cs, err := doltdb.NewCommitSpec(valStr, "")
+		cs, err := doltdb.NewCommitSpec(valStr)
 
 		if err != nil {
 			return err

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -154,7 +154,7 @@ func (sess *DoltSession) GetParentCommit(ctx context.Context, dbName string) (*d
 		return nil, hash.Hash{}, err
 	}
 
-	cm, err := dbd.ddb.Resolve(ctx, cs)
+	cm, err := dbd.ddb.Resolve(ctx, cs, nil)
 
 	if err != nil {
 		return nil, hash.Hash{}, err
@@ -183,7 +183,7 @@ func (sess *DoltSession) Set(ctx context.Context, key string, typ sql.Type, valu
 			return err
 		}
 
-		cm, err := dbd.ddb.Resolve(ctx, cs)
+		cm, err := dbd.ddb.Resolve(ctx, cs, nil)
 
 		if err != nil {
 			return err
@@ -258,7 +258,7 @@ func (sess *DoltSession) AddDB(ctx context.Context, db Database) error {
 
 	cs := rsr.CWBHeadSpec()
 
-	cm, err := ddb.Resolve(ctx, cs)
+	cm, err := ddb.Resolve(ctx, cs, rsr.CWBHeadRef())
 
 	if err != nil {
 		return err

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -1571,10 +1571,10 @@ func testSelectDiffQuery(t *testing.T, test SelectTest) {
 		test.AdditionalSetup(t, dEnv)
 	}
 
-	cs, err := doltdb.NewCommitSpec("HEAD", "master")
+	cs, err := doltdb.NewCommitSpec("master", "")
 	require.NoError(t, err)
 
-	cm, err := dEnv.DoltDB.Resolve(ctx, cs)
+	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)
 	require.NoError(t, err)
 
 	root, err := cm.GetRootValue()

--- a/go/libraries/doltcore/sqle/sqlselect_test.go
+++ b/go/libraries/doltcore/sqle/sqlselect_test.go
@@ -1571,7 +1571,7 @@ func testSelectDiffQuery(t *testing.T, test SelectTest) {
 		test.AdditionalSetup(t, dEnv)
 	}
 
-	cs, err := doltdb.NewCommitSpec("master", "")
+	cs, err := doltdb.NewCommitSpec("master")
 	require.NoError(t, err)
 
 	cm, err := dEnv.DoltDB.Resolve(ctx, cs, nil)


### PR DESCRIPTION
This changes `doltdb.CommitSpec` to carry the original input in the `refs` case, instead of trying to add a prefix or anything else. Instead, `doltdb.Resolve()` takes the current `HEAD` ref, and fully resolves the `CommitSpec` itself.

There was some confusion in usage across the code base with `NewCommitSpec`. In particular, there was a lot of `NewCommitSpec("HEAD", "some-branch-name-that-is-not-CWB")` in order to get `NewCommitSpec("some-branch-name-that-is-not-CWB", "")`. This collapsed all such uses to the same syntax. `"HEAD"` is only used for resolving the CWB now.

In places where the CommitSpec was statically known to not be `HEAD`, I've not bothered to always thread the `CWBRef` to the `Resolve` call.

This change will break `ld` Dolt usage, but I will follow up there when this lands in `master`.