### PR TITLE
Fixed memory leak when running sqllogictests

### DIFF
--- a/go/libraries/doltcore/doltdb/table_edit_session.go
+++ b/go/libraries/doltcore/doltdb/table_edit_session.go
@@ -52,6 +52,18 @@ func CreateTableEditSession(root *RootValue, props TableEditSessionProps) *Table
 	}
 }
 
+// Clear removes all table editors from the session. If a reference is held to an editor that has been cleared, then
+// any usage of that cleared editor will have undefined behavior (likely a panic). In normal usage, this should not need
+// to be called.
+func (tes *TableEditSession) Clear() {
+	tes.writeMutex.Lock()
+	defer tes.writeMutex.Unlock()
+	for name, table := range tes.tables {
+		_, _ = table.tableEditor.tea.ed.FinishedEditing()
+		delete(tes.tables, name)
+	}
+}
+
 // GetTableEditor returns a SessionedTableEditor for the given table. If a schema is provided and it does not match the one
 // that is used for currently open editors (if any), then those editors will reload the table from the root.
 func (tes *TableEditSession) GetTableEditor(ctx context.Context, tableName string, tableSch schema.Schema) (*SessionedTableEditor, error) {

--- a/go/libraries/doltcore/sqle/dolt_session.go
+++ b/go/libraries/doltcore/sqle/dolt_session.go
@@ -88,6 +88,14 @@ func DSessFromSess(sess sql.Session) *DoltSession {
 	return sess.(*DoltSession)
 }
 
+// Clears every table editor from each database.
+// TODO: find the exact location of the sqllogictest memory leak so that this may be removed
+func (sess *DoltSession) ClearEditors() {
+	for _, tes := range sess.dbEditors {
+		tes.Clear()
+	}
+}
+
 func (sess *DoltSession) CommitTransaction(ctx *sql.Context) error {
 	currentDb := sess.GetCurrentDatabase()
 	if currentDb == "" {

--- a/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
+++ b/go/libraries/doltcore/sqle/logictest/dolt/doltharness.go
@@ -61,6 +61,9 @@ func (h *DoltHarness) Init() error {
 }
 
 func (h *DoltHarness) ExecuteStatement(statement string) error {
+	if h.sess != nil {
+		h.sess.ClearEditors()
+	}
 	ctx := sql.NewContext(
 		context.Background(),
 		sql.WithPid(rand.Uint64()),
@@ -79,6 +82,9 @@ func (h *DoltHarness) ExecuteStatement(statement string) error {
 }
 
 func (h *DoltHarness) ExecuteQuery(statement string) (schema string, results []string, err error) {
+	if h.sess != nil {
+		h.sess.ClearEditors()
+	}
 	pid := rand.Uint32()
 	ctx := sql.NewContext(
 		context.Background(),
@@ -123,6 +129,9 @@ func innerInit(h *DoltHarness, dEnv *env.DoltEnv) error {
 		return err
 	}
 
+	if h.sess != nil {
+		h.sess.ClearEditors()
+	}
 	h.sess = dsql.DefaultDoltSession()
 	h.idxReg = sql.NewIndexRegistry()
 	h.viewReg = sql.NewViewRegistry()


### PR DESCRIPTION
Performance seems roughly the same compared to the pre-FK changes from my testing. Perhaps not the best solution, but it fixes the leak while preserving performance.