### PR TITLE
Resolved memory leak

### DIFF
--- a/go/libraries/doltcore/doltdb/table_editor.go
+++ b/go/libraries/doltcore/doltdb/table_editor.go
@@ -421,6 +421,12 @@ func (te *TableEditor) flushEditAccumulator(ctx context.Context, teaInterface in
 
 	te.t = newTable
 	te.rowData = updatedMap
+	// not sure where it is, but setting these to nil fixes a memory leak
+	tea.addedKeys = nil
+	tea.affectedKeys = nil
+	tea.ed = nil
+	tea.insertedKeys = nil
+	tea.removedKeys = nil
 	return nil
 }
 


### PR DESCRIPTION
Fixes a memory leak that was observed during a large import. It appears that the primary key tuples were never deallocating, although I could not pinpoint what's holding on to the tuples. The `tableEditAccumulator` seems to be the only place, and it is discarded after it goes through `flushEditAccumulator`, so that doesn't seem to be it. However, setting its fields to `nil` fixes the leak, indicating that there is somewhere holding on to old `tableEditAccumulator`s. I also checked if `async.ActionExecutor` was the culprit, but manual debugging and testing showed that it wasn't holding on to any references once they went through the `work` method. This isn't a true fix, as there is still technically a leak for whatever is holding on to the `tableEditAccumulator`, but it's a leak of mere kilobytes per hour rather than megabytes per minute.

Here is an image from `pprof` from before.
![image](https://user-images.githubusercontent.com/5618869/88026967-7bb7f480-caeb-11ea-99d2-2bcdb10c1778.png)

Same query, but with the changes. Will not be equal to zero as the tuples (returned from here) are still stored in memory before being written to disk, so this is what we'd expect/desire.
![image](https://user-images.githubusercontent.com/5618869/88027055-9db17700-caeb-11ea-9758-f623662290c2.png)

Also verified each by watching memory usage in Task Manager (Windows 10).