### PR TITLE
Db/fix ci checkfmt

### DIFF
--- a/.github/workflows/ci-check-repo.yaml
+++ b/.github/workflows/ci-check-repo.yaml
@@ -22,11 +22,11 @@ jobs:
         # Keep this in sync with //go/utils/prepr/prepr.sh.
         run: |
           GOFLAGS="-mod=readonly" go build ./...
-          ./utils/repofmt/check_fmt.sh
-          ./Godeps/verify.sh
-          ./utils/checkcommitters/check_pr.sh
           go vet -mod=readonly ./...
           go run -mod=readonly ./utils/copyrightshdrs/
+          ./utils/repofmt/check_fmt.sh
+          ./utils/checkcommitters/check_pr.sh
+          ./Godeps/verify.sh
         env:
           BRANCH_NAME: ${{ github.head_ref }}
           CHANGE_TARGET: ${{ github.base_ref }}


### PR DESCRIPTION
Not really sure what's going on here... I reran you branch, which seems to consistently fail the `go/utils/repofmt/checkfmt.sh`... That script uses `goimports` (`go install golang.org/x/tools/cmd/goimports`) to check the import order of the file...  Not really sure why this works.

Alternative I could separate each script into its own `run` step in the workflow...