### PR TITLE
add ReadAheadTableReader.go

### DIFF
--- a/go/libraries/doltcore/table/read_ahead_table_reader.go
+++ b/go/libraries/doltcore/table/read_ahead_table_reader.go
@@ -1,7 +1,22 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package table
 
 import (
 	"context"
+
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
 	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
 	"github.com/liquidata-inc/dolt/go/libraries/utils/async"

--- a/go/libraries/doltcore/table/read_ahead_table_reader.go
+++ b/go/libraries/doltcore/table/read_ahead_table_reader.go
@@ -1,0 +1,61 @@
+package table
+
+import (
+	"context"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/row"
+	"github.com/liquidata-inc/dolt/go/libraries/doltcore/schema"
+	"github.com/liquidata-inc/dolt/go/libraries/utils/async"
+)
+
+var _ TableReadCloser = (*AsyncReadAheadTableReader)(nil)
+
+// AsyncReadAheadTableReader is a TableReadCloser implementation that spins up a go routine to keep reading data into
+// a buffered channel so that it is ready when the caller wants it.
+type AsyncReadAheadTableReader struct {
+	backingReader TableReadCloser
+	reader        *async.AsyncReader
+}
+
+// NewAsyncReadAheadTableReader creates a new AsyncReadAheadTableReader
+func NewAsyncReadAheadTableReader(tr TableReadCloser, bufferSize int) *AsyncReadAheadTableReader {
+	read := func(ctx context.Context) (interface{}, error) {
+		return tr.ReadRow(ctx)
+	}
+
+	reader := async.NewAsyncReader(read, bufferSize)
+	return &AsyncReadAheadTableReader{tr, reader}
+}
+
+// Start the worker routine reading rows to the channel
+func (tr *AsyncReadAheadTableReader) Start(ctx context.Context) error {
+	return tr.reader.Start(ctx)
+}
+
+// GetSchema gets the schema of the rows that this reader will return
+func (tr *AsyncReadAheadTableReader) GetSchema() schema.Schema {
+	return tr.backingReader.GetSchema()
+}
+
+// ReadRow reads a row from a table.  If there is a bad row the returned error will be non nil, and calling
+// IsBadRow(err) will be return true. This is a potentially non-fatal error and callers can decide if they want to
+// continue on a bad row, or fail.
+func (tr *AsyncReadAheadTableReader) ReadRow(ctx context.Context) (row.Row, error) {
+	obj, err := tr.reader.Read()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return obj.(row.Row), err
+}
+
+// VerifySchema checks that the incoming schema matches the schema from the existing table
+func (tr *AsyncReadAheadTableReader) VerifySchema(outSch schema.Schema) (bool, error) {
+	return tr.backingReader.VerifySchema(outSch)
+}
+
+// Close releases resources being held
+func (tr *AsyncReadAheadTableReader) Close(ctx context.Context) error {
+	_ = tr.reader.Close()
+	return tr.backingReader.Close(ctx)
+}

--- a/go/libraries/utils/async/async_read_test.go
+++ b/go/libraries/utils/async/async_read_test.go
@@ -1,13 +1,28 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package async
 
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReader(t *testing.T) {

--- a/go/libraries/utils/async/async_read_test.go
+++ b/go/libraries/utils/async/async_read_test.go
@@ -1,0 +1,71 @@
+package async
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"math/rand"
+	"testing"
+)
+
+func TestReader(t *testing.T) {
+	testReadNItems(t, 0, 32)
+	testReadNItems(t, 1, 32)
+	testReadNItems(t, 65536, 32)
+
+	const maxItems = 4 * 1024
+	const minItems = 4
+	const maxTestBufferSize = 128
+
+	for i := 0; i < 32; i++ {
+		testReadNItems(t, rand.Int63n(maxItems-minItems)+minItems, rand.Int63n(maxTestBufferSize-1)+1)
+	}
+}
+
+func testReadNItems(t *testing.T, n int64, bufferSize int64) {
+	t.Run(fmt.Sprintf("%d_%d", n, bufferSize), func(t *testing.T) {
+		arr := make([]int64, n)
+
+		for i := int64(0); i < n; i++ {
+			arr[i] = i
+		}
+
+		readFunc := readFuncForArr(arr)
+		rd := NewAsyncReader(readFunc, 32)
+		err := rd.Start(context.Background())
+		require.NoError(t, err)
+
+		res := make([]int64, 0)
+		for {
+			val, err := rd.Read()
+
+			if err == io.EOF {
+				break
+			}
+
+			assert.NoError(t, err)
+			res = append(res, val.(int64))
+		}
+
+		err = rd.Close()
+		require.NoError(t, err)
+
+		assert.Equal(t, arr, res)
+	})
+}
+
+func readFuncForArr(arr []int64) ReadFunc {
+	pos := 0
+	return func(ctx context.Context) (interface{}, error) {
+		if pos >= len(arr) {
+			return nil, io.EOF
+		}
+
+		val := arr[pos]
+		pos++
+
+		return val, nil
+	}
+}

--- a/go/libraries/utils/async/async_reader.go
+++ b/go/libraries/utils/async/async_reader.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Liquidata, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package async
 
 import (


### PR DESCRIPTION
The pipeline framework already handles this, but when reading outside a pipeline it can have performance benefit to having a go routine reading the data than the go routine that is processing it.