### PR TITLE
Tie Dolt commit struct fields to Noms commit struct fields

### DIFF
--- a/go/libraries/doltcore/doltdb/commit.go
+++ b/go/libraries/doltcore/doltdb/commit.go
@@ -24,10 +24,10 @@ import (
 )
 
 const (
-	metaField        = "meta"
-	parentsField     = "parents"
-	parentsListField = "parentsList"
-	rootValueField   = "value"
+	metaField        = datas.MetaField
+	parentsField     = datas.ParentsField
+	parentsListField = datas.ParentsListField
+	rootValueField   = datas.ValueField
 )
 
 var errCommitHasNoMeta = errors.New("commit has no metadata")


### PR DESCRIPTION
As far as I can tell, the constants in `doltdb/Commit.go` only work because they match the constants [here](https://github.com/liquidata-inc/dolt/blob/ac8e8840c4cab2d43317acc0362d9b4fe44d3a93/go/store/datas/commit.go#L41)

Also, there is currently a mismatch between `doltdb.parentListField` and `datas.ParentListField` which should cause the list of parents to never be [found](https://github.com/liquidata-inc/dolt/blob/ac8e8840c4cab2d43317acc0362d9b4fe44d3a93/go/libraries/doltcore/doltdb/commit.go#L52)