### PR TITLE
go/libraries/doltcore/env/actions: commit.go: Error when attempting to create a commit with unresolved conflicts still in the working set.

### DIFF
--- a/go/cmd/dolt/commands/commit.go
+++ b/go/cmd/dolt/commands/commit.go
@@ -181,6 +181,12 @@ func handleCommitErr(ctx context.Context, dEnv *env.DoltEnv, err error, usage cl
 		}
 	}
 
+	if actions.IsTblInConflict(err) {
+		inConflict := actions.GetTablesForError(err)
+		bdr := errhand.BuildDError(`tables %v have unresolved conflicts from the merge. resolve the conflicts before commiting`, inConflict)
+		return HandleVErrAndExitCode(bdr.Build(), usage)
+	}
+
 	verr := errhand.BuildDError("error: Failed to commit changes.").AddCause(err).Build()
 	return HandleVErrAndExitCode(verr, usage)
 }

--- a/go/libraries/doltcore/env/actions/commit.go
+++ b/go/libraries/doltcore/env/actions/commit.go
@@ -88,6 +88,18 @@ func CommitStaged(ctx context.Context, dEnv *env.DoltEnv, props CommitStagedProp
 
 	var mergeCmSpec []*doltdb.CommitSpec
 	if dEnv.IsMergeActive() {
+		root, err := dEnv.WorkingRoot(ctx)
+		if err != nil {
+			return err
+		}
+		inConflict, err := root.TablesInConflict(ctx)
+		if err != nil {
+			return err
+		}
+		if len(inConflict) > 0 {
+			return NewTblInConflictError(inConflict)
+		}
+
 		spec, err := doltdb.NewCommitSpec(dEnv.RepoState.Merge.Commit)
 
 		if err != nil {


### PR DESCRIPTION
I realized when working on a blog post that `dolt commit` will currently go ahead and create the merge commit even if there are unstaged conflicts in one of the merged tables. This is not the behavior we want.

Currently, we do not allow staging tables that have conflicts. This change makes it so `dolt commit` also fails if there are any conflicts in any of the tables in the working set.