### PR TITLE
Bug fix for reverse sequence cursor. Not sufficient to just mark a cu…

### DIFF
--- a/go/store/types/map.go
+++ b/go/store/types/map.go
@@ -387,40 +387,11 @@ func (m Map) IteratorFrom(ctx context.Context, key Value) (MapIterator, error) {
 }
 
 func (m Map) IteratorBackFrom(ctx context.Context, key Value) (MapIterator, error) {
-	cur, err := newCursorAtValue(ctx, m.orderedSequence, key, false, false)
+	cur, err := newCursorBackFromValue(ctx, m.orderedSequence, key)
 
 	if err != nil {
 		return nil, err
 	}
-
-	// kinda hacky, but a lot less work than implementing newCursorFromValueAtEnd which would have to search back
-	cur.reverse = true
-	if !cur.valid() {
-		cur.advance(ctx)
-	}
-
-	if cur.valid() {
-		item, err := cur.current()
-
-		if err != nil {
-			return nil, err
-		}
-
-		entry := item.(mapEntry)
-		isLess, err := entry.key.Less(m.Format(), key)
-
-		if err != nil {
-			return nil, err
-		}
-
-		if !isLess && !key.Equals(entry.key) {
-			_, err := cur.advance(ctx)
-
-			if err != nil {
-				return nil, err
-			}
-		}
-	} // else: we're at the beginning of the map
 
 	return &mapIterator{sequenceIter: cur}, nil
 }

--- a/go/store/types/ordered_sequences.go
+++ b/go/store/types/ordered_sequences.go
@@ -136,7 +136,9 @@ func newCursorBackFrom(ctx context.Context, seq orderedSequence, key orderedKey)
 	// If we overshot the key, back off by one. We want the greatest element <= key
 	if cur.valid() {
 		currKey, err := cur.seq.(orderedSequence).getKey(cur.idx)
-		d.PanicIfError(err)
+		if err != nil {
+			return nil, err
+		}
 
 		isLess, err := key.Less(cur.seq.format(), currKey)
 		if err != nil {

--- a/go/store/types/ordered_sequences_test.go
+++ b/go/store/types/ordered_sequences_test.go
@@ -1,0 +1,171 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+type testOrderedSequence struct {
+	testSequence
+}
+
+func (t *testOrderedSequence) getKey(idx int) (orderedKey, error) {
+	cs, err := t.getChildSequence(nil, idx)
+	if err != nil {
+		return orderedKey{}, err
+	}
+	if cs != nil {
+		return cs.(*testOrderedSequence).getKey(0)
+	}
+
+	return newOrderedKey(t.items[idx].(Value), Format_Default)
+}
+
+func (t *testOrderedSequence) getChildSequence(_ context.Context, idx int) (sequence, error) {
+	child := t.items[idx]
+	childSeq, ok := child.(*testOrderedSequence)
+	if !ok {
+		return nil, nil
+	}
+	return childSeq, nil
+}
+
+func (t *testOrderedSequence) search(key orderedKey) (int, error) {
+	return SearchWithErroringLess(int(t.Len()), func(i int) (bool, error) {
+		k, err := t.getKey(i)
+
+		if err != nil {
+			return false, err
+		}
+
+		isLess, err := k.Less(t.format(), key)
+
+		if err != nil {
+			return false, nil
+		}
+
+		return !isLess, nil
+	})
+}
+
+// items is a slice of slices of slices... of Values. Each slice that contains non-value children will be treated as the
+// parent slice for N additional children, one for each slice.
+func newOrderedTestSequence(items []interface{}) *testOrderedSequence {
+	_, firstChildIsValue := items[0].(Value)
+	if firstChildIsValue {
+		return &testOrderedSequence{
+			testSequence: testSequence{items},
+		}
+	}
+
+	var sequenceItems []interface{}
+	for _, item := range items {
+		sequenceItems = append(sequenceItems, newOrderedTestSequence(item.([]interface{})))
+	}
+
+	return &testOrderedSequence{
+		testSequence: testSequence{sequenceItems},
+	}
+}
+
+type orderedSequenceTestCase struct {
+	value        Int
+	expectedVals []Int
+}
+
+func newOrderedSequenceTestCase(val int, expectedValues ...int) orderedSequenceTestCase {
+	expected := make([]Int, len(expectedValues))
+	for i, value := range expectedValues {
+		expected[i] = Int(value)
+	}
+	return orderedSequenceTestCase{
+		value:        Int(val),
+		expectedVals: expected,
+	}
+}
+
+func TestNewCursorAtValue(t *testing.T) {
+	testSequence := newOrderedTestSequence([]interface{}{
+		[]interface{}{
+			[]interface{}{
+				Int(1),
+				Int(2),
+			},
+			[]interface{}{
+				Int(4),
+				Int(5),
+				Int(7),
+			},
+		},
+		[]interface{}{
+			[]interface{}{
+				Int(10),
+				Int(11),
+			},
+			[]interface{}{
+				Int(20),
+			},
+		},
+	})
+
+	testCases := []orderedSequenceTestCase{
+		newOrderedSequenceTestCase(0, 1,2,4,5,7,10,11,20),
+		newOrderedSequenceTestCase(1, 1,2,4,5,7,10,11,20),
+		newOrderedSequenceTestCase(4, 4,5,7,10,11,20),
+		newOrderedSequenceTestCase(6, 7,10,11,20),
+		newOrderedSequenceTestCase(7, 7,10,11,20),
+		newOrderedSequenceTestCase(8, 10,11,20),
+		newOrderedSequenceTestCase(10, 10,11,20),
+		newOrderedSequenceTestCase(12, 20),
+		newOrderedSequenceTestCase(20, 20),
+		newOrderedSequenceTestCase(21),
+	}
+
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("%d", tt.value), func(t *testing.T) {
+			cursor, err := newCursorAtValue(context.Background(), testSequence, tt.value, false, false)
+			require.NoError(t, err)
+			assertCursorContents(t, cursor, tt.expectedVals)
+		})
+	}
+}
+
+func assertCursorContents(t *testing.T, cursor *sequenceCursor, expectedVals []Int) {
+	more := true
+	var vals []Int
+
+	for {
+		require.True(t, cursor.valid(), "more values expected")
+		item, err := cursor.current()
+		require.NoError(t, err)
+		intVal, ok := item.(Int)
+		require.True(t, ok)
+		vals = append(vals, intVal)
+
+		more, err = cursor.advance(context.Background())
+		require.NoError(t, err)
+		if !more {
+			break
+		}
+	}
+
+	require.False(t, cursor.valid())
+	assert.Equal(t, expectedVals, vals)
+}

--- a/go/store/types/ordered_sequences_test.go
+++ b/go/store/types/ordered_sequences_test.go
@@ -70,6 +70,12 @@ func (t *testOrderedSequence) search(key orderedKey) (int, error) {
 // items is a slice of slices of slices... of Values. Each slice that contains non-value children will be treated as the
 // parent slice for N additional children, one for each slice.
 func newOrderedTestSequence(items []interface{}) *testOrderedSequence {
+	if len(items) == 0 {
+		return &testOrderedSequence{
+			testSequence: testSequence{nil},
+		}
+	}
+
 	_, firstChildIsValue := items[0].(Value)
 	if firstChildIsValue {
 		return &testOrderedSequence{
@@ -135,6 +141,7 @@ func TestNewCursorAtValue(t *testing.T) {
 		newOrderedSequenceTestCase(7, 7, 10, 11, 20),
 		newOrderedSequenceTestCase(8, 10, 11, 20),
 		newOrderedSequenceTestCase(10, 10, 11, 20),
+		newOrderedSequenceTestCase(11, 11, 20),
 		newOrderedSequenceTestCase(12, 20),
 		newOrderedSequenceTestCase(20, 20),
 		newOrderedSequenceTestCase(21),
@@ -147,6 +154,13 @@ func TestNewCursorAtValue(t *testing.T) {
 			assertCursorContents(t, cursor, tt.expectedVals)
 		})
 	}
+
+	// empty sequence
+	tt := newOrderedSequenceTestCase(1)
+	emptySequence := newOrderedTestSequence(nil)
+	cursor, err := newCursorAtValue(context.Background(), emptySequence, tt.value, false, false)
+	require.NoError(t, err)
+	assertCursorContents(t, cursor, tt.expectedVals)
 }
 
 func TestNewCursorBackFromValue(t *testing.T) {
@@ -173,7 +187,6 @@ func TestNewCursorBackFromValue(t *testing.T) {
 		},
 	})
 
-	// TODO: figure out what the semantics for the first element of non-present key searches should be
 	testCases := []orderedSequenceTestCase{
 		newOrderedSequenceTestCase(0),
 		newOrderedSequenceTestCase(1, 1),
@@ -195,6 +208,13 @@ func TestNewCursorBackFromValue(t *testing.T) {
 			assertCursorContents(t, cursor, tt.expectedVals)
 		})
 	}
+
+	// empty sequence
+	tt := newOrderedSequenceTestCase(1)
+	emptySequence := newOrderedTestSequence(nil)
+	cursor, err := newCursorBackFromValue(context.Background(), emptySequence, tt.value)
+	require.NoError(t, err)
+	assertCursorContents(t, cursor, tt.expectedVals)
 }
 
 func assertCursorContents(t *testing.T, cursor *sequenceCursor, expectedVals []Int) {

--- a/go/store/types/ordered_sequences_test.go
+++ b/go/store/types/ordered_sequences_test.go
@@ -78,13 +78,6 @@ func newOrderedTestSequence(items []interface{}) *testOrderedSequence {
 		}
 	}
 
-	_, firstChildIsValue := items[0].(Value)
-	if firstChildIsValue {
-		return &testOrderedSequence{
-			testSequence: testSequence{items},
-		}
-	}
-
 	var sequenceItems []interface{}
 	for _, item := range items {
 		if slice, ok := item.([]interface{}); ok {

--- a/go/store/types/ordered_sequences_test.go
+++ b/go/store/types/ordered_sequences_test.go
@@ -17,9 +17,10 @@ package types
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 type testOrderedSequence struct {
@@ -32,7 +33,7 @@ func (t *testOrderedSequence) getKey(idx int) (orderedKey, error) {
 		return orderedKey{}, err
 	}
 	if cs != nil {
-		return cs.(*testOrderedSequence).getKey(cs.seqLen()-1)
+		return cs.(*testOrderedSequence).getKey(cs.seqLen() - 1)
 	}
 
 	return newOrderedKey(t.items[idx].(Value), Format_Default)

--- a/go/store/types/sequence_cursor_test.go
+++ b/go/store/types/sequence_cursor_test.go
@@ -82,9 +82,13 @@ func (ts testSequence) format() *NomsBinFormat {
 	return Format_7_18
 }
 
-func (ts testSequence) getChildSequence(ctx context.Context, idx int) (sequence, error) {
+func (ts testSequence) getChildSequence(_ context.Context, idx int) (sequence, error) {
 	child := ts.items[idx]
-	return testSequence{child.([]interface{})}, nil
+	childSlice, ok := child.([]interface{})
+	if !ok {
+		return nil, nil
+	}
+	return testSequence{childSlice}, nil
 }
 
 func (ts testSequence) isLeaf() bool {
@@ -120,7 +124,7 @@ func (ts testSequence) typeOf() (*Type, error) {
 }
 
 func (ts testSequence) Len() uint64 {
-	panic("not reached")
+	return uint64(len(ts.items))
 }
 
 func (ts testSequence) Empty() bool {


### PR DESCRIPTION
…rsor reverse after the fact, need to initialize cursors at all levels of the tree as reverse as well. Still needs tests, but fixes panics in sqllogictest.

Signed-off-by: Zach Musgrave <zach@liquidata.co>