### PR TITLE
go/store/nbs: Make tableIndex into an interface, and add an off-heap implementation using mmap.

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/codahale/blake2 v0.0.0-20150924215134-8d10d0420cbf
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/dustin/go-humanize v1.0.0
+	github.com/edsrzf/mmap-go v1.0.0
 	github.com/fatih/color v1.9.0
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/go-kit/kit v0.10.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -156,6 +156,7 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
+github.com/edsrzf/mmap-go v1.0.0 h1:CEBF7HpRnUCSJgGUb5h1Gm7e3VkmVDrR8lvWVLtrOFw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go/store/nbs/aws_chunk_source.go
+++ b/go/store/nbs/aws_chunk_source.go
@@ -28,7 +28,9 @@ import (
 	"time"
 )
 
-func newAWSChunkSource(ctx context.Context, ddb *ddbTableStore, s3 *s3ObjectReader, al awsLimits, name addr, chunkCount uint32, indexCache *indexCache, stats *Stats) (cs chunkSource, err error) {
+type indexParserF func ([]byte) (tableIndex, error)
+
+func newAWSChunkSource(ctx context.Context, ddb *ddbTableStore, s3 *s3ObjectReader, al awsLimits, name addr, chunkCount uint32, indexCache *indexCache, stats *Stats, parseIndex indexParserF) (cs chunkSource, err error) {
 	if indexCache != nil {
 		indexCache.lockEntry(name)
 		defer func() {
@@ -86,14 +88,14 @@ func newAWSChunkSource(ctx context.Context, ddb *ddbTableStore, s3 *s3ObjectRead
 	stats.IndexBytesPerRead.Sample(uint64(len(indexBytes)))
 	stats.IndexReadLatency.SampleTimeSince(t1)
 
-	index, err := parseTableIndex(indexBytes)
+	index, err := parseIndex(indexBytes)
 
 	if err != nil {
 		return emptyChunkSource{}, err
 	}
 
-	if indexCache != nil {
-		indexCache.put(name, index)
+	if ohi, ok := index.(onHeapTableIndex); indexCache != nil && ok {
+		indexCache.put(name, ohi)
 	}
 
 	return &chunkSourceAdapter{newTableReader(index, tra, s3BlockSize), name}, nil

--- a/go/store/nbs/aws_chunk_source_test.go
+++ b/go/store/nbs/aws_chunk_source_test.go
@@ -53,6 +53,9 @@ func TestAWSChunkSource(t *testing.T) {
 			uint32(len(chunks)),
 			ic,
 			&Stats{},
+			func (bs []byte) (tableIndex, error) {
+				return parseTableIndex(bs)
+			},
 		)
 
 		assert.NoError(t, err)

--- a/go/store/nbs/aws_table_persister.go
+++ b/go/store/nbs/aws_table_persister.go
@@ -61,6 +61,7 @@ type awsTablePersister struct {
 	limits     awsLimits
 	indexCache *indexCache
 	ns         string
+	parseIndex indexParserF
 }
 
 type awsLimits struct {
@@ -90,6 +91,7 @@ func (s3p awsTablePersister) Open(ctx context.Context, name addr, chunkCount uin
 		chunkCount,
 		s3p.indexCache,
 		stats,
+		s3p.parseIndex,
 	)
 }
 

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -23,8 +23,8 @@ func (csa chunkSourceAdapter) hash() (addr, error) {
 	return csa.h, nil
 }
 
-func (csa chunkSourceAdapter) index() (tableIndex, error) {
-	return csa.tableIndex, nil
+func (csa chunkSourceAdapter) index() (onHeapTableIndex, error) {
+	return csa.tableReader.index()
 }
 
 func newReaderFromIndexData(indexCache *indexCache, idxData []byte, name addr, tra tableReaderAt, blockSize uint64) (cs chunkSource, err error) {

--- a/go/store/nbs/chunk_source_adapter.go
+++ b/go/store/nbs/chunk_source_adapter.go
@@ -23,10 +23,6 @@ func (csa chunkSourceAdapter) hash() (addr, error) {
 	return csa.h, nil
 }
 
-func (csa chunkSourceAdapter) index() (onHeapTableIndex, error) {
-	return csa.tableReader.index()
-}
-
 func newReaderFromIndexData(indexCache *indexCache, idxData []byte, name addr, tra tableReaderAt, blockSize uint64) (cs chunkSource, err error) {
 	index, err := parseTableIndex(idxData)
 

--- a/go/store/nbs/file_table_persister.go
+++ b/go/store/nbs/file_table_persister.go
@@ -182,7 +182,7 @@ func (ftp *fsTablePersister) ConjoinAll(ctx context.Context, sources chunkSource
 			return "", ferr
 		}
 
-		var index tableIndex
+		var index onHeapTableIndex
 		index, ferr = parseTableIndex(plan.mergedIndex)
 
 		if ferr != nil {

--- a/go/store/nbs/mmap_table_reader.go
+++ b/go/store/nbs/mmap_table_reader.go
@@ -58,7 +58,7 @@ func init() {
 func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *indexCache, fc *fdCache) (cs chunkSource, err error) {
 	path := filepath.Join(dir, h.String())
 
-	var index tableIndex
+	var index onHeapTableIndex
 	found := false
 	if indexCache != nil {
 		indexCache.lockEntry(h)
@@ -73,7 +73,7 @@ func newMmapTableReader(dir string, h addr, chunkCount uint32, indexCache *index
 	}
 
 	if !found {
-		f := func() (ti tableIndex, err error) {
+		f := func() (ti onHeapTableIndex, err error) {
 			var f *os.File
 			f, err = fc.RefFile(path)
 

--- a/go/store/nbs/persisting_chunk_source.go
+++ b/go/store/nbs/persisting_chunk_source.go
@@ -192,7 +192,7 @@ func (ccs *persistingChunkSource) hash() (addr, error) {
 	return ccs.cs.hash()
 }
 
-func (ccs *persistingChunkSource) index() (onHeapTableIndex, error) {
+func (ccs *persistingChunkSource) index() (tableIndex, error) {
 	err := ccs.wait()
 
 	if err != nil {
@@ -282,7 +282,7 @@ func (ecs emptyChunkSource) hash() (addr, error) {
 	return addr{}, nil
 }
 
-func (ecs emptyChunkSource) index() (onHeapTableIndex, error) {
+func (ecs emptyChunkSource) index() (tableIndex, error) {
 	return onHeapTableIndex{}, nil
 }
 

--- a/go/store/nbs/persisting_chunk_source.go
+++ b/go/store/nbs/persisting_chunk_source.go
@@ -192,15 +192,15 @@ func (ccs *persistingChunkSource) hash() (addr, error) {
 	return ccs.cs.hash()
 }
 
-func (ccs *persistingChunkSource) index() (tableIndex, error) {
+func (ccs *persistingChunkSource) index() (onHeapTableIndex, error) {
 	err := ccs.wait()
 
 	if err != nil {
-		return tableIndex{}, err
+		return onHeapTableIndex{}, err
 	}
 
 	if ccs.cs == nil {
-		return tableIndex{}, ErrNoChunkSource
+		return onHeapTableIndex{}, ErrNoChunkSource
 	}
 
 	return ccs.cs.index()
@@ -282,8 +282,8 @@ func (ecs emptyChunkSource) hash() (addr, error) {
 	return addr{}, nil
 }
 
-func (ecs emptyChunkSource) index() (tableIndex, error) {
-	return tableIndex{}, nil
+func (ecs emptyChunkSource) index() (onHeapTableIndex, error) {
+	return onHeapTableIndex{}, nil
 }
 
 func (ecs emptyChunkSource) reader(context.Context) (io.Reader, error) {

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -115,10 +115,8 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 					}
 
 					for _, offsetRec := range offsetRecSlice {
-						ord := offsetRec.ordinal
-						length := tr.lengths[ord]
 						h := hash.Hash(*offsetRec.a)
-						y[h] = Range{Offset: offsetRec.offset, Length: length}
+						y[h] = Range{Offset: offsetRec.offset, Length: offsetRec.length}
 
 						delete(hashes, h)
 					}

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -143,10 +143,10 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 				var foundHashes []hash.Hash
 				for h := range hashes {
 					a := addr(h)
-					e, ok := tableIndex.lookup(&a)
+					e, ok := tableIndex.Lookup(&a)
 					if ok {
 						foundHashes = append(foundHashes, h)
-						y[h] = Range{Offset: e.offset(), Length: e.length()}
+						y[h] = Range{Offset: e.Offset(), Length: e.Length()}
 					}
 				}
 
@@ -963,7 +963,7 @@ func (nbs *NomsBlockStore) Size(ctx context.Context) (uint64, error) {
 		if err != nil {
 			return uint64(0), fmt.Errorf("error getting table file index for chunkSource. %w", err)
 		}
-		size += ti.tableFileSize()
+		size += ti.TableFileSize()
 	}
 	return size, nil
 }

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -144,11 +144,10 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 
 				var foundHashes []hash.Hash
 				for h := range hashes {
-					ord := tableIndex.lookupOrdinal(addr(h))
-
-					if ord < tableIndex.chunkCount {
+					e, ok := tableIndex.lookup(addr(h))
+					if ok {
 						foundHashes = append(foundHashes, h)
-						y[h] = Range{Offset: tableIndex.offsets[ord], Length: tableIndex.lengths[ord]}
+						y[h] = Range{Offset: e.offset(), Length: e.length()}
 					}
 				}
 

--- a/go/store/nbs/store.go
+++ b/go/store/nbs/store.go
@@ -142,7 +142,8 @@ func (nbs *NomsBlockStore) GetChunkLocations(hashes hash.HashSet) (map[hash.Hash
 
 				var foundHashes []hash.Hash
 				for h := range hashes {
-					e, ok := tableIndex.lookup(addr(h))
+					a := addr(h)
+					e, ok := tableIndex.lookup(&a)
 					if ok {
 						foundHashes = append(foundHashes, h)
 						y[h] = Range{Offset: e.offset(), Length: e.length()}

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -263,7 +263,7 @@ type chunkSource interface {
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
 	reader(context.Context) (io.Reader, error)
-	index() (onHeapTableIndex, error)
+	index() (tableIndex, error)
 }
 
 type chunkSources []chunkSource

--- a/go/store/nbs/table.go
+++ b/go/store/nbs/table.go
@@ -263,7 +263,7 @@ type chunkSource interface {
 
 	// opens a Reader to the first byte of the chunkData segment of this table.
 	reader(context.Context) (io.Reader, error)
-	index() (tableIndex, error)
+	index() (onHeapTableIndex, error)
 }
 
 type chunkSources []chunkSource

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -248,6 +248,7 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 	for _, sws := range plan.sources.sws {
 		var index tableIndex
 		index, err = sws.source.index()
+		ordinals := index.ordinals_()
 
 		if err != nil {
 			return compactionPlan{}, err
@@ -255,7 +256,7 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 
 		// Add all the prefix tuples from this index to the list of all prefixIndexRecs, modifying the ordinals such that all entries from the 1st item in sources come after those in the 0th and so on.
 		for j, prefix := range index.prefixes {
-			rec := prefixIndexRec{prefix: prefix, order: ordinalOffset + index.ordinals[j]}
+			rec := prefixIndexRec{prefix: prefix, order: ordinalOffset + ordinals[j]}
 			prefixIndexRecs = append(prefixIndexRecs, rec)
 		}
 

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -98,14 +98,14 @@ func (sic *indexCache) unlockEntry(name addr) error {
 	return nil
 }
 
-func (sic *indexCache) get(name addr) (tableIndex, bool) {
+func (sic *indexCache) get(name addr) (onHeapTableIndex, bool) {
 	if idx, found := sic.cache.Get(name); found {
-		return idx.(tableIndex), true
+		return idx.(onHeapTableIndex), true
 	}
-	return tableIndex{}, false
+	return onHeapTableIndex{}, false
 }
 
-func (sic *indexCache) put(name addr, idx tableIndex) {
+func (sic *indexCache) put(name addr, idx onHeapTableIndex) {
 	indexSize := uint64(idx.chunkCount) * (addrSize + ordinalSize + lengthSize + uint64Size)
 	sic.cache.Add(name, indexSize, idx)
 }
@@ -246,7 +246,7 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 	prefixIndexRecs := make(prefixIndexSlice, 0, plan.chunkCount)
 	var ordinalOffset uint32
 	for _, sws := range plan.sources.sws {
-		var index tableIndex
+		var index onHeapTableIndex
 		index, err = sws.source.index()
 		ordinals := index.ordinals_()
 
@@ -312,6 +312,6 @@ func nameFromSuffixes(suffixes []byte) (name addr) {
 	return
 }
 
-func calcChunkDataLen(index tableIndex) uint64 {
+func calcChunkDataLen(index onHeapTableIndex) uint64 {
 	return index.offsets[index.chunkCount-1] + uint64(index.lengths[index.chunkCount-1])
 }

--- a/go/store/nbs/table_persister.go
+++ b/go/store/nbs/table_persister.go
@@ -226,7 +226,7 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 			return compactionPlan{}, err
 		}
 
-		plan.chunkCount += index.chunkCount_()
+		plan.chunkCount += index.ChunkCount()
 
 		// Calculate the amount of chunk data in |src|
 		chunkDataLen := calcChunkDataLen(index)
@@ -253,8 +253,8 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 			return compactionPlan{}, err
 		}
 
-		ordinals := index.ordinals_()
-		prefixes := index.prefixes_()
+		ordinals := index.Ordinals()
+		prefixes := index.Prefixes()
 
 		// Add all the prefix tuples from this index to the list of all prefixIndexRecs, modifying the ordinals such that all entries from the 1st item in sources come after those in the 0th and so on.
 		for j, prefix := range prefixes {
@@ -291,10 +291,10 @@ func planConjoin(sources chunkSources, stats *Stats) (plan compactionPlan, err e
 			// Build up the index one entry at a time.
 			var a addr
 			for i := 0; i < len(ordinals); i++ {
-				e := index.indexEntry(uint32(i), &a)
+				e := index.IndexEntry(uint32(i), &a)
 				li := lengthsPos + lengthSize * uint64(ordinals[i])
 				si := suffixesPos + addrSuffixSize * uint64(ordinals[i])
-				binary.BigEndian.PutUint32(plan.mergedIndex[li:], e.length())
+				binary.BigEndian.PutUint32(plan.mergedIndex[li:], e.Length())
 				copy(plan.mergedIndex[si:], a[addrPrefixSize:])
 			}
 			lengthsPos += lengthSize * uint64(len(ordinals))
@@ -329,5 +329,5 @@ func nameFromSuffixes(suffixes []byte) (name addr) {
 }
 
 func calcChunkDataLen(index tableIndex) uint64 {
-	return index.tableFileSize() - indexSize(index.chunkCount_()) - footerSize
+	return index.TableFileSize() - indexSize(index.ChunkCount()) - footerSize
 }

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -293,13 +293,10 @@ func (ti tableIndex) prefixIdxToOrdinal(idx uint32) uint32 {
 // chunk in the file and that the last chunk in the file is in the
 // index.
 func (ti tableIndex) tableFileSize() uint64 {
-	len, offset := uint64(0), uint64(0)
-	for i := range ti.offsets {
-		if ti.offsets[i] >= offset {
-			offset = ti.offsets[i]
-			len = uint64(ti.lengths[i])
-		}
+	if ti.chunkCount == 0 {
+		return footerSize
 	}
+	len, offset := ti.offsets[ti.chunkCount-1], uint64(ti.lengths[ti.chunkCount-1])
 	return offset + len + indexSize(ti.chunkCount) + footerSize
 }
 

--- a/go/store/nbs/table_reader.go
+++ b/go/store/nbs/table_reader.go
@@ -361,6 +361,10 @@ func (ti tableIndex) prefixes_() []uint64 {
 	return ti.prefixes
 }
 
+func (ti tableIndex) ordinals_() []uint32 {
+	return ti.ordinals
+}
+
 // newTableReader parses a valid nbs table byte stream and returns a reader. buff must end with an NBS index
 // and footer, though it may contain an unspecified number of bytes before that data. r should allow
 // retrieving any desired range of bytes from the table.

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -301,7 +301,7 @@ func (ts tableSet) physicalLen() (uint64, error) {
 			if err != nil {
 				return 0, err
 			}
-			data += index.tableFileSize()
+			data += index.TableFileSize()
 		}
 		return
 	}

--- a/go/store/nbs/table_set.go
+++ b/go/store/nbs/table_set.go
@@ -298,25 +298,20 @@ func (ts tableSet) physicalLen() (uint64, error) {
 	f := func(css chunkSources) (data uint64, err error) {
 		for _, haver := range css {
 			index, err := haver.index()
-
 			if err != nil {
 				return 0, err
 			}
-
-			data += indexSize(index.chunkCount)
-			data += index.offsets[index.chunkCount-1] + (uint64(index.lengths[index.chunkCount-1]))
+			data += index.tableFileSize()
 		}
 		return
 	}
 
 	lenNovel, err := f(ts.novel)
-
 	if err != nil {
 		return 0, err
 	}
 
 	lenUp, err := f(ts.upstream)
-
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
A table file index maps chunk addresses to offsets within the file, and is a core part of the chunk store read path. An in-memory index entry consists of:

1) A chunk address prefix – the first 8 bytes of the chunk address.
2) A `uint32` ordinal – which number chunk this prefix entry is in the file.
3) A `uint64` offset – the first byte of the chunk in the file.
4) A `uint32` length – the length of the chunk in the file.
5) A chunk address suffix – the last 12 bytes of the chunk address.

On disk, `offset` isn't stored, but it's computed from the lengths when the index is loaded.

Overall, an index entry takes up 36 bytes. Target chunk size is 4096 bytes, so this is about 0.9% of the total repository size of RAM required to access table files in the repository. A 300GB repository needs 2.8GB of RAM just to locate a chunk.

This initial PR adds a separate index serving structure that moves some of the above off-heap. Initially, this usage does not use file backed `mmap`s. This initial implementation is slower on the compaction path and uses almost as much memory as the old implementation. It's a start to be able to play with tradeoffs in this space though.